### PR TITLE
Fix novedades JWT secret handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.2.25
+
+- `JWT_SECRET` es obligatorio en la ruta `/api/novedades`.
+
 ## 0.2.24
 
 - Sidebar global ahora puede ocultarse desde el navbar.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.24
+0.2.25
 
 ---
 

--- a/src/app/api/novedades/route.ts
+++ b/src/app/api/novedades/route.ts
@@ -3,7 +3,10 @@ import prisma from '@lib/prisma'
 import jwt from 'jsonwebtoken'
 import { SESSION_COOKIE } from '@lib/constants'
 
-const JWT_SECRET = process.env.JWT_SECRET ?? 'mi_clave_de_emergencia'
+const JWT_SECRET = process.env.JWT_SECRET
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET no definido en el entorno')
+}
 
 export async function GET(req: NextRequest) {
   try {


### PR DESCRIPTION
## Summary
- enforce JWT_SECRET env variable on novedades API
- update version to 0.2.25
- document change in CHANGELOG

## Testing
- `npm run lint` *(fails: next not found)*

------
