### PR TITLE
Fix preferences handler and add dev guide

### DIFF
--- a/DEVELOPER_README.md
+++ b/DEVELOPER_README.md
@@ -1,0 +1,39 @@
+# HoneyLabs Developer Overview
+
+Este documento resume los archivos y directorios clave del proyecto para que cualquier programador pueda ubicarse rápidamente.
+
+## Tecnologías
+- **Frontend:** Next.js 15 con React 19 y TypeScript.
+- **Estilos:** TailwindCSS y CSS Modules.
+- **Backend:** API Routes de Next.js y Prisma ORM sobre PostgreSQL.
+- **Otros:** Zustand para estado, bcryptjs para hashing y JWT para autenticación.
+
+## Frontend
+- **src/app/** – Páginas y rutas. Aquí se encuentran las vistas de la aplicación.
+  - **layout.tsx** – Diseño raíz con proveedores y estilos globales.
+  - **page.tsx** – Página principal pública.
+  - **dashboard/** – Contiene el panel privado y sus componentes.
+    - **page.tsx** – Vista principal del dashboard. Maneja widgets y su disposición.
+    - **components/** – NavbarDashboard, Sidebar y otros elementos reutilizables.
+  - **configuracion/** – Página de configuración y perfil de usuario.
+- **src/components/** – Componentes generales como `Navbar`, `Footer`, `UserMenu` y layouts condicionales.
+- **public/** – Recursos estáticos como imágenes y logos.
+
+## Backend
+- **src/app/api/** – Endpoints que resuelven la lógica de servidor.
+  - **login/** – Manejo de autenticación (login, logout y verificación de sesión).
+  - **dashboard/layout/** – Guarda la distribución de widgets del usuario.
+  - **preferences/** – Nuevo endpoint para obtener y actualizar preferencias generales.
+  - **perfil/** – Permite consultar y actualizar datos de perfil.
+- **lib/** – Utilidades compartidas.
+  - **auth.ts** – Obtiene el usuario actual desde la cookie de sesión.
+  - **prisma.ts** – Inicializa Prisma Client.
+  - **constants.ts** – Valores globales usados en varias partes del código.
+- **prisma/** – Esquema y migraciones de base de datos.
+
+## Otros Archivos
+- **next.config.ts** – Configuración de Next.js.
+- **tsconfig.json** – Opciones de compilación de TypeScript.
+- **package.json** – Dependencias y scripts disponibles.
+
+Este resumen sirve como guía rápida de la estructura del proyecto y los principales archivos que lo componen.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.12
+0.2.13
 
 ---
 

--- a/src/app/api/preferences/route.ts
+++ b/src/app/api/preferences/route.ts
@@ -1,0 +1,42 @@
+export const runtime = 'nodejs';
+
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@lib/prisma';
+import { getUsuarioFromSession } from '@lib/auth';
+
+export async function GET() {
+  try {
+    const usuario = await getUsuarioFromSession();
+    if (!usuario) {
+      return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+    }
+    const prefs = usuario.preferencias ? JSON.parse(usuario.preferencias) : {};
+    return NextResponse.json(prefs);
+  } catch (err) {
+    console.error('GET /api/preferences', err);
+    return NextResponse.json({ error: 'Error' }, { status: 500 });
+  }
+}
+
+export async function PUT(req: NextRequest) {
+  try {
+    const usuario = await getUsuarioFromSession();
+    if (!usuario) {
+      return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+    }
+    const update = await req.json();
+    if (typeof update !== 'object' || Array.isArray(update)) {
+      return NextResponse.json({ error: 'Datos inválidos' }, { status: 400 });
+    }
+    const prefs = usuario.preferencias ? JSON.parse(usuario.preferencias) : {};
+    const merged = { ...prefs, ...update };
+    await prisma.usuario.update({
+      where: { id: usuario.id },
+      data: { preferencias: JSON.stringify(merged) },
+    });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error('PUT /api/preferences', err);
+    return NextResponse.json({ error: 'Error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- persist theme preference in database
- create API endpoint `/api/preferences`
- document project structure in `DEVELOPER_README.md`
- bump version to 0.2.13

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422c14a0dc8328b8baa3a3a3f7e4e4