### PR TITLE
Add basic Pizarra canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,7 @@ honeylabs/
 
 ## Parches
 
-- Se centralizó el nombre de la cookie de sesión en `lib/constants.ts` y todas las APIs la utilizan.
-- El dashboard valida los datos almacenados en `localStorage` y calcula la posición de nuevos widgets sin usar `Infinity`.
-- Los widgets importados dinámicamente muestran un aviso cuando su archivo no existe.
+- Se añadió una estructura base para la **Pizarra Infinita** accesible solo desde el panel principal del dashboard.
 
 ---
 

--- a/src/app/dashboard/components/pizarra/PizarraCanvas.tsx
+++ b/src/app/dashboard/components/pizarra/PizarraCanvas.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import PizarraNavbar from "./PizarraNavbar";
+import PizarraSidebar from "./PizarraSidebar";
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function PizarraCanvas({ onClose }: Props) {
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const [fullscreen, setFullscreen] = useState(false);
+
+  // Load saved state
+  useEffect(() => {
+    const saved = localStorage.getItem("pizarra_content");
+    if (saved && canvasRef.current) {
+      canvasRef.current.innerHTML = saved;
+    }
+  }, []);
+
+  // Save state on unmount or mode change
+  const saveState = () => {
+    if (canvasRef.current) {
+      localStorage.setItem("pizarra_content", canvasRef.current.innerHTML);
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      saveState();
+    };
+  }, []);
+
+  const toggleFullscreen = () => {
+    setFullscreen((f) => {
+      const next = !f;
+      saveState();
+      return next;
+    });
+  };
+
+  const handleClose = () => {
+    saveState();
+    onClose();
+  };
+
+  return (
+    <div
+      className={`pizarra-overlay fixed inset-0 z-50 flex bg-[var(--dashboard-bg)] ${fullscreen ? "pizarra-full" : ""}`}
+    >
+      <PizarraSidebar />
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <PizarraNavbar onClose={handleClose} onToggleFullscreen={toggleFullscreen} fullscreen={fullscreen} />
+        <div ref={canvasRef} className="flex-1 overflow-auto p-4" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/components/pizarra/PizarraNavbar.tsx
+++ b/src/app/dashboard/components/pizarra/PizarraNavbar.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { Maximize, Minimize, X } from "lucide-react";
+
+interface Props {
+  onClose: () => void;
+  onToggleFullscreen: () => void;
+  fullscreen: boolean;
+}
+
+export default function PizarraNavbar({ onClose, onToggleFullscreen, fullscreen }: Props) {
+  return (
+    <header className="flex items-center justify-between p-2 border-b border-[var(--dashboard-border)] bg-[var(--dashboard-navbar)]" style={{minHeight: '50px'}}>
+      <div className="flex items-center gap-2">
+        <button onClick={onClose} className="p-2 hover:bg-white/15 rounded" title="Salir">
+          <X className="w-5 h-5" />
+        </button>
+        <span className="font-semibold">Pizarra Infinita</span>
+      </div>
+      <button onClick={onToggleFullscreen} className="p-2 hover:bg-white/15 rounded" title="Pantalla completa">
+        {fullscreen ? <Minimize className="w-5 h-5" /> : <Maximize className="w-5 h-5" />}
+      </button>
+    </header>
+  );
+}

--- a/src/app/dashboard/components/pizarra/PizarraSidebar.tsx
+++ b/src/app/dashboard/components/pizarra/PizarraSidebar.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+export default function PizarraSidebar() {
+  return (
+    <aside className="w-48 p-2 border-r border-[var(--dashboard-border)] bg-[var(--dashboard-sidebar)] flex flex-col gap-2">
+      <button className="p-2 hover:bg-white/10 rounded" title="Herramienta de selección">🔧</button>
+      <button className="p-2 hover:bg-white/10 rounded" title="Añadir nota">📝</button>
+      <button className="p-2 hover:bg-white/10 rounded" title="Agregar forma">◻️</button>
+    </aside>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import PizarraCanvas from "./components/pizarra/PizarraCanvas";
 import dynamic from "next/dynamic";
 import GridLayout, { Layout } from "react-grid-layout";
 import "react-grid-layout/css/styles.css";
@@ -37,6 +38,7 @@ export default function DashboardPage() {
   const [layout, setLayout] = useState<Layout[]>([]);
   const [componentes, setComponentes] = useState<{ [key: string]: any }>({});
   const [errores, setErrores] = useState<{ [key: string]: boolean }>({});
+  const [showPizarra, setShowPizarra] = useState(false);
 
   // 1. Obtener usuario logueado
   useEffect(() => {
@@ -176,22 +178,31 @@ export default function DashboardPage() {
         <h1 className="text-2xl font-bold" data-oid="4rx1xg2">
           Panel principal
         </h1>
-        <select
-          onChange={(e) => handleAddWidget(e.target.value)}
-          value=""
-          data-oid=".afd4c5"
-        >
-          <option disabled value="" data-oid="6wcsx7v">
-            Agregar widget...
-          </option>
-          {catalogo
-            .filter((w) => !widgets.includes(w.key))
-            .map((w) => (
-              <option key={w.key} value={w.key} data-oid="z4paaf7">
-                {w.title}
-              </option>
-            ))}
-        </select>
+        <div className="flex items-center gap-2">
+          <select
+            onChange={(e) => handleAddWidget(e.target.value)}
+            value=""
+            data-oid=".afd4c5"
+          >
+            <option disabled value="" data-oid="6wcsx7v">
+              Agregar widget...
+            </option>
+            {catalogo
+              .filter((w) => !widgets.includes(w.key))
+              .map((w) => (
+                <option key={w.key} value={w.key} data-oid="z4paaf7">
+                  {w.title}
+                </option>
+              ))}
+          </select>
+          <button
+            onClick={() => setShowPizarra(true)}
+            className="dashboard-btn"
+            data-oid="open-pizarra"
+          >
+            Abrir Pizarra
+          </button>
+        </div>
       </div>
 
       <GridLayout
@@ -255,6 +266,9 @@ export default function DashboardPage() {
           );
         })}
       </GridLayout>
+      {showPizarra && (
+        <PizarraCanvas onClose={() => setShowPizarra(false)} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add modular Pizarra canvas with navbar and sidebar
- toggle Pizarra from dashboard main page
- update README with latest patch notes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
