### PR TITLE
Improve dashboard sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.2.43
+
+- Nuevo botón **Herramientas e Integraciones** con buscador y submenú para alertas, plantillas, network, app center y billing.
+
 ## 0.2.42
 
 - Corrección de importación para `SIDEBAR_ALMACENES_WIDTH` en `AlmacenSidebar`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.42
+0.2.43
 
 ---
 

--- a/src/app/dashboard/components/Sidebar.tsx
+++ b/src/app/dashboard/components/Sidebar.tsx
@@ -37,32 +37,11 @@ const sidebarMenu = [
     allowed: ["admin", "administrador", "institucional", "empresarial", "individual"],
   },
   {
-    key: "alertas",
-    label: "Alertas",
-    icon: <Bell className="dashboard-sidebar-icon" data-oid=".ea6mni" />,
-    path: "/dashboard/alertas",
+    key: "tools",
+    label: "Herramientas e Integraciones",
+    icon: <AppWindow className="dashboard-sidebar-icon" />,
     allowed: ["admin", "administrador", "institucional", "empresarial", "individual"],
-  },
-  {
-    key: "appcenter",
-    label: "App Center",
-    icon: <AppWindow className="dashboard-sidebar-icon" data-oid="am_k.6c" />,
-    path: "/dashboard/app-center",
-    allowed: ["admin", "administrador", "institucional", "empresarial"],
-  },
-  {
-    key: "network",
-    label: "Network",
-    icon: <Network className="dashboard-sidebar-icon" data-oid="z-33x83" />,
-    path: "/dashboard/network",
-    allowed: ["admin", "administrador", "institucional"],
-  },
-  {
-    key: "plantillas",
-    label: "Plantillas",
-    icon: <FileStack className="dashboard-sidebar-icon" data-oid="0vwt0b-" />,
-    path: "/dashboard/plantillas",
-    allowed: ["admin", "administrador", "institucional", "empresarial", "individual"],
+    action: true,
   },
   {
     key: "reportes",
@@ -70,13 +49,6 @@ const sidebarMenu = [
     icon: <FileText className="dashboard-sidebar-icon" data-oid="wzewnea" />,
     path: "/dashboard/reportes",
     allowed: ["admin", "administrador", "institucional", "empresarial"],
-  },
-  {
-    key: "billing",
-    label: "Billing",
-    icon: <Receipt className="dashboard-sidebar-icon" data-oid="ny9b2pu" />,
-    path: "/dashboard/billing",
-    allowed: ["admin", "administrador", "institucional"],
   },
   {
     key: "admin",
@@ -88,8 +60,11 @@ const sidebarMenu = [
 ];
 
 export default function Sidebar({ usuario }: { usuario: Usuario }) {
-  const { sidebarGlobalCollapsed: collapsed, toggleSidebarCollapsed } =
-    useDashboardUI();
+  const {
+    sidebarGlobalCollapsed: collapsed,
+    toggleSidebarCollapsed,
+    toggleToolsSidebar,
+  } = useDashboardUI();
   const pathname = usePathname();
   const router = useRouter();
 
@@ -165,11 +140,18 @@ export default function Sidebar({ usuario }: { usuario: Usuario }) {
       <nav className="flex-1 py-6 px-2 flex flex-col gap-1" data-oid="_fmifu.">
         {filteredMenu.map((item) => {
           const active =
-            pathname === item.path || pathname.startsWith(`${item.path}/`);
+            item.path && (pathname === item.path || pathname.startsWith(`${item.path}/`));
+          const handleClick = () => {
+            if (item.action) {
+              toggleToolsSidebar();
+            } else if (item.path) {
+              router.push(item.path);
+            }
+          };
           return (
             <button
               key={item.key}
-              onClick={() => router.push(item.path)}
+              onClick={handleClick}
               className={`
                 dashboard-sidebar-item group relative
                 ${active ? "active" : ""}

--- a/src/app/dashboard/components/ToolsSidebar.tsx
+++ b/src/app/dashboard/components/ToolsSidebar.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useDashboardUI } from "../ui";
+import type { Usuario } from "@/types/usuario";
+import {
+  Bell,
+  AppWindow,
+  Network,
+  FileStack,
+  Receipt,
+  Search as SearchIcon,
+} from "lucide-react";
+import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
+
+const toolsMenu = [
+  {
+    key: "alertas",
+    label: "Alertas",
+    icon: <Bell className="dashboard-sidebar-icon" />,
+    path: "/dashboard/alertas",
+    allowed: ["admin", "administrador", "institucional", "empresarial", "individual"],
+  },
+  {
+    key: "plantillas",
+    label: "Plantillas",
+    icon: <FileStack className="dashboard-sidebar-icon" />,
+    path: "/dashboard/plantillas",
+    allowed: ["admin", "administrador", "institucional", "empresarial", "individual"],
+  },
+  {
+    key: "network",
+    label: "Network",
+    icon: <Network className="dashboard-sidebar-icon" />,
+    path: "/dashboard/network",
+    allowed: ["admin", "administrador", "institucional"],
+  },
+  {
+    key: "appcenter",
+    label: "App Center",
+    icon: <AppWindow className="dashboard-sidebar-icon" />,
+    path: "/dashboard/app-center",
+    allowed: ["admin", "administrador", "institucional", "empresarial"],
+  },
+  {
+    key: "billing",
+    label: "Billing",
+    icon: <Receipt className="dashboard-sidebar-icon" />,
+    path: "/dashboard/billing",
+    allowed: ["admin", "administrador", "institucional"],
+  },
+];
+
+export default function ToolsSidebar({ usuario }: { usuario: Usuario }) {
+  const { toggleToolsSidebar } = useDashboardUI();
+  const pathname = usePathname();
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+
+  const mainRole = getMainRole(usuario)?.toLowerCase();
+  const tipo = normalizeTipoCuenta(
+    mainRole === "admin" ? "admin" : usuario.tipoCuenta,
+  );
+
+  const filtered = toolsMenu.filter(
+    (i) =>
+      i.allowed.includes(tipo) &&
+      i.label.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  return (
+    <aside className="dashboard-sidebar flex flex-col h-full" data-oid="tools">
+      <div className="p-4 border-b border-[var(--dashboard-border)] flex items-center gap-2">
+        <SearchIcon className="w-4 h-4 text-[var(--dashboard-accent)]" />
+        <input
+          autoFocus
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Buscar..."
+          className="flex-1 bg-transparent focus:outline-none text-sm"
+        />
+        <button
+          onClick={() => toggleToolsSidebar(false)}
+          className="text-xs text-[var(--dashboard-accent)] hover:underline"
+        >
+          Cerrar
+        </button>
+      </div>
+      <nav className="flex-1 overflow-y-auto p-2 flex flex-col gap-1">
+        {filtered.map((item) => {
+          const active =
+            pathname === item.path || pathname.startsWith(`${item.path}/`);
+          return (
+            <button
+              key={item.key}
+              onClick={() => {
+                router.push(item.path);
+                toggleToolsSidebar(false);
+              }}
+              className={`dashboard-sidebar-item relative ${active ? "active" : ""}`}
+            >
+              <div className="flex items-center justify-center w-10 h-10">
+                {item.icon}
+              </div>
+              <span>{item.label}</span>
+            </button>
+          );
+        })}
+        {filtered.length === 0 && (
+          <span className="px-4 py-2 text-sm text-[var(--dashboard-muted)]">No hay resultados</span>
+        )}
+      </nav>
+    </aside>
+  );
+}

--- a/src/app/dashboard/constants.ts
+++ b/src/app/dashboard/constants.ts
@@ -1,4 +1,5 @@
 export const SIDEBAR_GLOBAL_WIDTH = 224;            // px, sidebar global expandido
 export const SIDEBAR_GLOBAL_COLLAPSED_WIDTH = 72;   // px, sidebar global colapsado
 export const SIDEBAR_ALMACENES_WIDTH = 192;         // px, sidebar de almacenes
+export const SIDEBAR_TOOLS_WIDTH = 192;            // px, sidebar herramientas
 export const NAVBAR_HEIGHT = 70;                    // px, navbar superior

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -2,11 +2,13 @@
 import React, { useEffect, useState } from "react";
 import useSession from "@/hooks/useSession";
 import Sidebar from "./components/Sidebar";
+import ToolsSidebar from "./components/ToolsSidebar";
 import NavbarDashboard from "./components/NavbarDashboard";
 import { DashboardUIProvider, useDashboardUI } from "./ui";
 import {
   SIDEBAR_GLOBAL_WIDTH,
   SIDEBAR_GLOBAL_COLLAPSED_WIDTH,
+  SIDEBAR_TOOLS_WIDTH,
   NAVBAR_HEIGHT,
 } from "./constants";
 import { useRouter, usePathname } from "next/navigation";
@@ -17,6 +19,7 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
     fullscreen,
     sidebarGlobalVisible = true,
     sidebarGlobalCollapsed,
+    toolsSidebarVisible,
   } = useDashboardUI();
   const router = useRouter();
   const pathname = usePathname();
@@ -60,6 +63,7 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
       ? SIDEBAR_GLOBAL_COLLAPSED_WIDTH
       : SIDEBAR_GLOBAL_WIDTH
     : 0;
+  const toolsWidth = toolsSidebarVisible ? SIDEBAR_TOOLS_WIDTH : 0;
 
   // Altura del navbar
   const navbarHeight = `${NAVBAR_HEIGHT}px`;
@@ -78,7 +82,10 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
           className="fixed top-0 left-0 right-0 z-40 bg-[var(--dashboard-navbar)] border-b border-[var(--dashboard-border)]"
           style={{
             height: navbarHeight,
-            paddingLeft: !fullscreen && sidebarGlobalVisible ? sidebarWidth : '0',
+            paddingLeft:
+              !fullscreen && sidebarGlobalVisible
+                ? sidebarWidth + toolsWidth
+                : '0',
             transition: 'padding-left 0.3s ease'
           }}
           data-oid="taw.mzt"
@@ -106,12 +113,30 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
         </div>
       )}
 
+      {/* --- SIDEBAR TOOLS --- */}
+      {!fullscreen && toolsSidebarVisible && (
+        <div
+          style={{
+            width: toolsWidth,
+            minWidth: toolsWidth,
+            left: sidebarWidth,
+            top: 0,
+            height: '100vh',
+            paddingTop: isAlmacenDetail ? 0 : navbarHeight,
+          }}
+          className="fixed z-40 border-r border-[var(--dashboard-border)] bg-[var(--dashboard-sidebar)] transition-all duration-300 dashboard-sidebar"
+          data-oid="tools-sidebar"
+        >
+          <ToolsSidebar usuario={usuario} />
+        </div>
+      )}
+
       {/* CONTENIDO PRINCIPAL */}
       <div
         className="flex flex-col min-h-screen transition-all duration-300 w-full"
         style={{
           paddingTop: isAlmacenDetail ? 0 : navbarHeight,
-          paddingLeft: !fullscreen ? sidebarWidth : 0,
+          paddingLeft: !fullscreen ? sidebarWidth + toolsWidth : 0,
           transition: 'padding-left 0.3s ease',
         }}
         data-oid="ou.:qgb"

--- a/src/app/dashboard/ui.tsx
+++ b/src/app/dashboard/ui.tsx
@@ -9,6 +9,8 @@ interface UIState {
   sidebarGlobalCollapsed: boolean;
   toggleSidebarVisible: (v?: boolean) => void;
   toggleSidebarCollapsed: () => void;
+  toolsSidebarVisible: boolean;
+  toggleToolsSidebar: (v?: boolean) => void;
 }
 
 const DashboardUIContext = createContext<UIState>({
@@ -19,6 +21,8 @@ const DashboardUIContext = createContext<UIState>({
   sidebarGlobalCollapsed: false,
   toggleSidebarVisible: () => {},
   toggleSidebarCollapsed: () => {},
+  toolsSidebarVisible: false,
+  toggleToolsSidebar: () => {},
 });
 
 export function DashboardUIProvider({
@@ -29,6 +33,7 @@ export function DashboardUIProvider({
   const [fullscreen, setFullscreen] = useState(false);
   const [sidebarGlobalCollapsed, setSidebarGlobalCollapsed] = useState(false);
   const [sidebarGlobalVisible, setSidebarGlobalVisible] = useState(true);
+  const [toolsSidebarVisible, setToolsSidebarVisible] = useState(false);
 
   useEffect(() => {
     if (window.innerWidth < 640) setSidebarGlobalVisible(false);
@@ -39,6 +44,8 @@ export function DashboardUIProvider({
   const toggleSidebarCollapsed = () => setSidebarGlobalCollapsed((c) => !c);
   const toggleSidebarVisible = (v?: boolean) =>
     setSidebarGlobalVisible((c) => (typeof v === "boolean" ? v : !c));
+  const toggleToolsSidebar = (v?: boolean) =>
+    setToolsSidebarVisible((c) => (typeof v === "boolean" ? v : !c));
 
   return (
     <DashboardUIContext.Provider
@@ -50,6 +57,8 @@ export function DashboardUIProvider({
         sidebarGlobalCollapsed,
         toggleSidebarVisible,
         toggleSidebarCollapsed,
+        toolsSidebarVisible,
+        toggleToolsSidebar,
       }}
       data-oid="juman50"
     >


### PR DESCRIPTION
## Summary
- add Tools sidebar with search and access to alertas, plantillas, network, app center and billing
- reorganize main dashboard menu
- expose tools sidebar width constant and state
- document version 0.2.43 in README
- log changes in changelog

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'clsx', etc.)*

------
