### PR TITLE
Fix Almacen interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.10
+0.2.11
 
 ---
 

--- a/src/app/dashboard/almacenes/page.tsx
+++ b/src/app/dashboard/almacenes/page.tsx
@@ -6,6 +6,7 @@ import { useAlmacenesUI } from "./ui";
 import type { Usuario } from "@/types/usuario";
 import { getMainRole, hasManagePerms } from "@lib/permisos";
 
+interface Almacen {
   id: number;
   nombre: string;
   descripcion?: string | null;


### PR DESCRIPTION
## Summary
- restore the `Almacen` interface to fix dashboard compile error
- bump version to 0.2.11

## Testing
- `npx next lint` *(fails: Need to install `next@15.3.3`)*

------
https://chatgpt.com/codex/tasks/task_e_68420e2559048328a39b4368773eb73f