### PR TITLE
Fix almacenes sidebar and add CRUD pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ honeylabs/
 - [ ] Notificaciones y alertas
 
 ## Parches
-* Se agregó un estado global para controlar el colapso del sidebar del dashboard y se sincronizó el desplazamiento del sidebar de Almacenes.
+* Se ajustaron los layouts de **Almacenes** para alinear correctamente su sidebar junto al sidebar global sin cubrir el navbar del dashboard.
+* Se añadieron páginas para crear y editar almacenes y se implementó la ruta API para actualizar información.
 
 
 ---

--- a/src/app/api/almacenes/[id]/route.ts
+++ b/src/app/api/almacenes/[id]/route.ts
@@ -33,3 +33,23 @@ export async function DELETE(req: NextRequest, { params }: { params: { id: strin
     return NextResponse.json({ error: 'Error al eliminar' }, { status: 500 });
   }
 }
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const usuario = await getUsuarioFromSession();
+    if (!usuario) {
+      return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+    }
+    const id = Number(params.id);
+    const { nombre, descripcion } = await req.json();
+    const almacen = await prisma.almacen.update({
+      where: { id },
+      data: { nombre, descripcion },
+      select: { id: true, nombre: true, descripcion: true },
+    });
+    return NextResponse.json({ almacen });
+  } catch (err) {
+    console.error('PUT /api/almacenes/[id]', err);
+    return NextResponse.json({ error: 'Error al actualizar' }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/almacenes/[id]/editar/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/editar/page.tsx
@@ -1,0 +1,72 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+
+export default function EditarAlmacenPage() {
+  const { id } = useParams();
+  const router = useRouter();
+  const [nombre, setNombre] = useState("");
+  const [descripcion, setDescripcion] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/almacenes/${id}`)
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.almacen) {
+          setNombre(d.almacen.nombre);
+          setDescripcion(d.almacen.descripcion || "");
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  const guardar = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/almacenes/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ nombre, descripcion }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        router.push(`/dashboard/almacenes/${id}`);
+      } else {
+        alert(data.error || "Error al actualizar");
+      }
+    } catch {
+      alert("Error de red");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) return <div className="p-4">Cargando...</div>;
+
+  return (
+    <div className="p-4 max-w-md" data-oid="editar-almacen">
+      <h1 className="text-xl font-bold mb-4">Editar almacén</h1>
+      <div className="flex flex-col gap-2">
+        <input
+          className="border p-2 rounded"
+          placeholder="Nombre"
+          value={nombre}
+          onChange={(e) => setNombre(e.target.value)}
+        />
+        <textarea
+          className="border p-2 rounded"
+          placeholder="Descripción"
+          value={descripcion}
+          onChange={(e) => setDescripcion(e.target.value)}
+        />
+        <button
+          onClick={guardar}
+          className="p-2 bg-[var(--dashboard-accent)] text-white rounded"
+        >
+          Guardar
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/almacenes/[id]/layout.tsx
+++ b/src/app/dashboard/almacenes/[id]/layout.tsx
@@ -1,9 +1,15 @@
 "use client";
 import React, { useEffect, useState } from "react";
-import { DashboardUIProvider, useDashboardUI } from "../../ui";
+import { useDashboardUI } from "../../ui";
 import { useRouter } from "next/navigation";
 import AlmacenNavbar from "../components/AlmacenNavbar";
 import AlmacenSidebar from "../components/AlmacenSidebar";
+import {
+  SIDEBAR_GLOBAL_WIDTH,
+  SIDEBAR_GLOBAL_COLLAPSED_WIDTH,
+  SIDEBAR_ALMACENES_WIDTH,
+  NAVBAR_HEIGHT,
+} from "../../constants";
 
 interface Usuario {
   id: number;
@@ -12,7 +18,11 @@ interface Usuario {
 }
 
 function ProtectedAlmacen({ children }: { children: React.ReactNode }) {
-  const { fullscreen } = useDashboardUI();
+  const {
+    fullscreen,
+    sidebarGlobalVisible = true,
+    sidebarGlobalCollapsed,
+  } = useDashboardUI();
   const router = useRouter();
   const [usuario, setUsuario] = useState<Usuario | null>(null);
   const [loading, setLoading] = useState(true);
@@ -52,10 +62,35 @@ function ProtectedAlmacen({ children }: { children: React.ReactNode }) {
 
   if (!usuario) return null;
 
+  const globalWidth = sidebarGlobalVisible
+    ? sidebarGlobalCollapsed
+      ? SIDEBAR_GLOBAL_COLLAPSED_WIDTH
+      : SIDEBAR_GLOBAL_WIDTH
+    : 0;
+  const sidebarLeft = globalWidth;
+  const mainMarginLeft = !fullscreen
+    ? globalWidth + SIDEBAR_ALMACENES_WIDTH
+    : 0;
+
   return (
-    <div className={`min-h-screen bg-[var(--dashboard-bg)] relative ${fullscreen ? 'dashboard-full' : ''}`}>
-      <AlmacenSidebar />
-      <main className="flex flex-col min-h-screen" style={{ paddingLeft: '192px' }}>
+    <div
+      className={`min-h-screen bg-[var(--dashboard-bg)] relative ${
+        fullscreen ? 'dashboard-full' : ''
+      }`}
+    >
+      <AlmacenSidebar
+        style={{
+          left: sidebarLeft,
+          top: NAVBAR_HEIGHT,
+          width: SIDEBAR_ALMACENES_WIDTH,
+          minWidth: SIDEBAR_ALMACENES_WIDTH,
+          height: `calc(100vh - ${NAVBAR_HEIGHT}px)`,
+        }}
+      />
+      <main
+        className="flex flex-col min-h-screen transition-all duration-300"
+        style={{ marginLeft: mainMarginLeft, marginTop: NAVBAR_HEIGHT }}
+      >
         <AlmacenNavbar />
         <section className="flex-1 p-4 overflow-y-auto bg-[var(--dashboard-bg)] text-[var(--dashboard-text)]">
           {children}
@@ -66,9 +101,5 @@ function ProtectedAlmacen({ children }: { children: React.ReactNode }) {
 }
 
 export default function AlmacenLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <DashboardUIProvider>
-      <ProtectedAlmacen>{children}</ProtectedAlmacen>
-    </DashboardUIProvider>
-  );
+  return <ProtectedAlmacen>{children}</ProtectedAlmacen>;
 }

--- a/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-export default function AlmacenSidebar() {
+export default function AlmacenSidebar({ style }: { style?: React.CSSProperties }) {
   return (
-    <aside className="w-48 p-2 border-r border-[var(--dashboard-border)] bg-[var(--dashboard-sidebar)] flex flex-col gap-1">
+    <aside
+      style={style}
+      className="w-48 p-2 border-r border-[var(--dashboard-border)] bg-[var(--dashboard-sidebar)] flex flex-col gap-1 fixed"
+    >
       <button className="p-2 rounded hover:bg-white/10 text-left">Información</button>
       <button className="p-2 rounded hover:bg-white/10 text-left">Inventario</button>
       <button className="p-2 rounded hover:bg-white/10 text-left">Usuarios</button>

--- a/src/app/dashboard/almacenes/components/AlmacenesSidebar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenesSidebar.tsx
@@ -24,6 +24,7 @@ import {
   SIDEBAR_GLOBAL_WIDTH,
   SIDEBAR_GLOBAL_COLLAPSED_WIDTH,
   SIDEBAR_ALMACENES_WIDTH,
+  NAVBAR_HEIGHT,
 } from "../../constants";
 
 export default function AlmacenesSidebar() {
@@ -45,9 +46,11 @@ export default function AlmacenesSidebar() {
         left: sidebarLeft,
         width: SIDEBAR_ALMACENES_WIDTH,
         minWidth: SIDEBAR_ALMACENES_WIDTH,
+        top: NAVBAR_HEIGHT,
+        height: `calc(100vh - ${NAVBAR_HEIGHT}px)`,
       }}
       className={`
-        fixed top-0 h-screen z-40
+        fixed z-40
         border-r border-[var(--dashboard-border)]
         bg-[var(--dashboard-sidebar)]
         flex flex-col gap-2 transition-all duration-300

--- a/src/app/dashboard/almacenes/layout.tsx
+++ b/src/app/dashboard/almacenes/layout.tsx
@@ -1,10 +1,11 @@
 "use client";
 import React, { useEffect, useState } from "react";
-import { DashboardUIProvider, useDashboardUI } from "../ui";
+import { useDashboardUI } from "../ui";
 import {
   SIDEBAR_GLOBAL_WIDTH,
   SIDEBAR_GLOBAL_COLLAPSED_WIDTH,
   SIDEBAR_ALMACENES_WIDTH,
+  NAVBAR_HEIGHT,
 } from "../constants";
 import { useRouter } from "next/navigation";
 import AlmacenesNavbar from "./components/AlmacenesNavbar";
@@ -20,7 +21,6 @@ interface Usuario {
 // Las constantes de ancho se comparten con el layout principal
 
 function ProtectedAlmacenes({ children }: { children: React.ReactNode }) {
-  // Ahora puedes controlar ambos desde tu context global (¡ajusta tu DashboardUIProvider!)
   const {
     fullscreen,
     sidebarGlobalVisible = true,
@@ -73,7 +73,9 @@ function ProtectedAlmacenes({ children }: { children: React.ReactNode }) {
       : SIDEBAR_GLOBAL_WIDTH
     : 0;
   const sidebarLeft = globalWidth;
-  const mainMarginLeft = !fullscreen ? globalWidth + SIDEBAR_ALMACENES_WIDTH : 0;
+  const mainMarginLeft = !fullscreen
+    ? globalWidth + SIDEBAR_ALMACENES_WIDTH
+    : 0;
 
   return (
     <div
@@ -88,8 +90,10 @@ function ProtectedAlmacenes({ children }: { children: React.ReactNode }) {
             width: SIDEBAR_ALMACENES_WIDTH,
             minWidth: SIDEBAR_ALMACENES_WIDTH,
             left: sidebarLeft,
+            top: NAVBAR_HEIGHT,
+            height: `calc(100vh - ${NAVBAR_HEIGHT}px)`,
           }}
-          className="fixed top-0 h-screen z-40 border-r border-[var(--dashboard-border)] bg-[var(--dashboard-sidebar)] flex flex-col transition-all duration-300"
+          className="fixed z-40 border-r border-[var(--dashboard-border)] bg-[var(--dashboard-sidebar)] flex flex-col transition-all duration-300"
         >
           <AlmacenesSidebar />
         </aside>
@@ -113,10 +117,8 @@ function ProtectedAlmacenes({ children }: { children: React.ReactNode }) {
 
 export default function AlmacenesLayout({ children }: { children: React.ReactNode }) {
   return (
-    <DashboardUIProvider>
-      <AlmacenesUIProvider>
-        <ProtectedAlmacenes>{children}</ProtectedAlmacenes>
-      </AlmacenesUIProvider>
-    </DashboardUIProvider>
+    <AlmacenesUIProvider>
+      <ProtectedAlmacenes>{children}</ProtectedAlmacenes>
+    </AlmacenesUIProvider>
   );
 }

--- a/src/app/dashboard/almacenes/nuevo/page.tsx
+++ b/src/app/dashboard/almacenes/nuevo/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function NuevoAlmacenPage() {
+  const [nombre, setNombre] = useState("");
+  const [descripcion, setDescripcion] = useState("");
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const crear = async () => {
+    if (!nombre.trim()) return alert("Nombre requerido");
+    setLoading(true);
+    try {
+      const res = await fetch("/api/almacenes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ nombre, descripcion }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        router.push(`/dashboard/almacenes/${data.almacen.id}`);
+      } else {
+        alert(data.error || "Error al crear");
+      }
+    } catch {
+      alert("Error de red");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-md" data-oid="nuevo-almacen">
+      <h1 className="text-xl font-bold mb-4">Crear almacén</h1>
+      <div className="flex flex-col gap-2">
+        <input
+          className="border p-2 rounded"
+          placeholder="Nombre"
+          value={nombre}
+          onChange={(e) => setNombre(e.target.value)}
+        />
+        <textarea
+          className="border p-2 rounded"
+          placeholder="Descripción"
+          value={descripcion}
+          onChange={(e) => setDescripcion(e.target.value)}
+        />
+        <button
+          onClick={crear}
+          disabled={loading}
+          className="p-2 bg-[var(--dashboard-accent)] text-white rounded"
+        >
+          {loading ? "Creando..." : "Crear"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/almacenes/page.tsx
+++ b/src/app/dashboard/almacenes/page.tsx
@@ -126,6 +126,12 @@ export default function AlmacenesPage() {
           <div className="flex items-center gap-1 text-sm">
             <button onClick={() => moveUp(idx)} className="px-1">↑</button>
             <button onClick={() => moveDown(idx)} className="px-1">↓</button>
+            <button
+              onClick={() => router.push(`/dashboard/almacenes/${a.id}/editar`)}
+              className="px-1 text-blue-500"
+            >
+              ✎
+            </button>
             <button onClick={() => eliminar(a.id)} className="px-1 text-red-500">✕</button>
           </div>
         </li>

--- a/src/app/dashboard/constants.ts
+++ b/src/app/dashboard/constants.ts
@@ -1,3 +1,4 @@
 export const SIDEBAR_GLOBAL_WIDTH = 256;
 export const SIDEBAR_GLOBAL_COLLAPSED_WIDTH = 80;
 export const SIDEBAR_ALMACENES_WIDTH = 192;
+export const NAVBAR_HEIGHT = 70;


### PR DESCRIPTION
## Summary
- align warehouse sidebar under dashboard navbar using global UI context
- add navbar height constant for layout calculations
- add create and edit pages for almacenes
- support updating warehouses via API
- document latest patch notes

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc10f28448328a7a12ff038b38519