### PR TITLE
Fix dashboard stability and unify cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ honeylabs/
 
 ## Parches
 
-- Se corrigió la ruta de importación de widgets en el *dashboard* eliminando la extensión `.tsx`. Esto resuelve el error "Minified React error #310" al cargar la página.
+- Se centralizó el nombre de la cookie de sesión en `lib/constants.ts` y todas las APIs la utilizan.
+- El dashboard valida los datos almacenados en `localStorage` y calcula la posición de nuevos widgets sin usar `Infinity`.
+- Los widgets importados dinámicamente muestran un aviso cuando su archivo no existe.
 
 ---
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,17 +1,17 @@
 import { cookies } from 'next/headers'
 import jwt from 'jsonwebtoken'
 import prisma from '@lib/prisma'
+import { SESSION_COOKIE } from '@lib/constants'
 
 const JWT_SECRET = process.env.JWT_SECRET
 if (!JWT_SECRET) {
   throw new Error('JWT_SECRET no definido en el entorno')
 }
-const COOKIE_NAME = 'hl_session'
 
 export async function getUsuarioFromSession() {
   // ASÍNCRONO en server actions o middleware
   const cookieStore = await cookies() // <-- await aquí
-  const token = cookieStore.get(COOKIE_NAME)?.value
+  const token = cookieStore.get(SESSION_COOKIE)?.value
 
   if (!token) return null
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,7 @@
+export const SESSION_COOKIE = 'hl_session';
+export const sessionCookieOptions = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'lax' as const,
+  path: '/',
+};

--- a/src/app/api/novedades/route.ts
+++ b/src/app/api/novedades/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@lib/prisma'
 import jwt from 'jsonwebtoken'
+import { SESSION_COOKIE } from '@lib/constants'
 
 const JWT_SECRET = process.env.JWT_SECRET ?? 'mi_clave_de_emergencia'
-const COOKIE_NAME = 'hl_session'
 
 export async function GET(req: NextRequest) {
   try {
-    const token = req.cookies.get(COOKIE_NAME)?.value
+    const token = req.cookies.get(SESSION_COOKIE)?.value
     if (!token) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     let payload: any
     try {

--- a/src/app/api/perfil/export/route.ts
+++ b/src/app/api/perfil/export/route.ts
@@ -3,6 +3,7 @@ export const runtime = 'nodejs';
 import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
 import jwt from 'jsonwebtoken';
+import { SESSION_COOKIE } from '@lib/constants';
 
 // Instancia Prisma singleton-safe para dev y prod
 const globalForPrisma = global as unknown as { prisma?: PrismaClient };
@@ -13,7 +14,6 @@ const JWT_SECRET = process.env.JWT_SECRET;
 if (!JWT_SECRET) {
   throw new Error('JWT_SECRET no definido en el entorno');
 }
-const COOKIE_NAME = 'hl_session';
 
 // Set de secciones permitidas para exportar
 const SECCIONES_VALIDAS = new Set([
@@ -26,7 +26,7 @@ const SECCIONES_VALIDAS = new Set([
 export async function GET(req: NextRequest) {
   try {
     // ======= 1. Autenticación =======
-    const token = req.cookies.get(COOKIE_NAME)?.value;
+    const token = req.cookies.get(SESSION_COOKIE)?.value;
     if (!token) {
       return NextResponse.json({ error: 'No autenticado.' }, { status: 401 });
     }


### PR DESCRIPTION
## Summary
- centralize session cookie options in `lib/constants`
- improve widget import error handling
- validate saved layout and avoid Infinity positions
- compute position for new widgets
- update API routes to use shared cookie options
- document new changes in `Parches`

## Testing
- `npm install` *(fails: Error fetching prisma engines checksum)*

------
