### PR TITLE
Update sidebar styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 0.2.45
+
+- Ajustados los tamaños de iconos y botones en ambos sidebars.
+- Nuevo diseño flotante claro para el sidebar de herramientas.
+- El botón de Dashboard solo se resalta en su ruta.
+- El contenido ahora se desplaza cuando el sidebar de herramientas está abierto.
+
 ## 0.2.44
 
 - Botones de Almacenes integrados en el menú de herramientas.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.44
+0.2.45
 
 ---
 

--- a/src/app/dashboard/components/Sidebar.tsx
+++ b/src/app/dashboard/components/Sidebar.tsx
@@ -142,8 +142,11 @@ export default function Sidebar({ usuario }: { usuario: Usuario }) {
       {/* Menú navegación */}
       <nav className="flex-1 py-6 px-2 flex flex-col gap-1" data-oid="_fmifu.">
         {filteredMenu.map((item) => {
-          const active =
-            item.path && (pathname === item.path || pathname.startsWith(`${item.path}/`));
+          const active = item.path
+            ? item.path === "/dashboard"
+              ? pathname === "/dashboard"
+              : pathname === item.path || pathname.startsWith(`${item.path}/`)
+            : false;
           const handleClick = () => {
             if (item.action) {
               toggleToolsSidebar();

--- a/src/app/dashboard/components/ToolsSidebar.tsx
+++ b/src/app/dashboard/components/ToolsSidebar.tsx
@@ -151,10 +151,10 @@ export default function ToolsSidebar({ usuario }: { usuario: Usuario }) {
   return (
     <aside
       ref={ref}
-      className="dashboard-sidebar flex flex-col h-full"
+      className="tools-sidebar flex flex-col h-full"
       data-oid="tools"
     >
-      <div className="p-4 border-b border-[var(--dashboard-border)] flex items-center gap-2">
+      <div className="p-4 border-b border-gray-200 flex items-center gap-2">
         <SearchIcon className="w-4 h-4 text-[var(--dashboard-accent)]" />
         <input
           autoFocus
@@ -170,7 +170,7 @@ export default function ToolsSidebar({ usuario }: { usuario: Usuario }) {
           Cerrar
         </button>
       </div>
-      <nav className="flex-1 overflow-y-auto p-2 flex flex-col gap-1">
+      <nav className="flex-1 overflow-y-auto py-6 flex flex-col items-center gap-4">
         {filtered.map((item) => {
           const active =
             pathname === item.path || pathname.startsWith(`${item.path}/`);
@@ -181,12 +181,12 @@ export default function ToolsSidebar({ usuario }: { usuario: Usuario }) {
                 router.push(item.path);
                 toggleToolsSidebar(false);
               }}
-              className={`dashboard-sidebar-item relative ${active ? "active" : ""}`}
+              className={`tool-item ${active ? "active" : ""}`}
             >
-              <div className="flex items-center justify-center w-10 h-10">
+              <div className="tool-icon flex items-center justify-center">
                 {item.icon}
               </div>
-              <span>{item.label}</span>
+              <span className="text-xs">{item.label}</span>
             </button>
           );
         })}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -84,7 +84,7 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
             height: navbarHeight,
             paddingLeft:
               !fullscreen && sidebarGlobalVisible
-                ? sidebarWidth
+                ? sidebarWidth + toolsWidth
                 : '0',
             transition: 'padding-left 0.3s ease'
           }}
@@ -136,7 +136,7 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
         className="flex flex-col min-h-screen transition-all duration-300 w-full"
         style={{
           paddingTop: isAlmacenDetail ? 0 : navbarHeight,
-          paddingLeft: !fullscreen ? sidebarWidth : 0,
+          paddingLeft: !fullscreen ? sidebarWidth + toolsWidth : 0,
           transition: 'padding-left 0.3s ease',
         }}
         data-oid="ou.:qgb"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -134,7 +134,7 @@ html, body {
   @apply ml-1;
 }
 .dashboard-sidebar-icon {
-  @apply w-5 h-5 mr-2;
+  @apply w-6 h-6 mr-2;
   color: var(--dashboard-accent);
   opacity: 0.93;
 }
@@ -142,6 +142,21 @@ html, body {
   @apply border-t border-[var(--dashboard-border)] mt-auto p-5 flex flex-col items-center;
   color: var(--dashboard-accent);
   background: var(--dashboard-sidebar);
+}
+
+/* --------- TOOLS SIDEBAR --------- */
+.tools-sidebar {
+  @apply bg-white text-gray-700 shadow-xl border border-gray-200 rounded-xl p-4;
+}
+.tool-item {
+  @apply flex flex-col items-center justify-center gap-1 py-2 w-14 h-14 rounded-full transition-colors;
+  @apply hover:bg-gray-200 text-gray-700;
+}
+.tool-item.active {
+  @apply bg-blue-200 text-blue-900;
+}
+.tool-icon {
+  @apply w-6 h-6;
 }
 
 /* --------- NAVBAR --------- */


### PR DESCRIPTION
## Summary
- tweak dashboard button highlighting
- revamp ToolsSidebar with lighter floating style
- adjust button/icon sizes for a cleaner look
- shift layout padding when opening tools sidebar
- document version 0.2.45 in README and changelog

## Testing
- `npm run lint` *(fails: next not found)*

------
