### PR TITLE
Implement almacenes dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,8 @@ honeylabs/
 - [ ] Notificaciones y alertas
 
 ## Parches
-
-
-- Se añadió una estructura base para la **Pizarra Infinita** accesible solo desde el panel principal del dashboard.
+- Se implementó la creación de **Almacenes** asociados al usuario con vista de detalle y navegación propia.
+- El panel principal guarda ahora la configuración de widgets en la base de datos.
 
 ---
 

--- a/src/app/api/almacenes/[id]/route.ts
+++ b/src/app/api/almacenes/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@lib/prisma";
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const id = Number(params.id);
+    const almacen = await prisma.almacen.findUnique({
+      where: { id },
+      select: { id: true, nombre: true, descripcion: true },
+    });
+    if (!almacen) {
+      return NextResponse.json({ error: "No encontrado" }, { status: 404 });
+    }
+    return NextResponse.json({ almacen });
+  } catch (err) {
+    console.error("Error en /api/almacenes/[id]", err);
+    return NextResponse.json({ error: "Error al obtener almacén" }, { status: 500 });
+  }
+}

--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -1,6 +1,8 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@lib/prisma";
+import crypto from "node:crypto";
+import { getUsuarioFromSession } from "@lib/auth";
 
 export async function GET(req: NextRequest) {
   try {
@@ -15,6 +17,47 @@ export async function GET(req: NextRequest) {
     console.error("Error en /api/almacenes:", err);
     return NextResponse.json(
       { error: "Error al obtener almacenes" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const usuario = await getUsuarioFromSession();
+    if (!usuario) {
+      return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+    }
+
+    const { nombre, descripcion } = await req.json();
+    if (!nombre) {
+      return NextResponse.json({ error: 'Nombre requerido' }, { status: 400 });
+    }
+
+    if (!usuario.entidadId) {
+      return NextResponse.json({ error: 'Usuario sin entidad' }, { status: 400 });
+    }
+
+    const codigoUnico = crypto.randomUUID().split('-')[0];
+
+    const almacen = await prisma.almacen.create({
+      data: {
+        nombre,
+        descripcion,
+        codigoUnico,
+        entidadId: usuario.entidadId,
+        usuarios: {
+          create: { usuarioId: usuario.id, rolEnAlmacen: 'propietario' },
+        },
+      },
+      select: { id: true, nombre: true, descripcion: true },
+    });
+
+    return NextResponse.json({ almacen });
+  } catch (err) {
+    console.error('POST /api/almacenes', err);
+    return NextResponse.json(
+      { error: 'Error al crear almacén' },
       { status: 500 },
     );
   }

--- a/src/app/api/dashboard/layout/route.ts
+++ b/src/app/api/dashboard/layout/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@lib/prisma';
+import { getUsuarioFromSession } from '@lib/auth';
+
+export async function GET() {
+  try {
+    const usuario = await getUsuarioFromSession();
+    if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+    const prefs = usuario.preferencias ? JSON.parse(usuario.preferencias) : {};
+    return NextResponse.json(prefs.dashboardLayout || { widgets: [], layout: [] });
+  } catch (err) {
+    console.error('GET /api/dashboard/layout', err);
+    return NextResponse.json({ error: 'Error' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const usuario = await getUsuarioFromSession();
+    if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+    const data = await req.json();
+    const prefs = usuario.preferencias ? JSON.parse(usuario.preferencias) : {};
+    prefs.dashboardLayout = data;
+    await prisma.usuario.update({ where: { id: usuario.id }, data: { preferencias: JSON.stringify(prefs) } });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error('POST /api/dashboard/layout', err);
+    return NextResponse.json({ error: 'Error' }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/almacenes/[id]/layout.tsx
+++ b/src/app/dashboard/almacenes/[id]/layout.tsx
@@ -1,0 +1,74 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { DashboardUIProvider, useDashboardUI } from "../../ui";
+import { useRouter } from "next/navigation";
+import AlmacenNavbar from "../components/AlmacenNavbar";
+import AlmacenSidebar from "../components/AlmacenSidebar";
+
+interface Usuario {
+  id: number;
+  nombre: string;
+  email?: string;
+}
+
+function ProtectedAlmacen({ children }: { children: React.ReactNode }) {
+  const { fullscreen } = useDashboardUI();
+  const router = useRouter();
+  const [usuario, setUsuario] = useState<Usuario | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const cargarUsuario = async () => {
+      try {
+        const res = await fetch("/api/login", { credentials: "include" });
+        const data = await res.json();
+        if (data?.success && data?.usuario) {
+          setUsuario(data.usuario);
+        } else {
+          setUsuario(null);
+        }
+      } catch {
+        setUsuario(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+    cargarUsuario();
+  }, []);
+
+  useEffect(() => {
+    if (!loading && !usuario) {
+      router.replace("/login");
+    }
+  }, [usuario, loading, router]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[var(--dashboard-bg)]">
+        <span className="text-[var(--dashboard-accent)] text-lg font-bold animate-pulse">Cargando...</span>
+      </div>
+    );
+  }
+
+  if (!usuario) return null;
+
+  return (
+    <div className={`min-h-screen bg-[var(--dashboard-bg)] relative ${fullscreen ? 'dashboard-full' : ''}`}>
+      <AlmacenSidebar />
+      <main className="flex flex-col min-h-screen" style={{ paddingLeft: '192px' }}>
+        <AlmacenNavbar />
+        <section className="flex-1 p-4 overflow-y-auto bg-[var(--dashboard-bg)] text-[var(--dashboard-text)]">
+          {children}
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default function AlmacenLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <DashboardUIProvider>
+      <ProtectedAlmacen>{children}</ProtectedAlmacen>
+    </DashboardUIProvider>
+  );
+}

--- a/src/app/dashboard/almacenes/[id]/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+
+interface Almacen {
+  id: number;
+  nombre: string;
+  descripcion?: string | null;
+}
+
+export default function AlmacenDetallePage() {
+  const params = useParams();
+  const id = params.id as string;
+  const [almacen, setAlmacen] = useState<Almacen | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/almacenes/${id}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.error) throw new Error(data.error);
+        setAlmacen(data.almacen);
+      })
+      .catch(() => setError("Error al cargar almacén"))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+  if (loading) return <div className="p-4">Cargando...</div>;
+  if (!almacen) return <div className="p-4">No encontrado</div>;
+
+  return (
+    <div data-oid="almacen-detalle">
+      <h1 className="text-2xl font-bold mb-2">{almacen.nombre}</h1>
+      {almacen.descripcion && <p className="text-sm text-[var(--dashboard-muted)]">{almacen.descripcion}</p>}
+    </div>
+  );
+}

--- a/src/app/dashboard/almacenes/components/AlmacenNavbar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenNavbar.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { ArrowLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+export default function AlmacenNavbar({ nombre }: { nombre?: string }) {
+  const router = useRouter();
+  return (
+    <header className="flex items-center justify-between p-2 border-b border-[var(--dashboard-border)] bg-[var(--dashboard-navbar)]" style={{ minHeight: '50px' }}>
+      <div className="flex items-center gap-2">
+        <button onClick={() => router.push('/dashboard/almacenes')} className="p-2 hover:bg-white/10 rounded" title="Volver">
+          <ArrowLeft className="w-5 h-5" />
+        </button>
+        <span className="font-semibold text-lg">{nombre || 'Almacén'}</span>
+      </div>
+    </header>
+  );
+}

--- a/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+export default function AlmacenSidebar() {
+  return (
+    <aside className="w-48 p-2 border-r border-[var(--dashboard-border)] bg-[var(--dashboard-sidebar)] flex flex-col gap-1">
+      <button className="p-2 rounded hover:bg-white/10 text-left">Información</button>
+      <button className="p-2 rounded hover:bg-white/10 text-left">Inventario</button>
+      <button className="p-2 rounded hover:bg-white/10 text-left">Usuarios</button>
+    </aside>
+  );
+}

--- a/src/app/dashboard/almacenes/components/AlmacenesNavbar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenesNavbar.tsx
@@ -1,0 +1,71 @@
+"use client";
+import { Plus, Upload, Download, Link2, Search, LayoutList, LayoutGrid, Star } from "lucide-react";
+import { useAlmacenesUI } from "../ui";
+import { useEffect, useState } from "react";
+
+interface Usuario {
+  tipoCuenta?: string;
+  rol?: string;
+}
+
+export default function AlmacenesNavbar() {
+  const { view, setView, filter, setFilter, onCreate } = useAlmacenesUI();
+  const [usuario, setUsuario] = useState<Usuario | null>(null);
+
+  useEffect(() => {
+    fetch('/api/login', { credentials: 'include' })
+      .then(r => r.json())
+      .then(d => d.success ? setUsuario(d.usuario) : setUsuario(null))
+      .catch(() => setUsuario(null));
+  }, []);
+
+  const allowManage = usuario?.rol === 'admin' || usuario?.tipoCuenta === 'institucional' || usuario?.tipoCuenta === 'empresarial';
+  return (
+    <header className="flex items-center justify-between p-2 border-b border-[var(--dashboard-border)] bg-[var(--dashboard-navbar)]" style={{ minHeight: '50px' }}>
+      <div className="flex items-center gap-2">
+        <span className="font-semibold text-lg">Almacenes</span>
+        <button onClick={() => setView('list')} className={`p-2 rounded hover:bg-white/10 ${view==='list'?'text-[var(--dashboard-accent)]':''}`} title="Lista">
+          <LayoutList className="w-5 h-5" />
+        </button>
+        <button onClick={() => setView('grid')} className={`p-2 rounded hover:bg-white/10 ${view==='grid'?'text-[var(--dashboard-accent)]':''}`} title="Cuadrícula">
+          <LayoutGrid className="w-5 h-5" />
+        </button>
+        <button onClick={() => setFilter('todos')} className={`p-2 rounded hover:bg-white/10 ${filter==='todos'?'text-[var(--dashboard-accent)]':''}`} title="Todos">
+          <span>Todos</span>
+        </button>
+        <button onClick={() => setFilter('favoritos')} className={`p-2 rounded hover:bg-white/10 ${filter==='favoritos'?'text-[var(--dashboard-accent)]':''}`} title="Favoritos">
+          <Star className="w-4 h-4" />
+        </button>
+      </div>
+      <div className="flex items-center gap-2">
+        {allowManage && (
+          <button onClick={() => {
+            const nombre = prompt('Nombre del almacén');
+            if (!nombre) return;
+            const descripcion = prompt('Descripción') || '';
+            onCreate?.(nombre, descripcion);
+          }} className="p-2 hover:bg-white/10 rounded" title="Crear">
+            <Plus className="w-5 h-5" />
+          </button>
+        )}
+        {allowManage && (
+          <button onClick={() => alert('Importar')} className="p-2 hover:bg-white/10 rounded" title="Importar">
+            <Upload className="w-5 h-5" />
+          </button>
+        )}
+        {allowManage && (
+          <button onClick={() => alert('Exportar')} className="p-2 hover:bg-white/10 rounded" title="Exportar">
+            <Download className="w-5 h-5" />
+          </button>
+        )}
+        <button onClick={() => alert('Conectar por código')} className="p-2 hover:bg-white/10 rounded" title="Conectar por código">
+          <Link2 className="w-5 h-5" />
+        </button>
+        <div className="relative ml-2">
+          <Search className="w-4 h-4 absolute left-3 top-2 text-[var(--dashboard-muted)]" />
+          <input className="pl-8 pr-2 py-1 rounded border border-[var(--dashboard-border)] bg-transparent" placeholder="Buscar" />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/app/dashboard/almacenes/components/AlmacenesSidebar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenesSidebar.tsx
@@ -1,0 +1,10 @@
+"use client";
+import Link from "next/link";
+
+export default function AlmacenesSidebar() {
+  return (
+    <aside className="w-48 p-2 border-r border-[var(--dashboard-border)] bg-[var(--dashboard-sidebar)] flex flex-col gap-1">
+      <span className="p-2 font-semibold text-sm text-[var(--dashboard-muted)]">Mis almacenes</span>
+    </aside>
+  );
+}

--- a/src/app/dashboard/almacenes/layout.tsx
+++ b/src/app/dashboard/almacenes/layout.tsx
@@ -1,0 +1,77 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { DashboardUIProvider, useDashboardUI } from "../ui";
+import { useRouter } from "next/navigation";
+import AlmacenesNavbar from "./components/AlmacenesNavbar";
+import AlmacenesSidebar from "./components/AlmacenesSidebar";
+import { AlmacenesUIProvider } from "./ui";
+
+interface Usuario {
+  id: number;
+  nombre: string;
+  email?: string;
+}
+
+function ProtectedAlmacenes({ children }: { children: React.ReactNode }) {
+  const { fullscreen } = useDashboardUI();
+  const router = useRouter();
+  const [usuario, setUsuario] = useState<Usuario | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const cargarUsuario = async () => {
+      try {
+        const res = await fetch("/api/login", { credentials: "include" });
+        const data = await res.json();
+        if (data?.success && data?.usuario) {
+          setUsuario(data.usuario);
+        } else {
+          setUsuario(null);
+        }
+      } catch {
+        setUsuario(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+    cargarUsuario();
+  }, []);
+
+  useEffect(() => {
+    if (!loading && !usuario) {
+      router.replace("/login");
+    }
+  }, [usuario, loading, router]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[var(--dashboard-bg)]">
+        <span className="text-[var(--dashboard-accent)] text-lg font-bold animate-pulse">Cargando...</span>
+      </div>
+    );
+  }
+
+  if (!usuario) return null;
+
+  return (
+    <div className={`min-h-screen bg-[var(--dashboard-bg)] relative ${fullscreen ? 'dashboard-full' : ''}`}>
+      <AlmacenesSidebar />
+      <main className="flex flex-col min-h-screen" style={{ paddingLeft: '192px' }}>
+        <AlmacenesNavbar />
+        <section className="flex-1 p-4 overflow-y-auto bg-[var(--dashboard-bg)] text-[var(--dashboard-text)]">
+          {children}
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default function AlmacenesLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <DashboardUIProvider>
+      <AlmacenesUIProvider>
+        <ProtectedAlmacenes>{children}</ProtectedAlmacenes>
+      </AlmacenesUIProvider>
+    </DashboardUIProvider>
+  );
+}

--- a/src/app/dashboard/almacenes/ui.tsx
+++ b/src/app/dashboard/almacenes/ui.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { createContext, useContext, useState } from "react";
+
+type View = "list" | "grid";
+type Filter = "todos" | "favoritos";
+interface AlmacenesUIState {
+  view: View;
+  setView: (view: View) => void;
+  filter: Filter;
+  setFilter: (f: Filter) => void;
+  onCreate?: (nombre: string, descripcion: string) => void;
+  registerCreate: (fn: (nombre: string, descripcion: string) => void) => void;
+}
+
+const AlmacenesUIContext = createContext<AlmacenesUIState>({
+  view: "list",
+  setView: () => {},
+  filter: "todos",
+  setFilter: () => {},
+});
+
+export function AlmacenesUIProvider({ children, onCreate }: { children: React.ReactNode; onCreate?: (nombre: string, descripcion: string) => void }) {
+  const [view, setView] = useState<View>("list");
+  const [filter, setFilter] = useState<Filter>("todos");
+  const [createFn, setCreateFn] = useState<((nombre: string, descripcion: string) => void) | undefined>(onCreate);
+  const registerCreate = (fn: (nombre: string, descripcion: string) => void) => setCreateFn(() => fn);
+  return (
+    <AlmacenesUIContext.Provider value={{ view, setView, filter, setFilter, onCreate: createFn, registerCreate }}>
+      {children}
+    </AlmacenesUIContext.Provider>
+  );
+}
+
+export function useAlmacenesUI() {
+  return useContext(AlmacenesUIContext);
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -96,11 +96,9 @@ export default function DashboardPage() {
 
         let saved: { widgets: string[]; layout: Layout[] } | null = null;
         try {
-          const raw = localStorage.getItem(`dashboardLayout_${usuario.id}`);
-          if (raw) saved = JSON.parse(raw);
-        } catch {
-          // si el JSON es inválido, ignoramos
-        }
+          const res = await fetch('/api/dashboard/layout');
+          if (res.ok) saved = await res.json();
+        } catch {}
 
         if (saved && Array.isArray(saved.widgets) && Array.isArray(saved.layout)) {
           const validKeys = permitidos.map((w) => w.key);
@@ -117,13 +115,15 @@ export default function DashboardPage() {
       .catch((err) => console.error("Error al cargar widgets:", err));
   }, [usuario]);
 
-  // Guardar en localStorage cada que cambian widgets o layout
+  // Guardar en DB cada que cambian widgets o layout
   useEffect(() => {
     if (!usuario) return;
-    const data = JSON.stringify({ widgets, layout });
-    try {
-      localStorage.setItem(`dashboardLayout_${usuario.id}`, data);
-    } catch {}
+    const data = { widgets, layout };
+    fetch('/api/dashboard/layout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    }).catch(() => {});
   }, [widgets, layout, usuario]);
 
   // Agregar widget


### PR DESCRIPTION
## Summary
- implement warehouse creation API with Prisma
- store dashboard layout in the database
- add dashboard layout API
- update almacenes navbar with filters and creation button
- update README patch notes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: Failed to fetch prisma engines)*

------
https://chatgpt.com/codex/tasks/task_e_683fa9d3de648328871dcd6105abcb34