### PR TITLE
Fix navbar position and allow blob images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.2.36
+
+- Navbar de almacenes permanece fijo debajo del navbar principal.
+- CSP actualizada para permitir imágenes `blob:`.
+
 ## 0.2.35
 
 - Navbar de almacenes se oculta al ver un almacén.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.35
+0.2.36
 
 ---
 

--- a/lib/securityHeaders.ts
+++ b/lib/securityHeaders.ts
@@ -5,7 +5,7 @@ export const ContentSecurityPolicy = dev
     default-src 'self' http://localhost:*;
     script-src 'self' 'unsafe-inline' 'unsafe-eval' vitals.vercel-insights.com http://localhost:*;
     style-src 'self' 'unsafe-inline';
-    img-src 'self' http: https: data:;
+    img-src 'self' http: https: data: blob:;
     connect-src 'self' http://localhost:* ws://localhost:*;
     object-src 'none';
   `
@@ -13,7 +13,7 @@ export const ContentSecurityPolicy = dev
     default-src 'self';
     script-src 'self' 'unsafe-inline' vitals.vercel-insights.com;
     style-src 'self' 'unsafe-inline';
-    img-src 'self' https: data:;
+    img-src 'self' https: data: blob:;
     connect-src 'self';
     object-src 'none';
   `;

--- a/src/app/dashboard/almacenes/layout.tsx
+++ b/src/app/dashboard/almacenes/layout.tsx
@@ -102,12 +102,11 @@ function ProtectedAlmacenes({ children }: { children: React.ReactNode }) {
           style={{
             top: navbarHeight, // Coloca este navbar debajo del navbar del dashboard
             height: almacenNavbarHeight,
-            left: fullscreen ? 0 : sidebarLeft,
-            right: 0,
+            paddingLeft: !fullscreen && sidebarGlobalVisible ? sidebarLeft : 0,
             display: 'flex',
             alignItems: 'center',
-            padding: '0 1rem',
-            transition: 'left 0.3s ease'
+            paddingRight: '1rem',
+            transition: 'padding-left 0.3s ease'
           }}
           data-oid="pyvpx.g"
         >


### PR DESCRIPTION
## Summary
- keep almacenes navbar fixed below dashboard
- allow blob: images in CSP
- update version to 0.2.36

## Testing
- `npm run lint` *(fails: next not found)*

------
