### PR TITLE
Fix legacy login without esSuperAdmin column

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.19
+0.2.20
 
 ---
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -18,6 +18,14 @@ export async function getUsuarioFromSession() {
     const decoded = jwt.verify(token, JWT_SECRET) as { id: number }
     const usuario = await prisma.usuario.findUnique({
       where: { id: decoded.id },
+      select: {
+        id: true,
+        nombre: true,
+        correo: true,
+        tipoCuenta: true,
+        entidadId: true,
+        preferencias: true,
+      },
     })
     return usuario
   } catch {

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -26,7 +26,13 @@ export async function POST(req: NextRequest) {
 
     let usuario = await prisma.usuario.findUnique({
       where: { correo: correo.toLowerCase().trim() },
-      include: {
+      select: {
+        id: true,
+        nombre: true,
+        correo: true,
+        contrasena: true,
+        tipoCuenta: true,
+        estado: true,
         entidad: { select: { id: true, nombre: true, tipo: true, planId: true } },
         roles: { select: { id: true, nombre: true, descripcion: true, permisos: true } },
         suscripciones: {
@@ -94,7 +100,7 @@ export async function POST(req: NextRequest) {
       id: usuario.id,
       nombre: usuario.nombre,
       correo: usuario.correo,
-      esSuperAdmin: usuario.esSuperAdmin ?? false,
+      esSuperAdmin: false,
       tipoCuenta: usuario.tipoCuenta,
       entidad: usuario.entidad,
       roles,

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -153,7 +153,10 @@ export async function PUT(req: NextRequest) {
     }
 
     // Verificar si el correo está en uso
-    const correoExistente = await prisma.usuario.findUnique({ where: { correo } });
+    const correoExistente = await prisma.usuario.findUnique({
+      where: { correo },
+      select: { id: true },
+    });
     if (correoExistente && correoExistente.id !== usuarioId) {
       return NextResponse.json({ error: 'Ese correo ya está registrado en otra cuenta.' }, { status: 409 });
     }
@@ -171,7 +174,10 @@ export async function PUT(req: NextRequest) {
       if (reg.intentos >= MAX_INTENTOS && now - reg.timestamp < TIEMPO_BLOQUEO_MS) {
         return NextResponse.json({ error: 'Demasiados intentos fallidos. Intenta de nuevo en unos minutos.' }, { status: 429 });
       }
-      const usuarioActual = await prisma.usuario.findUnique({ where: { id: usuarioId } });
+      const usuarioActual = await prisma.usuario.findUnique({
+        where: { id: usuarioId },
+        select: { contrasena: true },
+      });
       if (!usuarioActual || !(await bcrypt.compare(contrasenaActual, usuarioActual.contrasena))) {
         bloqueos.set(key, { intentos: reg.intentos + 1, timestamp: now });
         return NextResponse.json({ error: 'Contraseña actual incorrecta.' }, { status: 401 });

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -56,7 +56,10 @@ export async function POST(req: NextRequest) {
     }
 
     // Validación de usuario existente
-    const existente = await prisma.usuario.findUnique({ where: { correo } });
+    const existente = await prisma.usuario.findUnique({
+      where: { correo },
+      select: { id: true },
+    });
     if (existente) {
       return NextResponse.json({ error: 'Ya existe una cuenta con ese correo.' }, { status: 409 });
     }


### PR DESCRIPTION
## Summary
- handle missing `esSuperAdmin` column by explicitly selecting fields in Prisma queries
- keep session helpers minimal
- update version in README

## Testing
- `npm run lint` *(fails: next not found)*

------
