### PR TITLE
Require JWT_SECRET environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Variables de entorno para HoneyLabs
+# Copia este archivo como .env y completa los valores requeridos
+
+# Clave secreta para firmas JWT
+JWT_SECRET=
+
+# Ejemplos de otras variables (correos SMTP)
+EMAIL_ADMIN=
+SMTP_USER=
+SMTP_PASS=
+EMAIL_DESTINO_ESTANDAR=
+EMAIL_DESTINO_VALIDACION=

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env.local
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -110,9 +110,8 @@ honeylabs/
 
 ## Parches
 
-- Se actualizó la paleta de colores del dashboard a tonos más oscuros.
-- Se añadió modo de pantalla completa con barra de herramientas para widgets.
-- El tablero ahora guarda la posición de los widgets en el navegador.
+- Se añadió verificación de la variable de entorno `JWT_SECRET` en las rutas de autenticación.
+- Nuevo archivo `.env.example` para documentar las variables de entorno requeridas.
 
 ---
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,7 +2,10 @@ import { cookies } from 'next/headers'
 import jwt from 'jsonwebtoken'
 import prisma from '@lib/prisma'
 
-const JWT_SECRET = process.env.JWT_SECRET!
+const JWT_SECRET = process.env.JWT_SECRET
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET no definido en el entorno')
+}
 const COOKIE_NAME = 'hl_session'
 
 export async function getUsuarioFromSession() {

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -10,7 +10,10 @@ const globalForPrisma = global as unknown as { prisma?: PrismaClient };
 const prisma = globalForPrisma.prisma ?? new PrismaClient();
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
 
-const JWT_SECRET = process.env.JWT_SECRET ?? 'mi_clave_de_emergencia';
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET no definido en el entorno');
+}
 const COOKIE_NAME = 'hl_session';
 const COOKIE_EXPIRES = 60 * 60 * 24 * 7; // 7 días
 

--- a/src/app/api/perfil/export/route.ts
+++ b/src/app/api/perfil/export/route.ts
@@ -9,7 +9,10 @@ const globalForPrisma = global as unknown as { prisma?: PrismaClient };
 const prisma = globalForPrisma.prisma ?? new PrismaClient();
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
 
-const JWT_SECRET = process.env.JWT_SECRET ?? 'mi_clave_de_emergencia';
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET no definido en el entorno');
+}
 const COOKIE_NAME = 'hl_session';
 
 // Set de secciones permitidas para exportar

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -7,7 +7,10 @@ const globalForPrisma = global as unknown as { prisma?: PrismaClient };
 const prisma = globalForPrisma.prisma ?? new PrismaClient();
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
 
-const JWT_SECRET = process.env.JWT_SECRET ?? 'mi_clave_de_emergencia';
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET no definido en el entorno');
+}
 const COOKIE_NAME = 'hl_session';
 
 const TAMAÑO_MAXIMO_FOTO_MB = 10;


### PR DESCRIPTION
## Summary
- enforce JWT_SECRET presence in server routes and auth helper
- add `.env.example` illustrating required variables
- document the new requirement in README
- track `.env.example` via `.gitignore` update

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: Prisma engine checksum 403)*

------
https://chatgpt.com/codex/tasks/task_e_683f69de01b083289ebac8b04a356d82