### PR TITLE
Fix sidebar width constant import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.2.42
+
+- Corrección de importación para `SIDEBAR_ALMACENES_WIDTH` en `AlmacenSidebar`.
+
 ## 0.2.41
 
 - Ajustes de layout para que el contenido ocupe el ancho disponible entre los sidebars.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.41
+0.2.42
 
 ---
 

--- a/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenSidebar.tsx
@@ -19,6 +19,7 @@ import { useDashboardUI } from "../../ui"; // para saber si sidebar global está
 import {
   SIDEBAR_GLOBAL_WIDTH,
   SIDEBAR_GLOBAL_COLLAPSED_WIDTH,
+  SIDEBAR_ALMACENES_WIDTH,
   NAVBAR_HEIGHT,
 } from "../../constants";
 import useSession from "@/hooks/useSession";


### PR DESCRIPTION
## Summary
- fix missing SIDEBAR_ALMACENES_WIDTH import in AlmacenSidebar
- update version to 0.2.42 in README and CHANGELOG

## Testing
- `npm run lint` *(fails: next not found)*

------
