### PR TITLE
Implement almacenes dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,8 @@ honeylabs/
 - [ ] Notificaciones y alertas
 
 ## Parches
-
-
-- Se añadió una estructura base para la **Pizarra Infinita** accesible solo desde el panel principal del dashboard.
+- Se añadió la sección de **Almacenes** con barra lateral y navbar propios,
+  permitiendo cambiar entre vista de lista y cuadrícula.
 
 ---
 

--- a/src/app/api/almacenes/[id]/route.ts
+++ b/src/app/api/almacenes/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@lib/prisma";
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const id = Number(params.id);
+    const almacen = await prisma.almacen.findUnique({
+      where: { id },
+      select: { id: true, nombre: true, descripcion: true },
+    });
+    if (!almacen) {
+      return NextResponse.json({ error: "No encontrado" }, { status: 404 });
+    }
+    return NextResponse.json({ almacen });
+  } catch (err) {
+    console.error("Error en /api/almacenes/[id]", err);
+    return NextResponse.json({ error: "Error al obtener almacén" }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/almacenes/[id]/layout.tsx
+++ b/src/app/dashboard/almacenes/[id]/layout.tsx
@@ -1,0 +1,74 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { DashboardUIProvider, useDashboardUI } from "../../ui";
+import { useRouter } from "next/navigation";
+import AlmacenNavbar from "../components/AlmacenNavbar";
+import AlmacenSidebar from "../components/AlmacenSidebar";
+
+interface Usuario {
+  id: number;
+  nombre: string;
+  email?: string;
+}
+
+function ProtectedAlmacen({ children }: { children: React.ReactNode }) {
+  const { fullscreen } = useDashboardUI();
+  const router = useRouter();
+  const [usuario, setUsuario] = useState<Usuario | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const cargarUsuario = async () => {
+      try {
+        const res = await fetch("/api/login", { credentials: "include" });
+        const data = await res.json();
+        if (data?.success && data?.usuario) {
+          setUsuario(data.usuario);
+        } else {
+          setUsuario(null);
+        }
+      } catch {
+        setUsuario(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+    cargarUsuario();
+  }, []);
+
+  useEffect(() => {
+    if (!loading && !usuario) {
+      router.replace("/login");
+    }
+  }, [usuario, loading, router]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[var(--dashboard-bg)]">
+        <span className="text-[var(--dashboard-accent)] text-lg font-bold animate-pulse">Cargando...</span>
+      </div>
+    );
+  }
+
+  if (!usuario) return null;
+
+  return (
+    <div className={`min-h-screen bg-[var(--dashboard-bg)] relative ${fullscreen ? 'dashboard-full' : ''}`}>
+      <AlmacenSidebar />
+      <main className="flex flex-col min-h-screen" style={{ paddingLeft: '192px' }}>
+        <AlmacenNavbar />
+        <section className="flex-1 p-4 overflow-y-auto bg-[var(--dashboard-bg)] text-[var(--dashboard-text)]">
+          {children}
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default function AlmacenLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <DashboardUIProvider>
+      <ProtectedAlmacen>{children}</ProtectedAlmacen>
+    </DashboardUIProvider>
+  );
+}

--- a/src/app/dashboard/almacenes/[id]/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+
+interface Almacen {
+  id: number;
+  nombre: string;
+  descripcion?: string | null;
+}
+
+export default function AlmacenDetallePage() {
+  const params = useParams();
+  const id = params.id as string;
+  const [almacen, setAlmacen] = useState<Almacen | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/almacenes/${id}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.error) throw new Error(data.error);
+        setAlmacen(data.almacen);
+      })
+      .catch(() => setError("Error al cargar almacén"))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+  if (loading) return <div className="p-4">Cargando...</div>;
+  if (!almacen) return <div className="p-4">No encontrado</div>;
+
+  return (
+    <div data-oid="almacen-detalle">
+      <h1 className="text-2xl font-bold mb-2">{almacen.nombre}</h1>
+      {almacen.descripcion && <p className="text-sm text-[var(--dashboard-muted)]">{almacen.descripcion}</p>}
+    </div>
+  );
+}

