### PR TITLE
Ajuste dinámico de ancho para contenidos de dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.2.41
+
+- Ajustes de layout para que el contenido ocupe el ancho disponible entre los sidebars.
+
 ## 0.2.40
 
 - Eliminado el navbar de almacenes.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.40
+0.2.41
 
 ---
 

--- a/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
@@ -91,13 +91,15 @@ export default function AlmacenSidebar() {
     <aside
       className="
         fixed z-30
-        w-64 h-screen
+        h-screen
         bg-[var(--dashboard-sidebar)]
         border-r border-[var(--dashboard-border)]
         shadow-sm
         transition-all
       "
       style={{
+        width: SIDEBAR_ALMACENES_WIDTH,
+        minWidth: SIDEBAR_ALMACENES_WIDTH,
         left: sidebarLeft,
         top: 0,
         height: '100vh',

--- a/src/app/dashboard/almacenes/layout.tsx
+++ b/src/app/dashboard/almacenes/layout.tsx
@@ -84,6 +84,10 @@ function ProtectedAlmacenes({ children }: { children: React.ReactNode }) {
   const navbarHeight = isDetail ? '0px' : `${NAVBAR_HEIGHT}px`;
   const totalNavbarHeight = navbarHeight;
 
+  const contentPaddingLeft = !fullscreen
+    ? sidebarLeft + (!isDetail ? SIDEBAR_ALMACENES_WIDTH : 0)
+    : 0;
+
   return (
     <div
       className={`min-h-screen bg-[var(--dashboard-bg)] relative ${
@@ -95,12 +99,12 @@ function ProtectedAlmacenes({ children }: { children: React.ReactNode }) {
 
 
       <div
-        className="flex"
+        className="flex w-full"
         style={{
           paddingTop: totalNavbarHeight,
           minHeight: `calc(100vh - ${navbarHeight})`,
-          paddingLeft: !fullscreen ? sidebarLeft : 0,
-          transition: 'padding-left 0.3s ease'
+          paddingLeft: contentPaddingLeft,
+          transition: 'padding-left 0.3s ease',
         }}
         data-oid="3g2x0lf"
       >
@@ -134,9 +138,8 @@ function ProtectedAlmacenes({ children }: { children: React.ReactNode }) {
 
         {/* CONTENIDO PRINCIPAL */}
         <main
-          className="flex-1"
+          className="flex-1 w-full"
           style={{
-            marginLeft: !fullscreen && !isDetail ? `${SIDEBAR_ALMACENES_WIDTH}px` : 0,
             padding: "1.5rem",
             transition: "all 0.3s ease",
             minHeight: `calc(100vh - ${totalNavbarHeight})`,

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -60,7 +60,6 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
       ? SIDEBAR_GLOBAL_COLLAPSED_WIDTH
       : SIDEBAR_GLOBAL_WIDTH
     : 0;
-  const marginLeft = !fullscreen && !isMobile ? sidebarWidth : 0;
 
   // Altura del navbar
   const navbarHeight = `${NAVBAR_HEIGHT}px`;
@@ -109,17 +108,17 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
 
       {/* CONTENIDO PRINCIPAL */}
       <div
-        className="flex flex-col min-h-screen transition-all duration-300"
+        className="flex flex-col min-h-screen transition-all duration-300 w-full"
         style={{
           paddingTop: isAlmacenDetail ? 0 : navbarHeight,
           paddingLeft: !fullscreen ? sidebarWidth : 0,
-          transition: 'padding-left 0.3s ease'
+          transition: 'padding-left 0.3s ease',
         }}
         data-oid="ou.:qgb"
       >
         <section
           className="
-            flex-1 p-4 sm:p-8
+            flex-1 p-4 sm:p-8 w-full
             bg-[var(--dashboard-bg)]
             text-[var(--dashboard-text)]
             relative


### PR DESCRIPTION
## Summary
- actualiza a la versión **0.2.41**
- ajusta el layout del dashboard para usar `w-full` y `flex-1`
- aplica el mismo enfoque en la sección de almacenes
- alinea el sidebar de almacenes con el ancho configurado

## Testing
- `npm run lint` *(fails: next not found)*

------
