### PR TITLE
Implement data fetching in dashboard pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ honeylabs/
 
 ## Parches
 
-- Se actualizó la paleta de colores del dashboard a tonos más oscuros.
-- Se añadió modo de pantalla completa con barra de herramientas para widgets.
-- El tablero ahora guarda la posición de los widgets en el navegador.
+- Se añadieron endpoints de API para varias secciones del dashboard.
+- Cada página del dashboard ahora carga datos reales con estados de carga y error.
+- También se verifican los permisos del usuario antes de mostrar la información.
 
 ---
 

--- a/src/app/api/admin/route.ts
+++ b/src/app/api/admin/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const stats = { usuarios: 120, almacenes: 5 };
+  return NextResponse.json({ stats });
+}

--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@lib/prisma";
+
+export async function GET(req: NextRequest) {
+  try {
+    const usuarioId = req.nextUrl.searchParams.get("usuarioId");
+    const almacenes = await prisma.almacen.findMany({
+      take: 20,
+      where: usuarioId ? { usuarios: { some: { usuarioId: Number(usuarioId) } } } : {},
+      select: { id: true, nombre: true, descripcion: true },
+    });
+    return NextResponse.json({ almacenes });
+  } catch (err) {
+    console.error("Error en /api/almacenes:", err);
+    return NextResponse.json(
+      { error: "Error al obtener almacenes" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/app-center/route.ts
+++ b/src/app/api/app-center/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const apps = [
+    { id: 1, nombre: "Inventario" },
+    { id: 2, nombre: "Préstamos" },
+  ];
+  return NextResponse.json({ apps });
+}

--- a/src/app/api/billing/route.ts
+++ b/src/app/api/billing/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const invoices = [
+    { id: 1, concepto: "Suscripción Pro", monto: 19.99, estado: "pagado" },
+    { id: 2, concepto: "Suscripción Pro", monto: 19.99, estado: "pendiente" },
+  ];
+  return NextResponse.json({ invoices });
+}

--- a/src/app/api/network/route.ts
+++ b/src/app/api/network/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const peers = [
+    { id: 1, nombre: "Lab Central" },
+    { id: 2, nombre: "Depósito Norte" },
+  ];
+  return NextResponse.json({ peers });
+}

--- a/src/app/api/plantillas/route.ts
+++ b/src/app/api/plantillas/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const plantillas = [
+    { id: 1, nombre: "Solicitud básica" },
+    { id: 2, nombre: "Reporte de incidente" },
+  ];
+  return NextResponse.json({ plantillas });
+}

--- a/src/app/api/reportes/route.ts
+++ b/src/app/api/reportes/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const reportes = [
+    { id: 1, titulo: "Inventario mensual" },
+    { id: 2, titulo: "Incidencias" },
+  ];
+  return NextResponse.json({ reportes });
+}

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -1,10 +1,58 @@
 "use client";
+import { useEffect, useState } from "react";
+
+interface Usuario {
+  rol?: string;
+  tipoCuenta?: string;
+}
+interface Stats {
+  usuarios: number;
+  almacenes: number;
+}
 
 export default function AdminPage() {
+  const allowed = ["admin"];
+  const [usuario, setUsuario] = useState<Usuario | null>(null);
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetch("/api/login", { credentials: "include" })
+      .then((res) => res.json())
+      .then((data) => {
+        if (!data?.success) throw new Error();
+        const tipo =
+          data.usuario.rol === "admin"
+            ? "admin"
+            : data.usuario.tipoCuenta ?? "estandar";
+        if (!allowed.includes(tipo)) throw new Error("No autorizado");
+        setUsuario(data.usuario);
+      })
+      .catch((err) => setError(err.message || "Debes iniciar sesión"));
+  }, []);
+
+  useEffect(() => {
+    if (!usuario) return;
+    setLoading(true);
+    fetch("/api/admin")
+      .then((r) => r.json())
+      .then((d) => setStats(d.stats || null))
+      .catch(() => setError("Error al cargar datos"))
+      .finally(() => setLoading(false));
+  }, [usuario]);
+
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+  if (loading) return <div className="p-4">Cargando...</div>;
+  if (!stats) return null;
+
   return (
     <div className="p-4" data-oid="admin-page">
       <h1 className="text-2xl font-bold mb-4">Admin</h1>
-      <p>Contenido próximamente...</p>
+      <ul className="list-disc pl-4">
+        <li>Usuarios: {stats.usuarios}</li>
+        <li>Almacenes: {stats.almacenes}</li>
+      </ul>
     </div>
   );
 }

