### PR TITLE
Fix infinite render loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ honeylabs/
 - [ ] Notificaciones y alertas
 
 ## Parches
-- Se actualizó la barra de navegación de Almacenes con nuevas vistas (lista, cuadrícula y árbol) y botones adicionales para gestión y reportes.
+* Se solucionó un bucle de actualizaciones infinitas en el contexto de Almacenes al memorizar la función `registerCreate` con `useCallback`.
 
 
 ---

--- a/src/app/dashboard/almacenes/ui.tsx
+++ b/src/app/dashboard/almacenes/ui.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useState, useCallback } from "react";
 
 type View = "list" | "grid" | "tree";
 type Filter = "todos" | "favoritos";
@@ -23,8 +23,15 @@ const AlmacenesUIContext = createContext<AlmacenesUIState>({
 export function AlmacenesUIProvider({ children, onCreate }: { children: React.ReactNode; onCreate?: (nombre: string, descripcion: string) => void }) {
   const [view, setView] = useState<View>("list");
   const [filter, setFilter] = useState<Filter>("todos");
-  const [createFn, setCreateFn] = useState<((nombre: string, descripcion: string) => void) | undefined>(onCreate);
-  const registerCreate = (fn: (nombre: string, descripcion: string) => void) => setCreateFn(() => fn);
+  const [createFn, setCreateFn] =
+    useState<((nombre: string, descripcion: string) => void) | undefined>(onCreate);
+
+  const registerCreate = useCallback(
+    (fn: (nombre: string, descripcion: string) => void) => {
+      setCreateFn(() => fn);
+    },
+    [],
+  );
   return (
     <AlmacenesUIContext.Provider value={{ view, setView, filter, setFilter, onCreate: createFn, registerCreate }}>
 


### PR DESCRIPTION
## Summary
- avoid infinite re-renders in `AlmacenesUIProvider` by memoizing `registerCreate`
- update README patch notes

## Testing
- `npm install` *(fails: Failed to fetch checksum 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683fb49a735c8328b445cd22b6004911