### PR TITLE
Fix admin access by normalizing account types

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.21
+0.2.22
 
 ---
 

--- a/lib/permisos.ts
+++ b/lib/permisos.ts
@@ -5,6 +5,13 @@ export function getMainRole(u: { rol?: string; roles?: { nombre?: string }[] } |
   return undefined;
 }
 
+export function normalizeTipoCuenta(tipo?: string): string {
+  const t = (tipo ?? '').toLowerCase();
+  if (t === 'administrador') return 'admin';
+  if (t === 'estandar' || t === 'standard') return 'individual';
+  return t || 'individual';
+}
+
 export function hasManagePerms(
   u: {
     rol?: string;
@@ -16,7 +23,7 @@ export function hasManagePerms(
 ): boolean {
   if (u?.esSuperAdmin) return true;
   const rol = getMainRole(u)?.toLowerCase();
-  const tipo = (u?.tipoCuenta ?? '').toLowerCase();
+  const tipo = normalizeTipoCuenta(u?.tipoCuenta);
   const plan = (u?.plan?.nombre ?? '').toLowerCase();
   if (rol === 'admin' || rol === 'administrador') return true;
   if (['institucional', 'empresarial'].includes(tipo)) return true;

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -59,6 +59,10 @@ export async function POST(req: NextRequest) {
       updates.tipoCuenta = 'individual';
       usuario.tipoCuenta = 'individual';
     }
+    if (usuario.tipoCuenta === 'administrador') {
+      updates.tipoCuenta = 'admin';
+      usuario.tipoCuenta = 'admin';
+    }
     const roles: { id: number; nombre: string; descripcion: string | null; permisos: any }[] = [];
     for (const r of usuario.roles) {
       let perms = r.permisos as any;

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import type { Usuario } from "@/types/usuario";
-import { getMainRole } from "@lib/permisos";
+import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
 
 interface Stats {
   usuarios: number;
@@ -10,7 +10,7 @@ interface Stats {
 }
 
 export default function AdminPage() {
-  const allowed = ["admin"];
+  const allowed = ["admin", "administrador"];
   const [usuario, setUsuario] = useState<Usuario | null>(null);
   const [stats, setStats] = useState<Stats | null>(null);
   const [loading, setLoading] = useState(true);
@@ -22,7 +22,7 @@ export default function AdminPage() {
       .then((data) => {
         if (!data?.success) throw new Error();
         const rol = getMainRole(data.usuario)?.toLowerCase();
-        const tipo = (data.usuario.tipoCuenta ?? "individual").toLowerCase();
+        const tipo = normalizeTipoCuenta(data.usuario.tipoCuenta);
         if (rol !== "admin" && rol !== "administrador" && !allowed.includes(tipo))
           throw new Error("No autorizado");
         setUsuario(data.usuario);

--- a/src/app/dashboard/alertas/page.tsx
+++ b/src/app/dashboard/alertas/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import type { Usuario } from "@/types/usuario";
-import { getMainRole } from "@lib/permisos";
+import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
 
 interface Alerta {
   id: number;
@@ -11,7 +11,7 @@ interface Alerta {
 }
 
 export default function AlertasPage() {
-  const allowed = ["admin", "institucional", "empresarial", "individual"];
+  const allowed = ["admin", "administrador", "institucional", "empresarial", "individual"];
   const [usuario, setUsuario] = useState<Usuario | null>(null);
   const [alertas, setAlertas] = useState<Alerta[]>([]);
   const [loading, setLoading] = useState(true);
@@ -23,7 +23,7 @@ export default function AlertasPage() {
       .then((data) => {
         if (!data?.success) throw new Error();
         const rol = getMainRole(data.usuario)?.toLowerCase();
-        const tipo = (data.usuario.tipoCuenta ?? "individual").toLowerCase();
+        const tipo = normalizeTipoCuenta(data.usuario.tipoCuenta);
         if (rol !== "admin" && rol !== "administrador" && !allowed.includes(tipo)) {
           throw new Error("No autorizado");
         }

--- a/src/app/dashboard/almacenes/page.tsx
+++ b/src/app/dashboard/almacenes/page.tsx
@@ -4,7 +4,7 @@ import { jsonOrNull } from "@lib/http";
 import { useRouter } from "next/navigation";
 import { useAlmacenesUI } from "./ui";
 import type { Usuario } from "@/types/usuario";
-import { getMainRole, hasManagePerms } from "@lib/permisos";
+import { getMainRole, hasManagePerms, normalizeTipoCuenta } from "@lib/permisos";
 
 interface Almacen {
   id: number;
@@ -20,7 +20,7 @@ interface Almacen {
 }
 
 export default function AlmacenesPage() {
-  const allowed = ["admin", "institucional", "empresarial", "individual"];
+  const allowed = ["admin", "administrador", "institucional", "empresarial", "individual"];
   const [usuario, setUsuario] = useState<Usuario | null>(null);
   const [almacenes, setAlmacenes] = useState<Almacen[]>([]);
   const [loading, setLoading] = useState(true);
@@ -34,7 +34,7 @@ export default function AlmacenesPage() {
       .then((data) => {
         if (!data?.success) throw new Error();
         const rol = getMainRole(data.usuario)?.toLowerCase();
-        const tipo = (data.usuario.tipoCuenta ?? "individual").toLowerCase();
+        const tipo = normalizeTipoCuenta(data.usuario.tipoCuenta);
         if (
           rol !== "admin" &&
           rol !== "administrador" &&

--- a/src/app/dashboard/app-center/page.tsx
+++ b/src/app/dashboard/app-center/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import type { Usuario } from "@/types/usuario";
-import { getMainRole } from "@lib/permisos";
+import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
 
 interface AppInfo {
   id: number;
@@ -10,7 +10,7 @@ interface AppInfo {
 }
 
 export default function AppCenterPage() {
-  const allowed = ["admin", "institucional", "empresarial"];
+  const allowed = ["admin", "administrador", "institucional", "empresarial"];
   const [usuario, setUsuario] = useState<Usuario | null>(null);
   const [apps, setApps] = useState<AppInfo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -22,7 +22,7 @@ export default function AppCenterPage() {
       .then((data) => {
         if (!data?.success) throw new Error();
         const rol = getMainRole(data.usuario)?.toLowerCase();
-        const tipo = (data.usuario.tipoCuenta ?? "individual").toLowerCase();
+        const tipo = normalizeTipoCuenta(data.usuario.tipoCuenta);
         if (rol !== "admin" && rol !== "administrador" && !allowed.includes(tipo))
           throw new Error("No autorizado");
         setUsuario(data.usuario);

--- a/src/app/dashboard/billing/page.tsx
+++ b/src/app/dashboard/billing/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import type { Usuario } from "@/types/usuario";
-import { getMainRole } from "@lib/permisos";
+import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
 
 interface Invoice {
   id: number;
@@ -12,7 +12,7 @@ interface Invoice {
 }
 
 export default function BillingPage() {
-  const allowed = ["admin", "institucional"];
+  const allowed = ["admin", "administrador", "institucional"];
   const [usuario, setUsuario] = useState<Usuario | null>(null);
   const [invoices, setInvoices] = useState<Invoice[]>([]);
   const [loading, setLoading] = useState(true);
@@ -24,7 +24,7 @@ export default function BillingPage() {
       .then((data) => {
         if (!data?.success) throw new Error();
         const rol = getMainRole(data.usuario)?.toLowerCase();
-        const tipo = (data.usuario.tipoCuenta ?? "individual").toLowerCase();
+        const tipo = normalizeTipoCuenta(data.usuario.tipoCuenta);
         if (rol !== "admin" && rol !== "administrador" && !allowed.includes(tipo))
           throw new Error("No autorizado");
         setUsuario(data.usuario);

--- a/src/app/dashboard/components/NavbarDashboard.tsx
+++ b/src/app/dashboard/components/NavbarDashboard.tsx
@@ -18,7 +18,7 @@ import {
 import UserMenu from "@/components/UserMenu";
 import { useDashboardUI } from "../ui";
 import type { Usuario } from "@/types/usuario";
-import { hasManagePerms } from "@lib/permisos";
+import { hasManagePerms, normalizeTipoCuenta } from "@lib/permisos";
 
 const MOCK_RESULTS = [
   { tipo: "almacén", nombre: "Almacén Central", url: "/almacenes/central" },
@@ -86,7 +86,7 @@ export default function NavbarDashboard({ usuario }: { usuario: Usuario }) {
   const puedeCrear = hasManagePerms(usuario);
   const puedeInvitarUsuarios =
     hasManagePerms(usuario) &&
-    ((usuario?.tipoCuenta ?? "").toLowerCase() !== "individual");
+    normalizeTipoCuenta(usuario?.tipoCuenta) !== "individual";
 
   return (
     <header

--- a/src/app/dashboard/components/Sidebar.tsx
+++ b/src/app/dashboard/components/Sidebar.tsx
@@ -3,7 +3,7 @@
 import { usePathname, useRouter } from "next/navigation";
 import { useDashboardUI } from "../ui";
 import type { Usuario } from "@/types/usuario";
-import { getMainRole } from "@lib/permisos";
+import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
 import {
   Home,
   Boxes,
@@ -27,63 +27,63 @@ const sidebarMenu = [
     label: "Dashboard",
     icon: <Home className="dashboard-sidebar-icon" data-oid="i99r0xl" />,
     path: "/dashboard",
-    allowed: ["admin", "institucional", "empresarial", "individual"],
+    allowed: ["admin", "administrador", "institucional", "empresarial", "individual"],
   },
   {
     key: "almacenes",
     label: "Almacenes",
     icon: <Boxes className="dashboard-sidebar-icon" data-oid="fhr-clw" />,
     path: "/dashboard/almacenes",
-    allowed: ["admin", "institucional", "empresarial", "individual"],
+    allowed: ["admin", "administrador", "institucional", "empresarial", "individual"],
   },
   {
     key: "alertas",
     label: "Alertas",
     icon: <Bell className="dashboard-sidebar-icon" data-oid=".ea6mni" />,
     path: "/dashboard/alertas",
-    allowed: ["admin", "institucional", "empresarial", "individual"],
+    allowed: ["admin", "administrador", "institucional", "empresarial", "individual"],
   },
   {
     key: "appcenter",
     label: "App Center",
     icon: <AppWindow className="dashboard-sidebar-icon" data-oid="am_k.6c" />,
     path: "/dashboard/app-center",
-    allowed: ["admin", "institucional", "empresarial"],
+    allowed: ["admin", "administrador", "institucional", "empresarial"],
   },
   {
     key: "network",
     label: "Network",
     icon: <Network className="dashboard-sidebar-icon" data-oid="z-33x83" />,
     path: "/dashboard/network",
-    allowed: ["admin", "institucional"],
+    allowed: ["admin", "administrador", "institucional"],
   },
   {
     key: "plantillas",
     label: "Plantillas",
     icon: <FileStack className="dashboard-sidebar-icon" data-oid="0vwt0b-" />,
     path: "/dashboard/plantillas",
-    allowed: ["admin", "institucional", "empresarial", "individual"],
+    allowed: ["admin", "administrador", "institucional", "empresarial", "individual"],
   },
   {
     key: "reportes",
     label: "Reportes",
     icon: <FileText className="dashboard-sidebar-icon" data-oid="wzewnea" />,
     path: "/dashboard/reportes",
-    allowed: ["admin", "institucional", "empresarial"],
+    allowed: ["admin", "administrador", "institucional", "empresarial"],
   },
   {
     key: "billing",
     label: "Billing",
     icon: <Receipt className="dashboard-sidebar-icon" data-oid="ny9b2pu" />,
     path: "/dashboard/billing",
-    allowed: ["admin", "institucional"],
+    allowed: ["admin", "administrador", "institucional"],
   },
   {
     key: "admin",
     label: "Admin",
     icon: <Settings className="dashboard-sidebar-icon" data-oid="93xzl3d" />,
     path: "/dashboard/admin",
-    allowed: ["admin"],
+    allowed: ["admin", "administrador"],
   },
 ];
 
@@ -107,7 +107,9 @@ export default function Sidebar({ usuario }: { usuario: Usuario }) {
   }
 
   const mainRole = getMainRole(usuario)?.toLowerCase();
-  const tipo = mainRole === "admin" ? "admin" : usuario.tipoCuenta ?? "individual";
+  const tipo = normalizeTipoCuenta(
+    mainRole === "admin" ? "admin" : usuario.tipoCuenta,
+  );
 
   const filteredMenu = sidebarMenu.filter((item) =>
     item.allowed.includes(tipo),

--- a/src/app/dashboard/network/page.tsx
+++ b/src/app/dashboard/network/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import type { Usuario } from "@/types/usuario";
-import { getMainRole } from "@lib/permisos";
+import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
 
 interface Peer {
   id: number;
@@ -10,7 +10,7 @@ interface Peer {
 }
 
 export default function NetworkPage() {
-  const allowed = ["admin", "institucional"];
+  const allowed = ["admin", "administrador", "institucional"];
   const [usuario, setUsuario] = useState<Usuario | null>(null);
   const [peers, setPeers] = useState<Peer[]>([]);
   const [loading, setLoading] = useState(true);
@@ -22,7 +22,7 @@ export default function NetworkPage() {
       .then((data) => {
         if (!data?.success) throw new Error();
         const rol = getMainRole(data.usuario)?.toLowerCase();
-        const tipo = (data.usuario.tipoCuenta ?? "individual").toLowerCase();
+        const tipo = normalizeTipoCuenta(data.usuario.tipoCuenta);
         if (rol !== "admin" && rol !== "administrador" && !allowed.includes(tipo))
           throw new Error("No autorizado");
         setUsuario(data.usuario);

--- a/src/app/dashboard/plantillas/page.tsx
+++ b/src/app/dashboard/plantillas/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import type { Usuario } from "@/types/usuario";
-import { getMainRole } from "@lib/permisos";
+import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
 
 interface Plantilla {
   id: number;
@@ -10,7 +10,7 @@ interface Plantilla {
 }
 
 export default function PlantillasPage() {
-  const allowed = ["admin", "institucional", "empresarial", "individual"];
+  const allowed = ["admin", "administrador", "institucional", "empresarial", "individual"];
   const [usuario, setUsuario] = useState<Usuario | null>(null);
   const [plantillas, setPlantillas] = useState<Plantilla[]>([]);
   const [loading, setLoading] = useState(true);
@@ -22,7 +22,7 @@ export default function PlantillasPage() {
       .then((data) => {
         if (!data?.success) throw new Error();
         const rol = getMainRole(data.usuario)?.toLowerCase();
-        const tipo = (data.usuario.tipoCuenta ?? "individual").toLowerCase();
+        const tipo = normalizeTipoCuenta(data.usuario.tipoCuenta);
         if (rol !== "admin" && rol !== "administrador" && !allowed.includes(tipo))
           throw new Error("No autorizado");
         setUsuario(data.usuario);

--- a/src/app/dashboard/reportes/page.tsx
+++ b/src/app/dashboard/reportes/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import type { Usuario } from "@/types/usuario";
-import { getMainRole } from "@lib/permisos";
+import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
 
 interface Reporte {
   id: number;
@@ -10,7 +10,7 @@ interface Reporte {
 }
 
 export default function ReportesPage() {
-  const allowed = ["admin", "institucional", "empresarial"];
+  const allowed = ["admin", "administrador", "institucional", "empresarial"];
   const [usuario, setUsuario] = useState<Usuario | null>(null);
   const [reportes, setReportes] = useState<Reporte[]>([]);
   const [loading, setLoading] = useState(true);
@@ -22,7 +22,7 @@ export default function ReportesPage() {
       .then((data) => {
         if (!data?.success) throw new Error();
         const rol = getMainRole(data.usuario)?.toLowerCase();
-        const tipo = (data.usuario.tipoCuenta ?? "individual").toLowerCase();
+        const tipo = normalizeTipoCuenta(data.usuario.tipoCuenta);
         if (rol !== "admin" && rol !== "administrador" && !allowed.includes(tipo))
           throw new Error("No autorizado");
         setUsuario(data.usuario);

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -18,7 +18,7 @@ import { useEffect, useRef, useState } from "react";
 import clsx from "clsx";
 import { usePathname, useRouter } from "next/navigation";
 import { jsonOrNull } from "@lib/http";
-import { getMainRole } from "@lib/permisos";
+import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
 import { clearSessionCache } from "@/hooks/useSession";
 
 interface UsuarioData {
@@ -90,7 +90,7 @@ export default function UserMenu({
         const data = await jsonOrNull(res);
         if (data?.success && data.usuario) {
           const rol = getMainRole(data.usuario)?.toLowerCase();
-          const tipo = (data.usuario.tipoCuenta ?? "").toLowerCase();
+          const tipo = normalizeTipoCuenta(data.usuario.tipoCuenta);
           if (
             rol === "admin" ||
             rol === "administrador" ||


### PR DESCRIPTION
## Summary
- normalize account types into common values
- update login to convert legacy `administrador` type
- allow `administrador` type across dashboard pages
- adjust session checks in sidebar, navbar and user menu
- bump version to 0.2.22

## Testing
- `npm run lint` *(fails: next not found)*

------
