### PR TITLE
Add session hook and streamline login

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.20
+0.2.21
 
 ---
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import useSession, { clearSessionCache } from "@/hooks/useSession";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -41,19 +42,18 @@ export default function LoginPage() {
     setFocus("correo");
   }, [setFocus]);
 
+  const { usuario } = useSession();
+
   // --- Si ya tienes sesión, te manda a dashboard ---
   useEffect(() => {
-    fetch("/api/login", { credentials: "include" })
-      .then(jsonOrNull)
-      .then((data) => {
-        if (data?.success && data?.usuario) router.replace("/");
-      });
-  }, [router]);
+    if (usuario) router.replace("/");
+  }, [usuario, router]);
 
   const onSubmit = async (datos: LoginData) => {
     setMensaje("");
     setCargando(true);
     try {
+      clearSessionCache();
       const res = await fetch("/api/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useState } from "react";
-import { jsonOrNull } from "@lib/http";
+import useSession from "@/hooks/useSession";
 import Sidebar from "./components/Sidebar";
 import NavbarDashboard from "./components/NavbarDashboard";
 import WidgetToolbar from "./components/WidgetToolbar";
@@ -10,7 +10,6 @@ import {
   SIDEBAR_GLOBAL_COLLAPSED_WIDTH,
 } from "./constants";
 import { useRouter } from "next/navigation";
-import type { Usuario } from "@/types/usuario";
 
 function ProtectedDashboard({ children }: { children: React.ReactNode }) {
   // Añade en tu context esta propiedad si quieres permitir colapsar
@@ -20,8 +19,7 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
     sidebarGlobalCollapsed,
   } = useDashboardUI();
   const router = useRouter();
-  const [usuario, setUsuario] = useState<Usuario | null>(null);
-  const [loading, setLoading] = useState(true);
+  const { usuario, loading } = useSession();
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
@@ -31,24 +29,6 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
     return () => window.removeEventListener("resize", handleResize);
   }, []);
 
-  useEffect(() => {
-    const cargarUsuario = async () => {
-      try {
-        const res = await fetch("/api/login", { credentials: "include" });
-        const data = await jsonOrNull(res);
-        if (data?.success && data?.usuario) {
-          setUsuario(data.usuario);
-        } else {
-          setUsuario(null);
-        }
-      } catch {
-        setUsuario(null);
-      } finally {
-        setLoading(false);
-      }
-    };
-    cargarUsuario();
-  }, []);
 
   useEffect(() => {
     if (!loading && !usuario) {

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -19,6 +19,7 @@ import clsx from "clsx";
 import { usePathname, useRouter } from "next/navigation";
 import { jsonOrNull } from "@lib/http";
 import { getMainRole } from "@lib/permisos";
+import { clearSessionCache } from "@/hooks/useSession";
 
 interface UsuarioData {
   nombre: string;
@@ -160,6 +161,7 @@ export default function UserMenu({
   const cerrarSesion = async () => {
     setOpen(false);
     await fetch("/api/login", { method: "DELETE" });
+    clearSessionCache();
     router.replace("/login");
   };
 

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+import { jsonOrNull } from '@lib/http'
+import type { Usuario } from '@/types/usuario'
+
+let cachedUser: Usuario | null | undefined
+
+export function clearSessionCache() {
+  cachedUser = undefined
+}
+
+async function fetchSession(): Promise<Usuario | null> {
+  try {
+    const res = await fetch('/api/login', { credentials: 'include' })
+    const data = await jsonOrNull(res)
+    return data?.success && data.usuario ? data.usuario : null
+  } catch {
+    return null
+  }
+}
+
+export default function useSession() {
+  const [usuario, setUsuario] = useState<Usuario | null | undefined>(cachedUser)
+  const [loading, setLoading] = useState(cachedUser === undefined)
+
+  useEffect(() => {
+    if (cachedUser !== undefined) return
+    fetchSession()
+      .then((u) => {
+        cachedUser = u
+        setUsuario(u)
+      })
+      .finally(() => setLoading(false))
+  }, [])
+
+  return { usuario: usuario ?? null, loading }
+}


### PR DESCRIPTION
## Summary
- add `useSession` hook for caching session data
- use the new hook in login page and dashboard layout
- clear cache on logout or new login
- bump version to 0.2.21

## Testing
- `git status --short`

------
