### PR TITLE
Mejoras en menú y exportación

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.11
+0.2.12
 
 ---
 

--- a/src/app/configuracion/page.tsx
+++ b/src/app/configuracion/page.tsx
@@ -133,6 +133,7 @@ export default function Configuracion() {
         `/api/perfil/export?secciones=${secciones.join(",")}`,
         {
           method: "GET",
+          credentials: "include",
         },
       );
       if (res.ok) {
@@ -343,7 +344,7 @@ export default function Configuracion() {
                 data-oid="gh-884w"
               />
             </div>
-            <div data-oid=".py3z2y">
+            <div id="preferencias" data-oid=".py3z2y">
               <label
                 className="block text-sm font-semibold text-amber-800"
                 data-oid="8ubf_0r"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -333,22 +333,6 @@ function LoaderKPI() {
 // ========================
 // FEATURES BANNER SECTION
 // ========================
-function FeaturesBannerSection() {
-  return (
-    <section
-      className="relative bg-center bg-cover bg-no-repeat py-44"
-      style={{ backgroundImage: "url('/background.gif')" }}
-      data-oid="js391oi"
-    >
-      <div className="absolute inset-0 bg-zinc-900/70" />
-      <div className="relative max-w-7xl mx-auto px-4 text-center">
-        <h2 className="text-3xl md:text-4xl font-bold text-amber-300">
-          Funciones principales
-        </h2>
-      </div>
-    </section>
-  );
-}
 
 // ========================
 // PARTNERS/ALIADOS SECTION (Acordeón Multimedia)
@@ -481,7 +465,6 @@ export default function Page() {
         <HeroSection data-oid="obvdxpr" />
         <AboutSection data-oid="x4h0vfw" />
         <KpiSection data-oid="5izdndn" />
-        <FeaturesBannerSection data-oid="sfry:rj" />
         <PartnersSection data-oid="1-2.6t3" />
       </div>
     </main>

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -226,6 +226,13 @@ export default function UserMenu({
               />
 
               <MenuLink
+                href="/configuracion#preferencias"
+                icon={<Settings className="h-4 w-4" />}
+                label="Preferencias"
+                tabIndex={open ? 0 : -1}
+              />
+
+              <MenuLink
                 href="/"
                 icon={<Home className="h-4 w-4" />}
                 label="Inicio"


### PR DESCRIPTION
## Summary
- remove features banner from the home page
- add preferences link on user menu
- fix export profile request credentials
- anchor preferences section on config page
- bump version to 0.2.12

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422490ba248328b99a0d0b7a89c51e