--- a/src/app/dashboard/almacenes/components/AlmacenNavbar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenNavbar.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { ArrowLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+export default function AlmacenNavbar({ nombre }: { nombre?: string }) {
+  const router = useRouter();
+  return (
+    <header className="flex items-center justify-between p-2 border-b border-[var(--dashboard-border)] bg-[var(--dashboard-navbar)]" style={{ minHeight: '50px' }}>
+      <div className="flex items-center gap-2">
+        <button onClick={() => router.push('/dashboard/almacenes')} className="p-2 hover:bg-white/10 rounded" title="Volver">
+          <ArrowLeft className="w-5 h-5" />
+        </button>
+        <span className="font-semibold text-lg">{nombre || 'Almacén'}</span>
+      </div>
+    </header>
+  );
+}

--- a/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+export default function AlmacenSidebar() {
+  return (
+    <aside className="w-48 p-2 border-r border-[var(--dashboard-border)] bg-[var(--dashboard-sidebar)] flex flex-col gap-1">
+      <button className="p-2 rounded hover:bg-white/10 text-left">Información</button>
+      <button className="p-2 rounded hover:bg-white/10 text-left">Inventario</button>
+      <button className="p-2 rounded hover:bg-white/10 text-left">Usuarios</button>
+    </aside>
+  );
+}

--- a/src/app/dashboard/almacenes/components/AlmacenesNavbar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenesNavbar.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { Plus, Upload, Download, Link2, Search, LayoutList, LayoutGrid } from "lucide-react";
+import { useAlmacenesUI } from "../ui";
+
+export default function AlmacenesNavbar() {
+  const { view, setView } = useAlmacenesUI();
+  return (
+    <header className="flex items-center justify-between p-2 border-b border-[var(--dashboard-border)] bg-[var(--dashboard-navbar)]" style={{ minHeight: '50px' }}>
+      <div className="flex items-center gap-2">
+        <span className="font-semibold text-lg">Almacenes</span>
+        <button onClick={() => setView('list')} className={`p-2 rounded hover:bg-white/10 ${view==='list'?'text-[var(--dashboard-accent)]':''}`} title="Lista">
+          <LayoutList className="w-5 h-5" />
+        </button>
+        <button onClick={() => setView('grid')} className={`p-2 rounded hover:bg-white/10 ${view==='grid'?'text-[var(--dashboard-accent)]':''}`} title="Cuadrícula">
+          <LayoutGrid className="w-5 h-5" />
+        </button>
+      </div>
+      <div className="flex items-center gap-2">
+        <button onClick={() => alert('Crear almacén')} className="p-2 hover:bg-white/10 rounded" title="Crear">
+          <Plus className="w-5 h-5" />
+        </button>
+        <button onClick={() => alert('Importar')} className="p-2 hover:bg-white/10 rounded" title="Importar">
+          <Upload className="w-5 h-5" />
+        </button>
+        <button onClick={() => alert('Exportar')} className="p-2 hover:bg-white/10 rounded" title="Exportar">
+          <Download className="w-5 h-5" />
+        </button>
+        <button onClick={() => alert('Conectar por código')} className="p-2 hover:bg-white/10 rounded" title="Conectar por código">
+          <Link2 className="w-5 h-5" />
+        </button>
+        <div className="relative ml-2">
+          <Search className="w-4 h-4 absolute left-3 top-2 text-[var(--dashboard-muted)]" />
+          <input className="pl-8 pr-2 py-1 rounded border border-[var(--dashboard-border)] bg-transparent" placeholder="Buscar" />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/app/dashboard/almacenes/components/AlmacenesSidebar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenesSidebar.tsx
@@ -1,0 +1,11 @@
+"use client";
+import Link from "next/link";
+
+export default function AlmacenesSidebar() {
+  return (
+    <aside className="w-48 p-2 border-r border-[var(--dashboard-border)] bg-[var(--dashboard-sidebar)] flex flex-col gap-1">
+      <Link href="/dashboard/almacenes" className="p-2 rounded hover:bg-white/10">Todos</Link>
+      <Link href="/dashboard/almacenes?favoritos=1" className="p-2 rounded hover:bg-white/10">Favoritos</Link>
+    </aside>
+  );
+}

--- a/src/app/dashboard/almacenes/layout.tsx
+++ b/src/app/dashboard/almacenes/layout.tsx
@@ -1,0 +1,77 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { DashboardUIProvider, useDashboardUI } from "../ui";
+import { useRouter } from "next/navigation";
+import AlmacenesNavbar from "./components/AlmacenesNavbar";
+import AlmacenesSidebar from "./components/AlmacenesSidebar";
+import { AlmacenesUIProvider } from "./ui";
+
+interface Usuario {
+  id: number;
+  nombre: string;
+  email?: string;
+}
+
+function ProtectedAlmacenes({ children }: { children: React.ReactNode }) {
+  const { fullscreen } = useDashboardUI();
+  const router = useRouter();
+  const [usuario, setUsuario] = useState<Usuario | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const cargarUsuario = async () => {
+      try {
+        const res = await fetch("/api/login", { credentials: "include" });
+        const data = await res.json();
+        if (data?.success && data?.usuario) {
+          setUsuario(data.usuario);
+        } else {
+          setUsuario(null);
+        }
+      } catch {
+        setUsuario(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+    cargarUsuario();
+  }, []);
+
+  useEffect(() => {
+    if (!loading && !usuario) {
+      router.replace("/login");
+    }
+  }, [usuario, loading, router]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[var(--dashboard-bg)]">
+        <span className="text-[var(--dashboard-accent)] text-lg font-bold animate-pulse">Cargando...</span>
+      </div>
+    );
+  }
+
+  if (!usuario) return null;
+
+  return (
+    <div className={`min-h-screen bg-[var(--dashboard-bg)] relative ${fullscreen ? 'dashboard-full' : ''}`}>
+      <AlmacenesSidebar />
+      <main className="flex flex-col min-h-screen" style={{ paddingLeft: '192px' }}>
+        <AlmacenesNavbar />
+        <section className="flex-1 p-4 overflow-y-auto bg-[var(--dashboard-bg)] text-[var(--dashboard-text)]">
+          {children}
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default function AlmacenesLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <DashboardUIProvider>
+      <AlmacenesUIProvider>
+        <ProtectedAlmacenes>{children}</ProtectedAlmacenes>
+      </AlmacenesUIProvider>
+    </DashboardUIProvider>
+  );
+}

--- a/src/app/dashboard/almacenes/page.tsx
+++ b/src/app/dashboard/almacenes/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAlmacenesUI } from "./ui";
 
 interface Usuario {
   id: number;
@@ -19,6 +21,8 @@ export default function AlmacenesPage() {
   const [almacenes, setAlmacenes] = useState<Almacen[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const router = useRouter();
+  const { view } = useAlmacenesUI();
 
   useEffect(() => {
     fetch("/api/login", { credentials: "include" })
@@ -54,12 +58,41 @@ export default function AlmacenesPage() {
 
   return (
     <div className="p-4" data-oid="almacenes-page">
-      <h1 className="text-2xl font-bold mb-4">Almacenes</h1>
-      <ul className="list-disc pl-4">
-        {almacenes.map((a) => (
-          <li key={a.id}>{a.nombre}</li>
-        ))}
-      </ul>
+      {view === "list" ? (
+        <ul className="divide-y">
+          {almacenes.map((a) => (
+            <li
+              key={a.id}
+              className="p-2 cursor-pointer hover:bg-white/5"
+              onClick={() => router.push(`/dashboard/almacenes/${a.id}`)}
+            >
+              <h3 className="font-semibold">{a.nombre}</h3>
+              {a.descripcion && (
+                <p className="text-sm text-[var(--dashboard-muted)]">
+                  {a.descripcion}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {almacenes.map((a) => (
+            <div
+              key={a.id}
+              className="p-4 border rounded-lg cursor-pointer hover:bg-white/5"
+              onClick={() => router.push(`/dashboard/almacenes/${a.id}`)}
+            >
+              <h3 className="font-semibold mb-1">{a.nombre}</h3>
+              {a.descripcion && (
+                <p className="text-sm text-[var(--dashboard-muted)]">
+                  {a.descripcion}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/dashboard/almacenes/ui.tsx
+++ b/src/app/dashboard/almacenes/ui.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { createContext, useContext, useState } from "react";
+
+type View = "list" | "grid";
+interface AlmacenesUIState {
+  view: View;
+  setView: (view: View) => void;
+}
+
+const AlmacenesUIContext = createContext<AlmacenesUIState>({
+  view: "list",
+  setView: () => {},
+});
+
+export function AlmacenesUIProvider({ children }: { children: React.ReactNode }) {
+  const [view, setView] = useState<View>("list");
+  return (
+    <AlmacenesUIContext.Provider value={{ view, setView }}>
+      {children}
+    </AlmacenesUIContext.Provider>
+  );
+}
+
+export function useAlmacenesUI() {
+  return useContext(AlmacenesUIContext);
+}


### PR DESCRIPTION
## Summary
- add new UI context and components for `/dashboard/almacenes`
- implement dedicated layout with exclusive navbar and sidebar
- support list and grid views and navigation to warehouse detail
- create dynamic API and pages for warehouse detail
- update README patch notes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: Failed to fetch prisma engines)*

------
https://chatgpt.com/codex/tasks/task_e_683fa9d3de648328871dcd6105abcb34