### PR TITLE
Update middleware to use SESSION_COOKIE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.2.25
+
+- El middleware ahora detecta la cookie de sesión usando `SESSION_COOKIE`.
+
 ## 0.2.24
 
 - Sidebar global ahora puede ocultarse desde el navbar.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.24
+0.2.25
 
 ---
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { SESSION_COOKIE } from '@lib/constants';
 
 // --- Memory Rate Limiter ---
 // Solo para desarrollo, VPS o entornos con estado.
@@ -23,14 +24,12 @@ if (typeof global !== "undefined") {
 
 /**
  * Obtiene una clave única para el limitador:
- * - Si hay cookie de sesión/token, la usa.
+ * - Si hay cookie de sesión, la usa.
  * - Si no, toma la IP del request.
  * - En local, usa un ID random para evitar bloqueo global.
  */
 function getRateLimitKey(req: NextRequest): string {
-  const sessionCookie =
-    req.cookies.get('token')?.value ||
-    req.cookies.get('sessionid')?.value;
+  const sessionCookie = req.cookies.get(SESSION_COOKIE)?.value;
 
   if (sessionCookie) return `SESSION_${sessionCookie}`;
 


### PR DESCRIPTION
## Summary
- read `SESSION_COOKIE` in `getRateLimitKey`
- bump version to 0.2.25 and document changes

## Testing
- `npm run lint` *(fails: next not found)*

------
