### PR TITLE
v0.2.25 - fix sidebar active state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.2.25
+
+- Corrección en Sidebar para marcar solo la ruta actual como activa.
 ## 0.2.24
 
 - Sidebar global ahora puede ocultarse desde el navbar.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.24
+0.2.25
 
 ---
 

--- a/src/app/dashboard/components/Sidebar.tsx
+++ b/src/app/dashboard/components/Sidebar.tsx
@@ -164,7 +164,8 @@ export default function Sidebar({ usuario }: { usuario: Usuario }) {
       {/* Menú navegación */}
       <nav className="flex-1 py-6 px-2 flex flex-col gap-1" data-oid="_fmifu.">
         {filteredMenu.map((item) => {
-          const active = pathname.startsWith(item.path);
+          const active =
+            pathname === item.path || pathname.startsWith(`${item.path}/`);
           return (
             <button
               key={item.key}


### PR DESCRIPTION
## Summary
- fix Sidebar active route detection to highlight only the current route
- bump version to 0.2.25
- document changes in CHANGELOG

## Testing
- `npm run lint` *(fails: next not found)*

------
