### PR TITLE
Fix dashboard UI hook path and photo API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.2
+0.2.3
 
 ---
 

--- a/src/app/api/perfil/foto/route.ts
+++ b/src/app/api/perfil/foto/route.ts
@@ -14,37 +14,46 @@ export async function GET(req: NextRequest) {
   try {
     const url = new URL(req.url);
     const nombre = url.searchParams.get('nombre');
-    if (!nombre) {
-      return NextResponse.json({ error: 'Nombre de archivo requerido.' }, { status: 400 });
+    const correo = url.searchParams.get('correo');
+
+    let usuario;
+
+    if (correo) {
+      usuario = await prisma.usuario.findFirst({
+        where: { correo: { equals: correo, mode: 'insensitive' } },
+        select: { fotoPerfil: true, fotoPerfilNombre: true }
+      });
+    } else if (nombre) {
+      usuario = await prisma.usuario.findFirst({
+        where: { fotoPerfilNombre: { equals: nombre, mode: 'insensitive' } },
+        select: { fotoPerfil: true, fotoPerfilNombre: true }
+      });
+    } else {
+      return NextResponse.json(
+        { error: 'Nombre o correo requerido.' },
+        { status: 400 }
+      );
     }
 
-    // Validar extensión
-    const ext = nombre.split('.').pop()?.toLowerCase() ?? '';
-    if (!(ext in MIME_BY_EXT)) {
-      return NextResponse.json({ error: 'Tipo de archivo no permitido.' }, { status: 400 });
-    }
-
-    // Buscar usuario con esa imagen (case-insensitive)
-    const usuario = await prisma.usuario.findFirst({
-      where: { fotoPerfilNombre: { equals: nombre, mode: 'insensitive' } },
-      select: { fotoPerfil: true, fotoPerfilNombre: true }
-    });
-
-    if (!usuario || !usuario.fotoPerfil) {
+    if (!usuario || !usuario.fotoPerfil || !usuario.fotoPerfilNombre) {
       return NextResponse.json({ error: 'Imagen no encontrada.' }, { status: 404 });
     }
 
-    // Convertir a Buffer si no es ya
+    const ext = usuario.fotoPerfilNombre.split('.').pop()?.toLowerCase() ?? '';
+    if (!(ext in MIME_BY_EXT)) {
+      return NextResponse.json({ error: 'Tipo de archivo no permitido.' }, { status: 400 });
+    }
     const buffer = Buffer.isBuffer(usuario.fotoPerfil)
       ? usuario.fotoPerfil
       : Buffer.from(usuario.fotoPerfil);
 
     // Responder con el contenido binario de la imagen
+    const fileName = nombre ?? usuario.fotoPerfilNombre;
     return new NextResponse(buffer, {
       status: 200,
       headers: {
         'Content-Type': MIME_BY_EXT[ext],
-        'Content-Disposition': `inline; filename="${encodeURIComponent(nombre)}"`,
+        'Content-Disposition': `inline; filename="${encodeURIComponent(fileName)}"`,
         'Cache-Control': 'public, max-age=604800', // Cache 1 semana
         'Content-Length': buffer.length.toString()
       }

--- a/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
@@ -18,7 +18,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useDashboardUI } from "../ui"; // para saber si sidebar global está colapsado
+import { useDashboardUI } from "../../ui"; // para saber si sidebar global está colapsado
 import {
   SIDEBAR_GLOBAL_WIDTH,
   SIDEBAR_GLOBAL_COLLAPSED_WIDTH,


### PR DESCRIPTION
## Summary
- adjust dashboard sidebar to import the correct UI hook
- return profile photos by email or file name
- bump version to 0.2.3

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410f7ad9dc832896d1e9486cc87a1d