### PR TITLE
Fix role checks across dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.8
+0.2.9
 
 ---
 

--- a/lib/permisos.ts
+++ b/lib/permisos.ts
@@ -1,0 +1,16 @@
+export function getMainRole(u: { rol?: string; roles?: { nombre?: string }[] } | null | undefined): string | undefined {
+  if (!u) return undefined;
+  if (u.rol) return String(u.rol);
+  if (u.roles && u.roles.length > 0 && u.roles[0]?.nombre) return String(u.roles[0].nombre);
+  return undefined;
+}
+
+export function hasManagePerms(u: { rol?: string; roles?: { nombre?: string }[]; tipoCuenta?: string; plan?: { nombre?: string } } | null | undefined): boolean {
+  const rol = getMainRole(u)?.toLowerCase();
+  const tipo = (u?.tipoCuenta ?? '').toLowerCase();
+  const plan = (u?.plan?.nombre ?? '').toLowerCase();
+  if (rol === 'admin' || rol === 'administrador') return true;
+  if (['institucional', 'empresarial'].includes(tipo)) return true;
+  if (['empresarial', 'institucional', 'pro'].includes(plan)) return true;
+  return false;
+}

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import type { Usuario } from "@/types/usuario";
+import { getMainRole } from "@lib/permisos";
 
 interface Stats {
   usuarios: number;
@@ -20,11 +21,10 @@ export default function AdminPage() {
       .then(jsonOrNull)
       .then((data) => {
         if (!data?.success) throw new Error();
-        const tipo =
-          data.usuario.rol === "admin"
-            ? "admin"
-            : (data.usuario.tipoCuenta ?? "estandar");
-        if (!allowed.includes(tipo)) throw new Error("No autorizado");
+        const rol = getMainRole(data.usuario)?.toLowerCase();
+        const tipo = (data.usuario.tipoCuenta ?? "estandar").toLowerCase();
+        if (rol !== "admin" && rol !== "administrador" && !allowed.includes(tipo))
+          throw new Error("No autorizado");
         setUsuario(data.usuario);
       })
       .catch((err) => setError(err.message || "Debes iniciar sesión"));

--- a/src/app/dashboard/alertas/page.tsx
+++ b/src/app/dashboard/alertas/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import type { Usuario } from "@/types/usuario";
+import { getMainRole } from "@lib/permisos";
 
 interface Alerta {
   id: number;
@@ -21,11 +22,9 @@ export default function AlertasPage() {
       .then(jsonOrNull)
       .then((data) => {
         if (!data?.success) throw new Error();
-        const tipo =
-          data.usuario.rol === "admin"
-            ? "admin"
-            : (data.usuario.tipoCuenta ?? "estandar");
-        if (!allowed.includes(tipo)) {
+        const rol = getMainRole(data.usuario)?.toLowerCase();
+        const tipo = (data.usuario.tipoCuenta ?? "estandar").toLowerCase();
+        if (rol !== "admin" && rol !== "administrador" && !allowed.includes(tipo)) {
           throw new Error("No autorizado");
         }
         setUsuario(data.usuario);

--- a/src/app/dashboard/almacenes/components/AlmacenNavbar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenNavbar.tsx
@@ -14,20 +14,8 @@ import { useAlmacenesUI } from "../ui";
 import type { Usuario } from "@/types/usuario";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { getMainRole, hasManagePerms } from "@lib/permisos";
 
-function getMainRole(u: any): string | undefined {
-  return u?.rol || u?.roles?.[0]?.nombre;
-}
-
-function hasManagePerms(u: any): boolean {
-  const rol = getMainRole(u)?.toLowerCase();
-  const tipo = (u?.tipoCuenta ?? "").toLowerCase();
-  const plan = (u?.plan?.nombre ?? "").toLowerCase();
-  if (rol === "admin" || rol === "administrador") return true;
-  if (["institucional", "empresarial"].includes(tipo)) return true;
-  if (["empresarial", "institucional", "pro"].includes(plan)) return true;
-  return false;
-}
 
 interface AlmacenNavbarProps {
   mode?: 'list' | 'detail';

--- a/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
@@ -27,20 +27,7 @@ import {
 } from "../../constants";
 import type { Usuario } from "@/types/usuario";
 import { jsonOrNull } from "@lib/http";
-
-function getMainRole(u: any): string | undefined {
-  return u?.rol || u?.roles?.[0]?.nombre;
-}
-
-function hasManagePerms(u: any): boolean {
-  const rol = getMainRole(u)?.toLowerCase();
-  const tipo = (u?.tipoCuenta ?? "").toLowerCase();
-  const plan = (u?.plan?.nombre ?? "").toLowerCase();
-  if (rol === "admin" || rol === "administrador") return true;
-  if (["institucional", "empresarial"].includes(tipo)) return true;
-  if (["empresarial", "institucional", "pro"].includes(plan)) return true;
-  return false;
-}
+import { getMainRole, hasManagePerms } from "@lib/permisos";
 
 // --- Estilos base ---
 const sectionStyle =

--- a/src/app/dashboard/almacenes/page.tsx
+++ b/src/app/dashboard/almacenes/page.tsx
@@ -4,8 +4,8 @@ import { jsonOrNull } from "@lib/http";
 import { useRouter } from "next/navigation";
 import { useAlmacenesUI } from "./ui";
 import type { Usuario } from "@/types/usuario";
+import { getMainRole, hasManagePerms } from "@lib/permisos";
 
-interface Almacen {
   id: number;
   nombre: string;
   descripcion?: string | null;
@@ -16,20 +16,6 @@ interface Almacen {
   inventario?: number;
   encargado?: string | null;
   notificaciones?: boolean;
-}
-
-function getMainRole(u: any): string | undefined {
-  return u?.rol || u?.roles?.[0]?.nombre;
-}
-
-function hasManagePerms(u: any): boolean {
-  const rol = getMainRole(u)?.toLowerCase();
-  const tipo = (u?.tipoCuenta ?? "").toLowerCase();
-  const plan = (u?.plan?.nombre ?? "").toLowerCase();
-  if (rol === "admin" || rol === "administrador") return true;
-  if (["institucional", "empresarial"].includes(tipo)) return true;
-  if (["empresarial", "institucional", "pro"].includes(plan)) return true;
-  return false;
 }
 
 export default function AlmacenesPage() {

--- a/src/app/dashboard/app-center/page.tsx
+++ b/src/app/dashboard/app-center/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import type { Usuario } from "@/types/usuario";
+import { getMainRole } from "@lib/permisos";
 
 interface AppInfo {
   id: number;
@@ -20,11 +21,10 @@ export default function AppCenterPage() {
       .then(jsonOrNull)
       .then((data) => {
         if (!data?.success) throw new Error();
-        const tipo =
-          data.usuario.rol === "admin"
-            ? "admin"
-            : (data.usuario.tipoCuenta ?? "estandar");
-        if (!allowed.includes(tipo)) throw new Error("No autorizado");
+        const rol = getMainRole(data.usuario)?.toLowerCase();
+        const tipo = (data.usuario.tipoCuenta ?? "estandar").toLowerCase();
+        if (rol !== "admin" && rol !== "administrador" && !allowed.includes(tipo))
+          throw new Error("No autorizado");
         setUsuario(data.usuario);
       })
       .catch((err) => setError(err.message || "Debes iniciar sesión"));

--- a/src/app/dashboard/billing/page.tsx
+++ b/src/app/dashboard/billing/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import type { Usuario } from "@/types/usuario";
+import { getMainRole } from "@lib/permisos";
 
 interface Invoice {
   id: number;
@@ -22,11 +23,10 @@ export default function BillingPage() {
       .then(jsonOrNull)
       .then((data) => {
         if (!data?.success) throw new Error();
-        const tipo =
-          data.usuario.rol === "admin"
-            ? "admin"
-            : (data.usuario.tipoCuenta ?? "estandar");
-        if (!allowed.includes(tipo)) throw new Error("No autorizado");
+        const rol = getMainRole(data.usuario)?.toLowerCase();
+        const tipo = (data.usuario.tipoCuenta ?? "estandar").toLowerCase();
+        if (rol !== "admin" && rol !== "administrador" && !allowed.includes(tipo))
+          throw new Error("No autorizado");
         setUsuario(data.usuario);
       })
       .catch((err) => setError(err.message || "Debes iniciar sesión"));

--- a/src/app/dashboard/components/NavbarDashboard.tsx
+++ b/src/app/dashboard/components/NavbarDashboard.tsx
@@ -18,6 +18,7 @@ import {
 import UserMenu from "@/components/UserMenu";
 import { useDashboardUI } from "../ui";
 import type { Usuario } from "@/types/usuario";
+import { hasManagePerms } from "@lib/permisos";
 
 const MOCK_RESULTS = [
   { tipo: "almacén", nombre: "Almacén Central", url: "/almacenes/central" },
@@ -82,16 +83,10 @@ export default function NavbarDashboard({ usuario }: { usuario: Usuario }) {
     if (redirectUrl) window.location.href = redirectUrl;
   };
 
-  const puedeCrear =
-    usuario.rol === "admin" ||
-    usuario.tipoCuenta === "empresarial" ||
-    usuario.tipoCuenta === "institucional" ||
-    usuario.tipoCuenta === "estandar";
-
+  const puedeCrear = hasManagePerms(usuario);
   const puedeInvitarUsuarios =
-    usuario.rol === "admin" ||
-    usuario.tipoCuenta === "empresarial" ||
-    usuario.tipoCuenta === "institucional";
+    hasManagePerms(usuario) &&
+    ((usuario?.tipoCuenta ?? "").toLowerCase() !== "estandar");
 
   return (
     <header

--- a/src/app/dashboard/components/Sidebar.tsx
+++ b/src/app/dashboard/components/Sidebar.tsx
@@ -3,6 +3,7 @@
 import { usePathname, useRouter } from "next/navigation";
 import { useDashboardUI } from "../ui";
 import type { Usuario } from "@/types/usuario";
+import { getMainRole } from "@lib/permisos";
 import {
   Home,
   Boxes,
@@ -92,7 +93,7 @@ export default function Sidebar({ usuario }: { usuario: Usuario }) {
   const pathname = usePathname();
   const router = useRouter();
 
-  if (!usuario || (!usuario.rol && !usuario.tipoCuenta) || !usuario.nombre) {
+  if (!usuario || !usuario.nombre) {
     return (
       <aside
         className="dashboard-sidebar flex flex-col w-[72px] h-screen fixed top-0 left-0 z-30 justify-center items-center bg-[var(--dashboard-sidebar)] shadow-xl"
@@ -105,8 +106,8 @@ export default function Sidebar({ usuario }: { usuario: Usuario }) {
     );
   }
 
-  const tipo =
-    usuario.rol === "admin" ? "admin" : (usuario.tipoCuenta ?? "estandar");
+  const mainRole = getMainRole(usuario)?.toLowerCase();
+  const tipo = mainRole === "admin" ? "admin" : usuario.tipoCuenta ?? "estandar";
 
   const filteredMenu = sidebarMenu.filter((item) =>
     item.allowed.includes(tipo),

--- a/src/app/dashboard/network/page.tsx
+++ b/src/app/dashboard/network/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import type { Usuario } from "@/types/usuario";
+import { getMainRole } from "@lib/permisos";
 
 interface Peer {
   id: number;
@@ -20,11 +21,10 @@ export default function NetworkPage() {
       .then(jsonOrNull)
       .then((data) => {
         if (!data?.success) throw new Error();
-        const tipo =
-          data.usuario.rol === "admin"
-            ? "admin"
-            : (data.usuario.tipoCuenta ?? "estandar");
-        if (!allowed.includes(tipo)) throw new Error("No autorizado");
+        const rol = getMainRole(data.usuario)?.toLowerCase();
+        const tipo = (data.usuario.tipoCuenta ?? "estandar").toLowerCase();
+        if (rol !== "admin" && rol !== "administrador" && !allowed.includes(tipo))
+          throw new Error("No autorizado");
         setUsuario(data.usuario);
       })
       .catch((err) => setError(err.message || "Debes iniciar sesión"));

--- a/src/app/dashboard/plantillas/page.tsx
+++ b/src/app/dashboard/plantillas/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import type { Usuario } from "@/types/usuario";
+import { getMainRole } from "@lib/permisos";
 
 interface Plantilla {
   id: number;
@@ -20,11 +21,10 @@ export default function PlantillasPage() {
       .then(jsonOrNull)
       .then((data) => {
         if (!data?.success) throw new Error();
-        const tipo =
-          data.usuario.rol === "admin"
-            ? "admin"
-            : (data.usuario.tipoCuenta ?? "estandar");
-        if (!allowed.includes(tipo)) throw new Error("No autorizado");
+        const rol = getMainRole(data.usuario)?.toLowerCase();
+        const tipo = (data.usuario.tipoCuenta ?? "estandar").toLowerCase();
+        if (rol !== "admin" && rol !== "administrador" && !allowed.includes(tipo))
+          throw new Error("No autorizado");
         setUsuario(data.usuario);
       })
       .catch((err) => setError(err.message || "Debes iniciar sesión"));

--- a/src/app/dashboard/reportes/page.tsx
+++ b/src/app/dashboard/reportes/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import type { Usuario } from "@/types/usuario";
+import { getMainRole } from "@lib/permisos";
 
 interface Reporte {
   id: number;
@@ -20,11 +21,10 @@ export default function ReportesPage() {
       .then(jsonOrNull)
       .then((data) => {
         if (!data?.success) throw new Error();
-        const tipo =
-          data.usuario.rol === "admin"
-            ? "admin"
-            : (data.usuario.tipoCuenta ?? "estandar");
-        if (!allowed.includes(tipo)) throw new Error("No autorizado");
+        const rol = getMainRole(data.usuario)?.toLowerCase();
+        const tipo = (data.usuario.tipoCuenta ?? "estandar").toLowerCase();
+        if (rol !== "admin" && rol !== "administrador" && !allowed.includes(tipo))
+          throw new Error("No autorizado");
         setUsuario(data.usuario);
       })
       .catch((err) => setError(err.message || "Debes iniciar sesión"));

--- a/src/types/usuario.ts
+++ b/src/types/usuario.ts
@@ -5,7 +5,8 @@ export interface Usuario {
   email?: string;
   tipoCuenta?: string;
   rol?: string;
-  plan?: { nombre?: string };
+  roles?: { id?: number; nombre?: string; descripcion?: string; permisos?: Record<string, any> }[];
+  plan?: { nombre?: string; limites?: Record<string, any>; fechaFin?: string };
   avatarUrl?: string | null;
   imagen?: string | null;
   tiene2FA?: boolean;


### PR DESCRIPTION
## Summary
- centralize role and plan checks
- use new helpers in dashboard pages and components
- expand `Usuario` type
- bump version to 0.2.9

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842005f226c8328a75de218656e6f32