### PR TITLE
Update docs and fix sidebar fullscreen issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
-## 0.2.29
+## 0.2.31
 
-- Se añadieron placeholders para inventario, operaciones, reportes, archivos, configuracion y ayuda.
+- Rediseño del sidebar de almacenes y corrección de la navegación para mantener visibles los navbars y sidebars.
 
 ## 0.2.30
 
 - Sidebar de almacenes simplificado con las nuevas categorías principales.
+
+## 0.2.29
+
+- Se añadieron placeholders para inventario, operaciones, reportes, archivos, configuracion y ayuda.
 
 ## 0.2.28
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.30
+0.2.29
 
 ---
 

--- a/src/app/dashboard/almacenes/[id]/layout.tsx
+++ b/src/app/dashboard/almacenes/[id]/layout.tsx
@@ -18,7 +18,6 @@ function ProtectedAlmacen({ children }: { children: React.ReactNode }) {
     fullscreen,
     sidebarGlobalVisible = true,
     sidebarGlobalCollapsed,
-    toggleFullscreen,
   } = useDashboardUI();
   const router = useRouter();
   const [usuario, setUsuario] = useState<Usuario | null>(null);
@@ -43,12 +42,6 @@ function ProtectedAlmacen({ children }: { children: React.ReactNode }) {
     cargarUsuario();
   }, []);
 
-  useEffect(() => {
-    toggleFullscreen();
-    return () => {
-      toggleFullscreen();
-    };
-  }, []);
 
   useEffect(() => {
     if (!loading && !usuario) {


### PR DESCRIPTION
## Summary
- update version in README
- document sidebar redesign and navigation fix
- keep navbars visible in almacen detail pages

## Testing
- `npm run lint` *(fails: next not found)*

------
