### PR TITLE
Add dashboard sections and security headers

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -5,9 +5,18 @@ const globalForPrisma = global as unknown as { prisma: PrismaClient }
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
-    log: process.env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],
+    log:
+      process.env.NODE_ENV === 'development'
+        ? ['query', 'error', 'warn']
+        : ['error'],
   })
 
-if (process.env.NODE_ENV === 'development') globalForPrisma.prisma = prisma
+if (!globalForPrisma.prisma) {
+  prisma.$connect().catch((e) =>
+    console.error('Prisma connection error:', e),
+  )
+}
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
 
 export default prisma

--- a/lib/securityHeaders.ts
+++ b/lib/securityHeaders.ts
@@ -1,0 +1,30 @@
+export const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: "default-src 'self'; img-src 'self' data: https:; object-src 'none';" ,
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'origin-when-cross-origin',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'X-DNS-Prefetch-Control',
+    value: 'on',
+  },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=31536000; includeSubDomains; preload',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()',
+  },
+];

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,23 @@
+import { securityHeaders } from './lib/securityHeaders';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   eslint: {
-    ignoreDuringBuilds: true
+    ignoreDuringBuilds: true,
   },
-  output: "standalone",
-  distDir: ".next",
+  output: 'standalone',
+  distDir: '.next',
   typescript: {
-    ignoreBuildErrors: true
-  }
+    ignoreBuildErrors: true,
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
+
 export default nextConfig;

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export default function AdminPage() {
+  return (
+    <div className="p-4" data-oid="admin-page">
+      <h1 className="text-2xl font-bold mb-4">Admin</h1>
+      <p>Contenido próximamente...</p>
+    </div>
+  );
+}

--- a/src/app/dashboard/alertas/page.tsx
+++ b/src/app/dashboard/alertas/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export default function AlertasPage() {
+  return (
+    <div className="p-4" data-oid="alertas-page">
+      <h1 className="text-2xl font-bold mb-4">Alertas</h1>
+      <p>Contenido próximamente...</p>
+    </div>
+  );
+}

--- a/src/app/dashboard/almacenes/page.tsx
+++ b/src/app/dashboard/almacenes/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export default function AlmacenesPage() {
+  return (
+    <div className="p-4" data-oid="almacenes-page">
+      <h1 className="text-2xl font-bold mb-4">Almacenes</h1>
+      <p>Contenido próximamente...</p>
+    </div>
+  );
+}

--- a/src/app/dashboard/app-center/page.tsx
+++ b/src/app/dashboard/app-center/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export default function AppCenterPage() {
+  return (
+    <div className="p-4" data-oid="appcenter-page">
+      <h1 className="text-2xl font-bold mb-4">App Center</h1>
+      <p>Contenido próximamente...</p>
+    </div>
+  );
+}

--- a/src/app/dashboard/billing/page.tsx
+++ b/src/app/dashboard/billing/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export default function BillingPage() {
+  return (
+    <div className="p-4" data-oid="billing-page">
+      <h1 className="text-2xl font-bold mb-4">Billing</h1>
+      <p>Contenido próximamente...</p>
+    </div>
+  );
+}

--- a/src/app/dashboard/components/Sidebar.tsx
+++ b/src/app/dashboard/components/Sidebar.tsx
@@ -160,7 +160,7 @@ export default function Sidebar({ usuario }: { usuario: Usuario }) {
       {/* Menú navegación */}
       <nav className="flex-1 py-6 px-2 flex flex-col gap-1" data-oid="8r1zf-8">
         {filteredMenu.map((item) => {
-          const active = pathname === item.path;
+          const active = pathname.startsWith(item.path);
           return (
             <button
               key={item.key}

--- a/src/app/dashboard/network/page.tsx
+++ b/src/app/dashboard/network/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export default function NetworkPage() {
+  return (
+    <div className="p-4" data-oid="network-page">
+      <h1 className="text-2xl font-bold mb-4">Network</h1>
+      <p>Contenido próximamente...</p>
+    </div>
+  );
+}

--- a/src/app/dashboard/plantillas/page.tsx
+++ b/src/app/dashboard/plantillas/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export default function PlantillasPage() {
+  return (
+    <div className="p-4" data-oid="plantillas-page">
+      <h1 className="text-2xl font-bold mb-4">Plantillas</h1>
+      <p>Contenido próximamente...</p>
+    </div>
+  );
+}

--- a/src/app/dashboard/reportes/page.tsx
+++ b/src/app/dashboard/reportes/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export default function ReportesPage() {
+  return (
+    <div className="p-4" data-oid="reportes-page">
+      <h1 className="text-2xl font-bold mb-4">Reportes</h1>
+      <p>Contenido próximamente...</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create minimal placeholder pages for each dashboard item
- keep sidebar active state for subroutes
- centralize security headers and apply in Next.js config
- improve Prisma connection handling

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: Prisma binaries 403 Forbidden)*

------
