### PR TITLE
Fix toggle Tools sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.2.47
+
+- El botón de **Herramientas** ahora cierra el menú al pulsarlo nuevamente.
+
 ## 0.2.46
 
 - Colores y estilo del sidebar de herramientas ahora coinciden con el dashboard.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.46
+0.2.47
 
 ---
 

--- a/src/app/dashboard/components/Sidebar.tsx
+++ b/src/app/dashboard/components/Sidebar.tsx
@@ -67,6 +67,7 @@ export default function Sidebar({ usuario }: { usuario: Usuario }) {
     sidebarGlobalCollapsed: collapsed,
     toggleSidebarCollapsed,
     toggleToolsSidebar,
+    toolsSidebarVisible,
   } = useDashboardUI();
   const pathname = usePathname();
   const router = useRouter();
@@ -149,7 +150,7 @@ export default function Sidebar({ usuario }: { usuario: Usuario }) {
             : false;
           const handleClick = () => {
             if (item.action) {
-              toggleToolsSidebar();
+              toggleToolsSidebar(!toolsSidebarVisible);
             } else if (item.path) {
               router.push(item.path);
             }


### PR DESCRIPTION
## Summary
- close tools menu when clicking the button again
- update version to 0.2.47
- document changes in changelog

## Testing
- `npm run lint` *(fails: next not found)*

------
