### PR TITLE
Fix dashboard widget import issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ honeylabs/
 
 ## Parches
 
-- Se corrigió un error al cargar el *dashboard* que mostraba el mensaje "Minified React error #310". Ahora los widgets se importan correctamente.
+- Se ajustó nuevamente la importación dinámica de widgets eliminando la extensión `.tsx` para evitar el error "Minified React error #310" al cargar el *dashboard*.
 
 ---
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -64,7 +64,7 @@ export default function DashboardPage() {
         const mapa: Record<string, any> = {};
         permitidos.forEach((widget: WidgetMeta) => {
           mapa[widget.key] = dynamic(
-            () => import(`./components/widgets/${widget.file}.tsx`),
+            () => import(`./components/widgets/${widget.file}`),
             { ssr: false },
           );
         });


### PR DESCRIPTION
## Summary
- fix dynamic widget import path on Dashboard
- update patch notes in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
