### PR TITLE
Actualiza UI de almacenes y verificaciones

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.7
+0.2.8
 
 ---
 

--- a/src/app/dashboard/almacenes/components/AlmacenNavbar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenNavbar.tsx
@@ -15,6 +15,20 @@ import type { Usuario } from "@/types/usuario";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 
+function getMainRole(u: any): string | undefined {
+  return u?.rol || u?.roles?.[0]?.nombre;
+}
+
+function hasManagePerms(u: any): boolean {
+  const rol = getMainRole(u)?.toLowerCase();
+  const tipo = (u?.tipoCuenta ?? "").toLowerCase();
+  const plan = (u?.plan?.nombre ?? "").toLowerCase();
+  if (rol === "admin" || rol === "administrador") return true;
+  if (["institucional", "empresarial"].includes(tipo)) return true;
+  if (["empresarial", "institucional", "pro"].includes(plan)) return true;
+  return false;
+}
+
 interface AlmacenNavbarProps {
   mode?: 'list' | 'detail';
   nombre?: string;
@@ -35,10 +49,7 @@ export default function AlmacenNavbar({ mode = 'list', nombre }: AlmacenNavbarPr
   }, []);
 
   // Permisos de gestión
-  const allowManage =
-    usuario?.rol === "admin" ||
-    usuario?.tipoCuenta === "institucional" ||
-    usuario?.tipoCuenta === "empresarial";
+  const allowManage = usuario ? hasManagePerms(usuario) : false;
 
   if (mode === "detail") {
     return (
@@ -150,7 +161,7 @@ export default function AlmacenNavbar({ mode = 'list', nombre }: AlmacenNavbarPr
               e.preventDefault();
               if (onCreate) onCreate("", "");
             }}
-            className="dashboard-btn flex items-center gap-2 h-9 text-sm"
+            className="dashboard-btn flex items-center gap-2 h-10 text-base px-4"
           >
             <Plus className="w-4 h-4" />
             <span>Crear almacén</span>


### PR DESCRIPTION
## Summary
- enlarges "Crear almacén" button
- show create option in almacenes sidebar
- ensure role, type and plan are checked before enabling actions
- bump version to 0.2.8

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f9b3da408328a04687f791a83169