### PR TITLE
Fix session logic in almacen components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.2.25
+
+- Componentes de almacenes ahora usan `useSession` para obtener al usuario.
+- Se eliminó la lógica duplicada de carga en dichos componentes.
+
 ## 0.2.24
 
 - Sidebar global ahora puede ocultarse desde el navbar.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.24
+0.2.25
 
 ---
 

--- a/src/app/dashboard/almacenes/components/AlmacenNavbar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenNavbar.tsx
@@ -11,9 +11,8 @@ import {
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useAlmacenesUI } from "../ui";
-import type { Usuario } from "@/types/usuario";
-import { useEffect, useState } from "react";
-import { jsonOrNull } from "@lib/http";
+import useSession from "@/hooks/useSession";
+import { useState } from "react";
 import { getMainRole, hasManagePerms } from "@lib/permisos";
 
 
@@ -25,16 +24,9 @@ interface AlmacenNavbarProps {
 export default function AlmacenNavbar({ mode = 'list', nombre }: AlmacenNavbarProps) {
   const router = useRouter();
   const { view, setView, filter, setFilter, onCreate } = useAlmacenesUI();
-  const [usuario, setUsuario] = useState<Usuario | null>(null);
+  const { usuario } = useSession();
   const [busqueda, setBusqueda] = useState("");
   const [menuOpen, setMenuOpen] = useState(false);
-
-  useEffect(() => {
-    fetch("/api/login", { credentials: "include" })
-      .then(jsonOrNull)
-      .then((d) => (d?.success ? setUsuario(d.usuario) : setUsuario(null)))
-      .catch(() => setUsuario(null));
-  }, []);
 
   // Permisos de gestión
   const allowManage = usuario ? hasManagePerms(usuario) : false;

--- a/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
@@ -19,14 +19,13 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useDashboardUI } from "../../ui"; // para saber si sidebar global está colapsado
 import {
   SIDEBAR_GLOBAL_WIDTH,
   SIDEBAR_GLOBAL_COLLAPSED_WIDTH,
 } from "../../constants";
-import type { Usuario } from "@/types/usuario";
-import { jsonOrNull } from "@lib/http";
+import useSession from "@/hooks/useSession";
 import { getMainRole, hasManagePerms } from "@lib/permisos";
 
 // --- Estilos base ---
@@ -79,14 +78,7 @@ export default function AlmacenSidebar({
 }) {
   // Lee el estado del sidebar global para alinear el sidebar de almacenes
   const { sidebarGlobalCollapsed, sidebarGlobalVisible, fullscreen } = useDashboardUI();
-  const [usuario, setUsuario] = useState<Usuario | null>(null);
-
-  useEffect(() => {
-    fetch("/api/login", { credentials: "include" })
-      .then(jsonOrNull)
-      .then((d) => (d?.success ? setUsuario(d.usuario) : setUsuario(null)))
-      .catch(() => setUsuario(null));
-  }, []);
+  const { usuario } = useSession();
 
   const allowCreate = usuario ? hasManagePerms(usuario) : false;
 


### PR DESCRIPTION
## Summary
- use the existing `useSession` hook in almacen navbar and sidebar
- update version to 0.2.25 and document changes

## Testing
- `npm run lint` *(fails: next not found)*

------
