### PR TITLE
Implementa modo de vista en almacenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.2.34
+
+- Los navbars y sidebars del dashboard y de almacenes se ocultan al entrar a un almacén.
+- Se muestra una barra superior del almacén con opción para volver.
+
 ## 0.2.33
 
 - Unificado el sidebar de almacenes eliminando el modo "detalle".

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.33
+0.2.34
 
 ---
 

--- a/src/app/dashboard/almacenes/[id]/layout.tsx
+++ b/src/app/dashboard/almacenes/[id]/layout.tsx
@@ -8,7 +8,7 @@ import { NAVBAR_HEIGHT } from "../../constants";
 import type { Usuario } from "@/types/usuario";
 
 function ProtectedAlmacen({ children }: { children: React.ReactNode }) {
-  const { fullscreen } = useDashboardUI();
+  const { fullscreen, setFullscreen } = useDashboardUI();
   const router = useRouter();
   const [usuario, setUsuario] = useState<Usuario | null>(null);
   const [loading, setLoading] = useState(true);
@@ -38,6 +38,11 @@ function ProtectedAlmacen({ children }: { children: React.ReactNode }) {
       router.replace("/login");
     }
   }, [usuario, loading, router]);
+
+  useEffect(() => {
+    setFullscreen(true);
+    return () => setFullscreen(false);
+  }, [setFullscreen]);
 
   if (loading) {
     return (

--- a/src/app/dashboard/almacenes/layout.tsx
+++ b/src/app/dashboard/almacenes/layout.tsx
@@ -96,7 +96,7 @@ function ProtectedAlmacenes({ children }: { children: React.ReactNode }) {
     >
       {/* --- NAVBAR ALMACENES --- */}
       <div
-        className="fixed left-0 right-0 z-40 bg-[var(--dashboard-navbar)] border-b border-[var(--dashboard-border)]"
+        className="dashboard-navbar fixed left-0 right-0 z-40 bg-[var(--dashboard-navbar)] border-b border-[var(--dashboard-border)]"
         style={{
           top: navbarHeight, // Coloca este navbar debajo del navbar del dashboard
           height: almacenNavbarHeight,
@@ -125,6 +125,7 @@ function ProtectedAlmacenes({ children }: { children: React.ReactNode }) {
         {/* --- SIDEBAR ALMACENES --- */}
         {!fullscreen && (
           <aside
+            className="dashboard-sidebar"
             style={{
               width: SIDEBAR_ALMACENES_WIDTH,
               minWidth: SIDEBAR_ALMACENES_WIDTH,

--- a/src/app/dashboard/ui.tsx
+++ b/src/app/dashboard/ui.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useState, useEffect } from "react";
 interface UIState {
   fullscreen: boolean;
   toggleFullscreen: () => void;
+  setFullscreen: (v: boolean) => void;
   sidebarGlobalVisible: boolean;
   sidebarGlobalCollapsed: boolean;
   toggleSidebarVisible: (v?: boolean) => void;
@@ -13,6 +14,7 @@ interface UIState {
 const DashboardUIContext = createContext<UIState>({
   fullscreen: false,
   toggleFullscreen: () => {},
+  setFullscreen: () => {},
   sidebarGlobalVisible: true,
   sidebarGlobalCollapsed: false,
   toggleSidebarVisible: () => {},
@@ -33,6 +35,7 @@ export function DashboardUIProvider({
   }, []);
 
   const toggleFullscreen = () => setFullscreen((f) => !f);
+  const setFullscreenState = (v: boolean) => setFullscreen(v);
   const toggleSidebarCollapsed = () => setSidebarGlobalCollapsed((c) => !c);
   const toggleSidebarVisible = (v?: boolean) =>
     setSidebarGlobalVisible((c) => (typeof v === "boolean" ? v : !c));
@@ -42,6 +45,7 @@ export function DashboardUIProvider({
       value={{
         fullscreen,
         toggleFullscreen,
+        setFullscreen: setFullscreenState,
         sidebarGlobalVisible,
         sidebarGlobalCollapsed,
         toggleSidebarVisible,


### PR DESCRIPTION
## Summary
- oculta todos los sidebars y navbars al entrar en un almacén
- agrega control setFullscreen en el contexto de UI
- actualiza la versión a 0.2.34
- documenta el cambio en el changelog

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843951222508328866f510c2d29367d