### PR TITLE
0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.1.2
+0.1.3
 
 ---
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -9,8 +9,7 @@ if (!JWT_SECRET) {
 }
 
 export async function getUsuarioFromSession() {
-  // ASÍNCRONO en server actions o middleware
-  const cookieStore = await cookies() // <-- await aquí
+  const cookieStore = cookies()
   const token = cookieStore.get(SESSION_COOKIE)?.value
 
   if (!token) return null

--- a/lib/securityHeaders.ts
+++ b/lib/securityHeaders.ts
@@ -1,10 +1,22 @@
-export const ContentSecurityPolicy = `
-  default-src 'self';
-  script-src 'self' 'unsafe-inline' vitals.vercel-insights.com;
-  style-src 'self' 'unsafe-inline';
-  img-src 'self' https: data:;
-  object-src 'none';
-`;
+const dev = process.env.NODE_ENV !== 'production';
+
+export const ContentSecurityPolicy = dev
+  ? `
+    default-src 'self' http://localhost:*;
+    script-src 'self' 'unsafe-inline' 'unsafe-eval' vitals.vercel-insights.com http://localhost:*;
+    style-src 'self' 'unsafe-inline';
+    img-src 'self' http: https: data:;
+    connect-src 'self' http://localhost:* ws://localhost:*;
+    object-src 'none';
+  `
+  : `
+    default-src 'self';
+    script-src 'self' 'unsafe-inline' vitals.vercel-insights.com;
+    style-src 'self' 'unsafe-inline';
+    img-src 'self' https: data:;
+    connect-src 'self';
+    object-src 'none';
+  `;
 
 export const securityHeaders = [
   {
@@ -17,7 +29,7 @@ export const securityHeaders = [
   },
   {
     key: 'X-Frame-Options',
-    value: 'DENY',
+    value: dev ? 'SAMEORIGIN' : 'DENY',
   },
   {
     key: 'X-Content-Type-Options',

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "postinstall": "prisma generate",
     "build": "next build",
     "start": "next start",

--- a/src/app/api/perfil/export/route.ts
+++ b/src/app/api/perfil/export/route.ts
@@ -1,14 +1,9 @@
 export const runtime = 'nodejs';
 
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
 import jwt from 'jsonwebtoken';
 import { SESSION_COOKIE } from '@lib/constants';
-
-// Instancia Prisma singleton-safe para dev y prod
-const globalForPrisma = global as unknown as { prisma?: PrismaClient };
-const prisma = globalForPrisma.prisma ?? new PrismaClient();
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+import prisma from '@lib/prisma';
 
 const JWT_SECRET = process.env.JWT_SECRET;
 if (!JWT_SECRET) {

--- a/src/app/api/perfil/foto/route.ts
+++ b/src/app/api/perfil/foto/route.ts
@@ -1,10 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
-
-// Prisma singleton-safe
-const globalForPrisma = global as unknown as { prisma?: PrismaClient };
-const prisma = globalForPrisma.prisma ?? new PrismaClient();
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+import prisma from '@lib/prisma';
 
 // Mime types permitidos para evitar servir archivos no deseados
 const MIME_BY_EXT: Record<string, string> = {

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -1,12 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { SESSION_COOKIE, sessionCookieOptions } from '@lib/constants';
-
-const globalForPrisma = global as unknown as { prisma?: PrismaClient };
-const prisma = globalForPrisma.prisma ?? new PrismaClient();
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+import prisma from '@lib/prisma';
 
 const JWT_SECRET = process.env.JWT_SECRET;
 if (!JWT_SECRET) {

--- a/src/app/api/ping-db/route.ts
+++ b/src/app/api/ping-db/route.ts
@@ -1,10 +1,8 @@
 // Forzar entorno Node.js
 export const runtime = 'nodejs';
 
-import { PrismaClient } from '@prisma/client';
 import { NextResponse } from 'next/server';
-
-const prisma = new PrismaClient();
+import prisma from '@lib/prisma';
 
 export async function GET() {
   try {

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -1,12 +1,11 @@
 export const runtime = 'nodejs';
 
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@lib/prisma';
 import bcrypt from 'bcryptjs';
 import { v4 as uuidv4 } from 'uuid';
 import { enviarCorreoValidacionEmpresa } from '@/lib/email/enviarRegistro';
 
-const prisma = new PrismaClient();
 
 const TAMAÑO_MAXIMO_MB = 2;
 const BYTES_MAXIMOS = TAMAÑO_MAXIMO_MB * 1024 * 1024;


### PR DESCRIPTION
## Summary
- allow localhost in CSP and support frames in dev
- clean auth helper
- use shared prisma client across APIs
- simplify `npm run dev` script
- bump version to 0.1.3

## Testing
- `npm install` *(fails: Failed to fetch sha256 checksum)*

------
https://chatgpt.com/codex/tasks/task_e_6840f0a9b6e083288298a0b5dbebd395