### PR TITLE
Update CSP header

### DIFF
--- a/lib/securityHeaders.ts
+++ b/lib/securityHeaders.ts
@@ -1,7 +1,15 @@
+export const ContentSecurityPolicy = `
+  default-src 'self';
+  script-src 'self' 'unsafe-inline' vitals.vercel-insights.com;
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' https: data:;
+  object-src 'none';
+`;
+
 export const securityHeaders = [
   {
     key: 'Content-Security-Policy',
-    value: "default-src 'self'; img-src 'self' data: https:; object-src 'none';" ,
+    value: ContentSecurityPolicy.replace(/\n/g, ''),
   },
   {
     key: 'Referrer-Policy',


### PR DESCRIPTION
## Summary
- add multi-line CSP definition
- inject Vercel analytics domain into security headers

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5a7f5ec48328973bb041a2725f57