### PR TITLE
Apply NAVBAR_HEIGHT constant to dashboard layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.2.27
+
+- NAVBAR_HEIGHT se exporta y aplica en todos los layouts del dashboard para mantener una altura consistente.
+
 ## 0.2.26
 
 - Páginas del dashboard ahora consultan la sesión con `useSession`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.26
+0.2.27
 
 ---
 

--- a/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
@@ -24,6 +24,7 @@ import { useDashboardUI } from "../../ui"; // para saber si sidebar global está
 import {
   SIDEBAR_GLOBAL_WIDTH,
   SIDEBAR_GLOBAL_COLLAPSED_WIDTH,
+  NAVBAR_HEIGHT,
 } from "../../constants";
 import useSession from "@/hooks/useSession";
 import { getMainRole, hasManagePerms } from "@lib/permisos";
@@ -92,7 +93,7 @@ export default function AlmacenSidebar({
       : 0;
 
   // Debes usar la misma altura de tus navbars globales (ajusta según tus constantes)
-  const navbarsHeight = "calc(var(--navbar-height, 64px) + var(--almacen-navbar-height, 56px))";
+  const navbarsHeight = `calc(var(--navbar-height, ${NAVBAR_HEIGHT}px) + var(--almacen-navbar-height, 56px))`;
 
   // --- Sidebar modo detalle (un almacén específico) ---
   if (mode === "detail") {

--- a/src/app/dashboard/almacenes/layout.tsx
+++ b/src/app/dashboard/almacenes/layout.tsx
@@ -81,7 +81,7 @@ function ProtectedAlmacenes({ children }: { children: React.ReactNode }) {
     : 0;
 
   // Alturas para los elementos fijos
-  const navbarHeight = '64px'; // Misma altura que el navbar del dashboard
+  const navbarHeight = `${NAVBAR_HEIGHT}px`; // Misma altura que el navbar del dashboard
   const almacenNavbarHeight = '50px'; // Altura del navbar de almacenes
   const totalNavbarHeight = `calc(${navbarHeight} + ${almacenNavbarHeight})`;
 

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -8,6 +8,7 @@ import { DashboardUIProvider, useDashboardUI } from "./ui";
 import {
   SIDEBAR_GLOBAL_WIDTH,
   SIDEBAR_GLOBAL_COLLAPSED_WIDTH,
+  NAVBAR_HEIGHT,
 } from "./constants";
 import { useRouter } from "next/navigation";
 
@@ -62,7 +63,7 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
   const marginLeft = !fullscreen && !isMobile ? sidebarWidth : 0;
 
   // Altura del navbar
-  const navbarHeight = '64px';
+  const navbarHeight = `${NAVBAR_HEIGHT}px`;
 
   return (
     <div
@@ -121,8 +122,8 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
             relative
             animate-fade-in
             transition-colors duration-300
-            min-h-[calc(100vh-64px)]
           "
+          style={{ minHeight: `calc(100vh - ${NAVBAR_HEIGHT}px)` }}
           data-oid="xvd._xa"
         >
           {children}


### PR DESCRIPTION
## Summary
- unify navbar height handling across dashboard layouts using `NAVBAR_HEIGHT`
- update documentation with new version 0.2.27
- log changes in Changelog

## Testing
- `npm run lint` *(fails: next not found)*

------
