### PR TITLE
Fix almacenes navbars alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.3
+0.2.4
 
 ---
 

--- a/src/app/dashboard/almacenes/components/AlmacenDetailNavbar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenDetailNavbar.tsx
@@ -51,7 +51,7 @@ export default function AlmacenDetailNavbar() {
   };
 
   return (
-    <header className="flex items-center justify-between h-14 px-4 border-b border-[var(--dashboard-border)] bg-[var(--dashboard-navbar)] fixed top-[70px] left-0 right-0 z-30">
+    <header className="flex items-center justify-between h-[56px] px-4 border-b border-[var(--dashboard-border)] bg-[var(--dashboard-navbar)] fixed top-[70px] left-0 right-0 z-30">
       <div className="flex items-center gap-3">
         <button onClick={volver} className="p-2 text-gray-400 hover:bg-white/10 rounded-lg" title="Regresar">
           <ArrowLeft className="w-5 h-5" />

--- a/src/app/dashboard/almacenes/components/AlmacenNavbar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenNavbar.tsx
@@ -44,9 +44,9 @@ export default function AlmacenNavbar({ mode = 'list', nombre }: AlmacenNavbarPr
     usuario?.tipoCuenta === "institucional" ||
     usuario?.tipoCuenta === "empresarial";
 
-  if (mode === 'detail') {
+  if (mode === "detail") {
     return (
-      <header className="dashboard-navbar justify-between px-6">
+      <header className="flex items-center justify-between h-full px-6 w-full">
         <div className="flex items-center gap-3">
           <button
             onClick={() => router.push("/dashboard/almacenes")}
@@ -65,7 +65,7 @@ export default function AlmacenNavbar({ mode = 'list', nombre }: AlmacenNavbarPr
 
   // Modo lista (default)
   return (
-    <header className="dashboard-navbar justify-between px-4 md:px-6">
+    <header className="flex items-center justify-between h-full w-full px-4 md:px-6">
       <div className="flex items-center gap-4 md:gap-6">
         <h1 className="text-lg font-semibold text-white">Almacenes</h1>
 
@@ -138,12 +138,12 @@ export default function AlmacenNavbar({ mode = 'list', nombre }: AlmacenNavbarPr
       </div>
 
       <div className="flex items-center gap-3">
-        <div className="relative">
+        <div className="relative w-52 sm:w-64">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--dashboard-muted)]" />
           <input
             value={busqueda}
             onChange={(e) => setBusqueda(e.target.value)}
-            className="dashboard-input pl-8 pr-2 py-1.5"
+            className="dashboard-input pl-8 pr-2"
             placeholder="Buscar almacén..."
           />
         </div>


### PR DESCRIPTION
## Summary
- tweak almacenes navbars so they match dashboard styles
- bump version in README

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684112570c388328a314ad65dbbe3905