### PR TITLE
Cache widget catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,8 @@ honeylabs/
 
 ## Parches
 
-- Se actualizó la paleta de colores del dashboard a tonos más oscuros.
-- Se añadió modo de pantalla completa con barra de herramientas para widgets.
-- El tablero ahora guarda la posición de los widgets en el navegador.
+- Se agregó `lib/widgets.json` como catálogo estático de widgets.
+- La ruta `/api/widgets` ahora lee desde este archivo sin acceder al sistema de archivos.
 
 ---
 

--- a/lib/widgets.json
+++ b/lib/widgets.json
@@ -1,0 +1,46 @@
+[
+  {
+    "key": "alertas",
+    "title": "Alertas",
+    "file": "AlertasWidget",
+    "category": "General",
+    "w": 2,
+    "h": 2,
+    "minW": 2,
+    "minH": 2,
+    "plans": ["Free", "Pro", "Empresarial", "Institucional"]
+  },
+  {
+    "key": "almacenes",
+    "title": "Almacenes",
+    "file": "AlmacenesWidget",
+    "category": "General",
+    "w": 2,
+    "h": 2,
+    "minW": 2,
+    "minH": 2,
+    "plans": ["Free", "Pro", "Empresarial", "Institucional"]
+  },
+  {
+    "key": "grafica",
+    "title": "Grafica",
+    "file": "GraficaWidget",
+    "category": "General",
+    "w": 2,
+    "h": 2,
+    "minW": 2,
+    "minH": 2,
+    "plans": ["Free", "Pro", "Empresarial", "Institucional"]
+  },
+  {
+    "key": "novedades",
+    "title": "Novedades",
+    "file": "NovedadesWidget",
+    "category": "General",
+    "w": 2,
+    "h": 2,
+    "minW": 2,
+    "minH": 2,
+    "plans": ["Free", "Pro", "Empresarial", "Institucional"]
+  }
+]

--- a/src/app/api/widgets/route.ts
+++ b/src/app/api/widgets/route.ts
@@ -1,32 +1,8 @@
 import { NextResponse } from "next/server";
-import path from "path";
-import fs from "fs";
+import widgets from "@lib/widgets.json";
 
 export async function GET() {
   try {
-    const widgetsDir = path.join(process.cwd(), "src/app/dashboard/components/widgets");
-    const files = fs.readdirSync(widgetsDir);
-
-    const widgets = files
-      .filter((f) => f.endsWith("Widget.tsx") || f.endsWith("Widget.jsx"))
-      .map((filename) => {
-        const rawName = filename.replace(/\.tsx|\.jsx/, "");
-        const key = rawName.replace("Widget", "").toLowerCase();
-        const title = rawName.replace("Widget", "");
-
-        return {
-          key,
-          title,
-          file: rawName, // solo el nombre sin "./" para usar en dynamic()
-          category: "General",
-          w: 2,
-          h: 2,
-          minW: 2,
-          minH: 2,
-          plans: ["Free", "Pro", "Empresarial", "Institucional"],
-        };
-      });
-
     return NextResponse.json({ widgets });
   } catch (err: any) {
     console.error("❌ Error leyendo widgets:", err);


### PR DESCRIPTION
## Summary
- cache available widgets in a new `lib/widgets.json`
- update `/api/widgets` to return the cached list
- document changes in the `Parches` section of the README

## Testing
- `npx next lint` *(fails: prisma generate 403)*

------