--- a/src/app/dashboard/alertas/page.tsx
+++ b/src/app/dashboard/alertas/page.tsx
@@ -1,10 +1,67 @@
 "use client";
+import { useEffect, useState } from "react";
+
+interface Usuario {
+  id: number;
+  rol?: string;
+  tipoCuenta?: string;
+}
+interface Alerta {
+  id: number;
+  mensaje: string;
+  almacen?: { nombre: string };
+}
 
 export default function AlertasPage() {
+  const allowed = ["admin", "institucional", "empresarial", "estandar"];
+  const [usuario, setUsuario] = useState<Usuario | null>(null);
+  const [alertas, setAlertas] = useState<Alerta[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetch("/api/login", { credentials: "include" })
+      .then((res) => res.json())
+      .then((data) => {
+        if (!data?.success) throw new Error();
+        const tipo =
+          data.usuario.rol === "admin"
+            ? "admin"
+            : data.usuario.tipoCuenta ?? "estandar";
+        if (!allowed.includes(tipo)) {
+          throw new Error("No autorizado");
+        }
+        setUsuario(data.usuario);
+      })
+      .catch((err) => {
+        setError(err.message || "Debes iniciar sesión");
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!usuario) return;
+    setLoading(true);
+    fetch(`/api/alertas?usuarioId=${usuario.id}`)
+      .then((res) => res.json())
+      .then((data) => setAlertas(data.alertas || []))
+      .catch(() => setError("Error al cargar datos"))
+      .finally(() => setLoading(false));
+  }, [usuario]);
+
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+  if (loading) return <div className="p-4">Cargando...</div>;
+
   return (
     <div className="p-4" data-oid="alertas-page">
       <h1 className="text-2xl font-bold mb-4">Alertas</h1>
-      <p>Contenido próximamente...</p>
+      <ul className="list-disc pl-4">
+        {alertas.map((a) => (
+          <li key={a.id}>
+            {a.almacen ? `${a.almacen.nombre}: ` : ""}
+            {a.mensaje}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/app/dashboard/almacenes/page.tsx
+++ b/src/app/dashboard/almacenes/page.tsx
@@ -1,10 +1,65 @@
 "use client";
+import { useEffect, useState } from "react";
+
+interface Usuario {
+  id: number;
+  rol?: string;
+  tipoCuenta?: string;
+}
+
+interface Almacen {
+  id: number;
+  nombre: string;
+  descripcion?: string | null;
+}
 
 export default function AlmacenesPage() {
+  const allowed = ["admin", "institucional", "empresarial", "estandar"];
+  const [usuario, setUsuario] = useState<Usuario | null>(null);
+  const [almacenes, setAlmacenes] = useState<Almacen[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetch("/api/login", { credentials: "include" })
+      .then((res) => res.json())
+      .then((data) => {
+        if (!data?.success) throw new Error();
+        const tipo =
+          data.usuario.rol === "admin"
+            ? "admin"
+            : data.usuario.tipoCuenta ?? "estandar";
+        if (!allowed.includes(tipo)) {
+          throw new Error("No autorizado");
+        }
+        setUsuario(data.usuario);
+      })
+      .catch((err) => {
+        setError(err.message || "Debes iniciar sesión");
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!usuario) return;
+    setLoading(true);
+    fetch(`/api/almacenes?usuarioId=${usuario.id}`)
+      .then((res) => res.json())
+      .then((data) => setAlmacenes(data.almacenes || []))
+      .catch(() => setError("Error al cargar datos"))
+      .finally(() => setLoading(false));
+  }, [usuario]);
+
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+  if (loading) return <div className="p-4">Cargando...</div>;
+
   return (
     <div className="p-4" data-oid="almacenes-page">
       <h1 className="text-2xl font-bold mb-4">Almacenes</h1>
-      <p>Contenido próximamente...</p>
+      <ul className="list-disc pl-4">
+        {almacenes.map((a) => (
+          <li key={a.id}>{a.nombre}</li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/app/dashboard/app-center/page.tsx
+++ b/src/app/dashboard/app-center/page.tsx
@@ -1,10 +1,58 @@
 "use client";
+import { useEffect, useState } from "react";
+
+interface Usuario {
+  rol?: string;
+  tipoCuenta?: string;
+}
+interface AppInfo {
+  id: number;
+  nombre: string;
+}
 
 export default function AppCenterPage() {
+  const allowed = ["admin", "institucional", "empresarial"];
+  const [usuario, setUsuario] = useState<Usuario | null>(null);
+  const [apps, setApps] = useState<AppInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetch("/api/login", { credentials: "include" })
+      .then((res) => res.json())
+      .then((data) => {
+        if (!data?.success) throw new Error();
+        const tipo =
+          data.usuario.rol === "admin"
+            ? "admin"
+            : data.usuario.tipoCuenta ?? "estandar";
+        if (!allowed.includes(tipo)) throw new Error("No autorizado");
+        setUsuario(data.usuario);
+      })
+      .catch((err) => setError(err.message || "Debes iniciar sesión"));
+  }, []);
+
+  useEffect(() => {
+    if (!usuario) return;
+    setLoading(true);
+    fetch("/api/app-center")
+      .then((r) => r.json())
+      .then((d) => setApps(d.apps || []))
+      .catch(() => setError("Error al cargar datos"))
+      .finally(() => setLoading(false));
+  }, [usuario]);
+
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+  if (loading) return <div className="p-4">Cargando...</div>;
+
   return (
     <div className="p-4" data-oid="appcenter-page">
       <h1 className="text-2xl font-bold mb-4">App Center</h1>
-      <p>Contenido próximamente...</p>
+      <ul className="list-disc pl-4">
+        {apps.map((a) => (
+          <li key={a.id}>{a.nombre}</li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/app/dashboard/billing/page.tsx
+++ b/src/app/dashboard/billing/page.tsx
@@ -1,10 +1,62 @@
 "use client";
+import { useEffect, useState } from "react";
+
+interface Usuario {
+  rol?: string;
+  tipoCuenta?: string;
+}
+interface Invoice {
+  id: number;
+  concepto: string;
+  monto: number;
+  estado: string;
+}
 
 export default function BillingPage() {
+  const allowed = ["admin", "institucional"];
+  const [usuario, setUsuario] = useState<Usuario | null>(null);
+  const [invoices, setInvoices] = useState<Invoice[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetch("/api/login", { credentials: "include" })
+      .then((res) => res.json())
+      .then((data) => {
+        if (!data?.success) throw new Error();
+        const tipo =
+          data.usuario.rol === "admin"
+            ? "admin"
+            : data.usuario.tipoCuenta ?? "estandar";
+        if (!allowed.includes(tipo)) throw new Error("No autorizado");
+        setUsuario(data.usuario);
+      })
+      .catch((err) => setError(err.message || "Debes iniciar sesión"));
+  }, []);
+
+  useEffect(() => {
+    if (!usuario) return;
+    setLoading(true);
+    fetch("/api/billing")
+      .then((r) => r.json())
+      .then((d) => setInvoices(d.invoices || []))
+      .catch(() => setError("Error al cargar datos"))
+      .finally(() => setLoading(false));
+  }, [usuario]);
+
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+  if (loading) return <div className="p-4">Cargando...</div>;
+
   return (
     <div className="p-4" data-oid="billing-page">
       <h1 className="text-2xl font-bold mb-4">Billing</h1>
-      <p>Contenido próximamente...</p>
+      <ul className="list-disc pl-4">
+        {invoices.map((i) => (
+          <li key={i.id}>
+            {i.concepto} - ${"{i.monto}"} ({i.estado})
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/app/dashboard/network/page.tsx
+++ b/src/app/dashboard/network/page.tsx
@@ -1,10 +1,58 @@
 "use client";
+import { useEffect, useState } from "react";
+
+interface Usuario {
+  rol?: string;
+  tipoCuenta?: string;
+}
+interface Peer {
+  id: number;
+  nombre: string;
+}
 
 export default function NetworkPage() {
+  const allowed = ["admin", "institucional"];
+  const [usuario, setUsuario] = useState<Usuario | null>(null);
+  const [peers, setPeers] = useState<Peer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetch("/api/login", { credentials: "include" })
+      .then((res) => res.json())
+      .then((data) => {
+        if (!data?.success) throw new Error();
+        const tipo =
+          data.usuario.rol === "admin"
+            ? "admin"
+            : data.usuario.tipoCuenta ?? "estandar";
+        if (!allowed.includes(tipo)) throw new Error("No autorizado");
+        setUsuario(data.usuario);
+      })
+      .catch((err) => setError(err.message || "Debes iniciar sesión"));
+  }, []);
+
+  useEffect(() => {
+    if (!usuario) return;
+    setLoading(true);
+    fetch("/api/network")
+      .then((r) => r.json())
+      .then((d) => setPeers(d.peers || []))
+      .catch(() => setError("Error al cargar datos"))
+      .finally(() => setLoading(false));
+  }, [usuario]);
+
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+  if (loading) return <div className="p-4">Cargando...</div>;
+
   return (
     <div className="p-4" data-oid="network-page">
       <h1 className="text-2xl font-bold mb-4">Network</h1>
-      <p>Contenido próximamente...</p>
+      <ul className="list-disc pl-4">
+        {peers.map((p) => (
+          <li key={p.id}>{p.nombre}</li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/app/dashboard/plantillas/page.tsx
+++ b/src/app/dashboard/plantillas/page.tsx
@@ -1,10 +1,58 @@
 "use client";
+import { useEffect, useState } from "react";
+
+interface Usuario {
+  rol?: string;
+  tipoCuenta?: string;
+}
+interface Plantilla {
+  id: number;
+  nombre: string;
+}
 
 export default function PlantillasPage() {
+  const allowed = ["admin", "institucional", "empresarial", "estandar"];
+  const [usuario, setUsuario] = useState<Usuario | null>(null);
+  const [plantillas, setPlantillas] = useState<Plantilla[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetch("/api/login", { credentials: "include" })
+      .then((res) => res.json())
+      .then((data) => {
+        if (!data?.success) throw new Error();
+        const tipo =
+          data.usuario.rol === "admin"
+            ? "admin"
+            : data.usuario.tipoCuenta ?? "estandar";
+        if (!allowed.includes(tipo)) throw new Error("No autorizado");
+        setUsuario(data.usuario);
+      })
+      .catch((err) => setError(err.message || "Debes iniciar sesión"));
+  }, []);
+
+  useEffect(() => {
+    if (!usuario) return;
+    setLoading(true);
+    fetch("/api/plantillas")
+      .then((r) => r.json())
+      .then((d) => setPlantillas(d.plantillas || []))
+      .catch(() => setError("Error al cargar datos"))
+      .finally(() => setLoading(false));
+  }, [usuario]);
+
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+  if (loading) return <div className="p-4">Cargando...</div>;
+
   return (
     <div className="p-4" data-oid="plantillas-page">
       <h1 className="text-2xl font-bold mb-4">Plantillas</h1>
-      <p>Contenido próximamente...</p>
+      <ul className="list-disc pl-4">
+        {plantillas.map((p) => (
+          <li key={p.id}>{p.nombre}</li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/app/dashboard/reportes/page.tsx
+++ b/src/app/dashboard/reportes/page.tsx
@@ -1,10 +1,58 @@
 "use client";
+import { useEffect, useState } from "react";
+
+interface Usuario {
+  rol?: string;
+  tipoCuenta?: string;
+}
+interface Reporte {
+  id: number;
+  titulo: string;
+}
 
 export default function ReportesPage() {
+  const allowed = ["admin", "institucional", "empresarial"];
+  const [usuario, setUsuario] = useState<Usuario | null>(null);
+  const [reportes, setReportes] = useState<Reporte[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetch("/api/login", { credentials: "include" })
+      .then((res) => res.json())
+      .then((data) => {
+        if (!data?.success) throw new Error();
+        const tipo =
+          data.usuario.rol === "admin"
+            ? "admin"
+            : data.usuario.tipoCuenta ?? "estandar";
+        if (!allowed.includes(tipo)) throw new Error("No autorizado");
+        setUsuario(data.usuario);
+      })
+      .catch((err) => setError(err.message || "Debes iniciar sesión"));
+  }, []);
+
+  useEffect(() => {
+    if (!usuario) return;
+    setLoading(true);
+    fetch("/api/reportes")
+      .then((r) => r.json())
+      .then((d) => setReportes(d.reportes || []))
+      .catch(() => setError("Error al cargar datos"))
+      .finally(() => setLoading(false));
+  }, [usuario]);
+
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+  if (loading) return <div className="p-4">Cargando...</div>;
+
   return (
     <div className="p-4" data-oid="reportes-page">
       <h1 className="text-2xl font-bold mb-4">Reportes</h1>
-      <p>Contenido próximamente...</p>
+      <ul className="list-disc pl-4">
+        {reportes.map((r) => (
+          <li key={r.id}>{r.titulo}</li>
+        ))}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create API endpoints for dashboard sections
- load data on each dashboard page with loading/error states
- verify user permissions before showing data
- update patch notes in README

## Testing
- `npm run lint` *(fails: next not found)*

------
