### PR TITLE
Unify user types and clean dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.4
+0.2.5
 
 ---
 

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import type { Usuario } from "@/types/usuario";
 
-interface Usuario {
-  rol?: string;
-  tipoCuenta?: string;
-}
 interface Stats {
   usuarios: number;
   almacenes: number;

--- a/src/app/dashboard/alertas/page.tsx
+++ b/src/app/dashboard/alertas/page.tsx
@@ -1,12 +1,8 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import type { Usuario } from "@/types/usuario";
 
-interface Usuario {
-  id: number;
-  rol?: string;
-  tipoCuenta?: string;
-}
 interface Alerta {
   id: number;
   mensaje: string;

--- a/src/app/dashboard/almacenes/[id]/layout.tsx
+++ b/src/app/dashboard/almacenes/[id]/layout.tsx
@@ -9,12 +9,7 @@ import {
   SIDEBAR_GLOBAL_COLLAPSED_WIDTH,
   NAVBAR_HEIGHT,
 } from "../../constants";
-
-interface Usuario {
-  id: number;
-  nombre: string;
-  email?: string;
-}
+import type { Usuario } from "@/types/usuario";
 
 function ProtectedAlmacen({ children }: { children: React.ReactNode }) {
   const {

--- a/src/app/dashboard/almacenes/components/AlmacenNavbar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenNavbar.tsx
@@ -11,13 +11,9 @@ import {
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useAlmacenesUI } from "../ui";
+import type { Usuario } from "@/types/usuario";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
-
-interface Usuario {
-  tipoCuenta?: string;
-  rol?: string;
-}
 
 interface AlmacenNavbarProps {
   mode?: 'list' | 'detail';

--- a/src/app/dashboard/almacenes/layout.tsx
+++ b/src/app/dashboard/almacenes/layout.tsx
@@ -12,12 +12,7 @@ import { useRouter, usePathname } from "next/navigation";
 import AlmacenNavbar from "./components/AlmacenNavbar";
 import AlmacenSidebar from "./components/AlmacenSidebar";
 import { AlmacenesUIProvider } from "./ui";
-
-interface Usuario {
-  id: number;
-  nombre: string;
-  email?: string;
-}
+import type { Usuario } from "@/types/usuario";
 
 // Las constantes de ancho se comparten con el layout principal
 

--- a/src/app/dashboard/almacenes/page.tsx
+++ b/src/app/dashboard/almacenes/page.tsx
@@ -3,12 +3,7 @@ import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import { useRouter } from "next/navigation";
 import { useAlmacenesUI } from "./ui";
-
-interface Usuario {
-  id: number;
-  rol?: string;
-  tipoCuenta?: string;
-}
+import type { Usuario } from "@/types/usuario";
 
 interface Almacen {
   id: number;

--- a/src/app/dashboard/app-center/page.tsx
+++ b/src/app/dashboard/app-center/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import type { Usuario } from "@/types/usuario";
 
-interface Usuario {
-  rol?: string;
-  tipoCuenta?: string;
-}
 interface AppInfo {
   id: number;
   nombre: string;

--- a/src/app/dashboard/billing/page.tsx
+++ b/src/app/dashboard/billing/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import type { Usuario } from "@/types/usuario";
 
-interface Usuario {
-  rol?: string;
-  tipoCuenta?: string;
-}
 interface Invoice {
   id: number;
   concepto: string;

--- a/src/app/dashboard/components/NavbarDashboard.tsx
+++ b/src/app/dashboard/components/NavbarDashboard.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import UserMenu from "@/components/UserMenu";
 import { useDashboardUI } from "../ui";
+import type { Usuario } from "@/types/usuario";
 
 const MOCK_RESULTS = [
   { tipo: "almacén", nombre: "Almacén Central", url: "/almacenes/central" },
@@ -25,15 +26,7 @@ const MOCK_RESULTS = [
   { tipo: "almacén", nombre: "Almacén de Química", url: "/almacenes/quimica" },
 ];
 
-interface Usuario {
-  id: number;
-  nombre: string;
-  correo?: string;
-  tipoCuenta?: string;
-  rol?: string;
-  plan?: { nombre?: string };
-  avatarUrl?: string;
-}
+
 
 export default function NavbarDashboard({ usuario }: { usuario: Usuario }) {
   // Estado UI

--- a/src/app/dashboard/components/Sidebar.tsx
+++ b/src/app/dashboard/components/Sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname, useRouter } from "next/navigation";
 import { useDashboardUI } from "../ui";
+import type { Usuario } from "@/types/usuario";
 import {
   Home,
   Boxes,
@@ -18,12 +19,6 @@ import {
 } from "lucide-react";
 
 // El tipo mínimo del usuario (ajusta según tu modelo)
-type Usuario = {
-  nombre: string;
-  avatarUrl?: string | null;
-  rol?: string;
-  tipoCuenta?: string;
-};
 
 const sidebarMenu = [
   {

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -10,16 +10,7 @@ import {
   SIDEBAR_GLOBAL_COLLAPSED_WIDTH,
 } from "./constants";
 import { useRouter } from "next/navigation";
-
-interface Usuario {
-  id: number;
-  nombre: string;
-  email?: string;
-  tipoCuenta?: string;
-  rol?: string;
-}
-
-// Puedes controlar el colapso con un estado global/context
+import type { Usuario } from "@/types/usuario";
 
 function ProtectedDashboard({ children }: { children: React.ReactNode }) {
   // Añade en tu context esta propiedad si quieres permitir colapsar

--- a/src/app/dashboard/network/page.tsx
+++ b/src/app/dashboard/network/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import type { Usuario } from "@/types/usuario";
 
-interface Usuario {
-  rol?: string;
-  tipoCuenta?: string;
-}
 interface Peer {
   id: number;
   nombre: string;

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import type { Usuario } from "@/types/usuario";
 
 import PizarraCanvas from "./components/pizarra/PizarraCanvas";
 import dynamic from "next/dynamic";
@@ -22,13 +23,7 @@ interface WidgetMeta {
   plans?: string[];
 }
 
-interface Usuario {
-  id: number;
-  nombre: string;
-  correo: string;
-  plan?: { nombre?: string };
-  [key: string]: any;
-}
+
 
 export default function DashboardPage() {
   const [usuario, setUsuario] = useState<Usuario | null>(null);

--- a/src/app/dashboard/plantillas/page.tsx
+++ b/src/app/dashboard/plantillas/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import type { Usuario } from "@/types/usuario";
 
-interface Usuario {
-  rol?: string;
-  tipoCuenta?: string;
-}
 interface Plantilla {
   id: number;
   nombre: string;

--- a/src/app/dashboard/reportes/page.tsx
+++ b/src/app/dashboard/reportes/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import type { Usuario } from "@/types/usuario";
 
-interface Usuario {
-  rol?: string;
-  tipoCuenta?: string;
-}
 interface Reporte {
   id: number;
   titulo: string;

--- a/src/types/usuario.ts
+++ b/src/types/usuario.ts
@@ -1,0 +1,12 @@
+export interface Usuario {
+  id?: number;
+  nombre?: string;
+  correo?: string;
+  email?: string;
+  tipoCuenta?: string;
+  rol?: string;
+  plan?: { nombre?: string };
+  avatarUrl?: string | null;
+  imagen?: string | null;
+  tiene2FA?: boolean;
+}


### PR DESCRIPTION
## Summary
- create shared `Usuario` type
- refactor dashboard files to use new type
- tidy extra blank lines
- bump version to 0.2.5

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841e960f1d48328828587602541e86e