### PR TITLE
Update env example and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@
 # Clave secreta para firmas JWT
 JWT_SECRET=
 
+# URL de la base de datos PostgreSQL
+DATABASE_URL=
+
 # Ejemplos de otras variables (correos SMTP)
 EMAIL_ADMIN=
 SMTP_USER=

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.21
+0.2.22
 
 ---
 
@@ -76,7 +76,7 @@ npx prisma migrate deploy
 vercel --prod
 ```
 
-Configura las variables de entorno copiando `.env.example` a `.env` y ajustando los valores necesarios.
+Configura las variables de entorno copiando `.env.example` a `.env` y ajustando los valores necesarios, en especial `DATABASE_URL` con la cadena de conexión a PostgreSQL.
 
 ---
 


### PR DESCRIPTION
## Summary
- include `DATABASE_URL` in `.env.example`
- note about setting `DATABASE_URL` in README
- bump version to 0.2.22

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436db03114832880bcb1fc06f0250c