### PR TITLE
Unificar sidebar de almacenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.2.33
+
+- Unificado el sidebar de almacenes eliminando el modo "detalle".
+
 ## 0.2.32
 
 - Eliminado el sidebar duplicado en las páginas de detalle de almacenes.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.32
+0.2.33
 
 ---
 

--- a/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
@@ -67,11 +67,7 @@ function MenuLink({
   );
 }
 
-export default function AlmacenSidebar({
-  mode = "list",
-}: {
-  mode?: "list" | "detail";
-}) {
+export default function AlmacenSidebar() {
   // Lee el estado del sidebar global para alinear el sidebar de almacenes
   const { sidebarGlobalCollapsed, sidebarGlobalVisible, fullscreen } = useDashboardUI();
   const { usuario } = useSession();
@@ -90,42 +86,7 @@ export default function AlmacenSidebar({
   // Debes usar la misma altura de tus navbars globales (ajusta según tus constantes)
   const navbarsHeight = `calc(var(--navbar-height, ${NAVBAR_HEIGHT}px) + var(--almacen-navbar-height, 56px))`;
 
-  // --- Sidebar modo detalle (un almacén específico) ---
-  if (mode === "detail") {
-    return (
-      <aside
-        className="
-          fixed z-30
-          w-64 h-[calc(100vh-120px)]
-          bg-[var(--dashboard-sidebar)]
-          border-r border-[var(--dashboard-border)]
-          shadow-sm
-          transition-all
-        "
-        style={{
-          left: sidebarLeft,
-          top: `calc(${navbarsHeight})`,
-          height: `calc(100vh - ${navbarsHeight})`,
-        }}
-      >
-        <nav className="flex flex-col gap-1">
-          <h3 className={sectionStyle}>Navegación</h3>
-          <MenuLink href="#" icon={Box} label="Inventario" />
-          <MenuLink href="#categorias" icon={Tag} label="Categorías" />
-          <MenuLink href="#ubicaciones" icon={Layers} label="Ubicaciones" />
-          <MenuLink href="#movimientos" icon={History} label="Movimientos" />
-          <MenuLink href="#reportes" icon={FileText} label="Reportes" />
-          <div className="my-2 border-t border-white/10"></div>
-          <h3 className={sectionStyle}>Configuración</h3>
-          <MenuLink href="#usuarios" icon={Users} label="Usuarios" />
-          <MenuLink href="#configuracion" icon={Settings} label="Ajustes" />
-          <MenuLink href="#ayuda" icon={BookOpen} label="Ayuda" />
-        </nav>
-      </aside>
-    );
-  }
-
-  // --- Sidebar modo lista (todos los almacenes) ---
+  // --- Sidebar de almacenes ---
   return (
     <aside
       className="

--- a/src/app/dashboard/almacenes/layout.tsx
+++ b/src/app/dashboard/almacenes/layout.tsx
@@ -143,7 +143,7 @@ function ProtectedAlmacenes({ children }: { children: React.ReactNode }) {
             data-oid="ea00760"
           >
             <div className="space-y-1">
-              <AlmacenSidebar mode={pathname !== "/dashboard/almacenes" ? 'detail' : 'list'} />
+              <AlmacenSidebar />
             </div>
           </aside>
         )}


### PR DESCRIPTION
## Summary
- quitar modo `detail` del componente `AlmacenSidebar`
- actualizar layout de almacenes para usar un único sidebar
- documentar versión 0.2.33
- registrar cambio en `CHANGELOG`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684391095a448328813c1f3ff72627d5