### PR TITLE
0.2.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 0.2.57
+- Permitimos eliminar almacenes junto con sus registros relacionados.
+- Las imágenes editadas ahora reemplazan correctamente la anterior.
+- Añadimos un formulario de operaciones para entradas y salidas.
+- El listado de almacenes se actualiza cada diez segundos.
+- Mostramos el inventario con un estilo más destacado.
 ## 0.2.56
 - Muestra el correo del creador en las tarjetas de almacenes.
 - Añadimos la fecha de última actualización en la vista de un almacén.

--- a/src/app/api/almacenes/[id]/movimientos/route.ts
+++ b/src/app/api/almacenes/[id]/movimientos/route.ts
@@ -1,0 +1,38 @@
+export const runtime = 'nodejs';
+
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@lib/prisma';
+import { getUsuarioFromSession } from '@lib/auth';
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const usuario = await getUsuarioFromSession();
+    if (!usuario) {
+      return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+    }
+    const id = Number(params.id);
+    const { tipo, cantidad, descripcion } = await req.json();
+    if (tipo !== 'entrada' && tipo !== 'salida') {
+      return NextResponse.json({ error: 'Tipo inválido' }, { status: 400 });
+    }
+    const n = Number(cantidad);
+    if (!n || n <= 0) {
+      return NextResponse.json({ error: 'Cantidad inválida' }, { status: 400 });
+    }
+
+    await prisma.movimiento.create({
+      data: {
+        tipo,
+        cantidad: n,
+        descripcion: descripcion || undefined,
+        almacenId: id,
+        usuarioId: usuario.id,
+      },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('POST /api/almacenes/[id]/movimientos', err);
+    return NextResponse.json({ error: 'Error al registrar' }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/almacenes/[id]/editar/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/editar/page.tsx
@@ -35,6 +35,7 @@ export default function EditarAlmacenPage() {
         form.append('nombre', nombre);
         form.append('descripcion', descripcion);
         form.append('imagen', imagen);
+        form.append('prevImagenUrl', imagenUrl);
         body = form;
       } else {
         body = JSON.stringify({ nombre, descripcion, imagenUrl });

--- a/src/app/dashboard/almacenes/operaciones/page.tsx
+++ b/src/app/dashboard/almacenes/operaciones/page.tsx
@@ -1,8 +1,83 @@
 "use client";
+import { useEffect, useState } from "react";
+import { jsonOrNull } from "@lib/http";
+import useSession from "@/hooks/useSession";
+
+interface Almacen { id: number; nombre: string }
+
 export default function OperacionesPage() {
+  const { usuario } = useSession();
+  const [almacenes, setAlmacenes] = useState<Almacen[]>([]);
+  const [almacenId, setAlmacenId] = useState("");
+  const [tipo, setTipo] = useState<"entrada" | "salida">("entrada");
+  const [cantidad, setCantidad] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!usuario) return;
+    fetch(`/api/almacenes?usuarioId=${usuario.id}`)
+      .then(jsonOrNull)
+      .then((d) => setAlmacenes(d.almacenes || []));
+  }, [usuario]);
+
+  const registrar = async () => {
+    if (!almacenId) return alert("Selecciona un almacén");
+    if (!cantidad || cantidad <= 0) return alert("Ingresa una cantidad válida");
+    setLoading(true);
+    const res = await fetch(`/api/almacenes/${almacenId}/movimientos`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tipo, cantidad }),
+    });
+    const data = await jsonOrNull(res);
+    setLoading(false);
+    if (res.ok) {
+      setCantidad(0);
+      alert("Movimiento registrado");
+    } else {
+      alert(data.error || "Error al registrar");
+    }
+  };
+
   return (
-    <div className="p-4">
+    <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Operaciones</h1>
+      <select
+        value={almacenId}
+        onChange={(e) => setAlmacenId(e.target.value)}
+        className="p-2 border rounded-md"
+      >
+        <option value="">Selecciona almacén</option>
+        {almacenes.map((a) => (
+          <option key={a.id} value={a.id}>
+            {a.nombre}
+          </option>
+        ))}
+      </select>
+      <div className="flex items-center gap-2">
+        <select
+          value={tipo}
+          onChange={(e) => setTipo(e.target.value as any)}
+          className="p-2 border rounded-md"
+        >
+          <option value="entrada">Entrada</option>
+          <option value="salida">Salida</option>
+        </select>
+        <input
+          type="number"
+          value={cantidad}
+          onChange={(e) => setCantidad(Number(e.target.value))}
+          className="p-2 border rounded-md w-24"
+          placeholder="Cantidad"
+        />
+        <button
+          onClick={registrar}
+          disabled={loading}
+          className="px-4 py-2 rounded-md bg-[var(--dashboard-accent)] text-white"
+        >
+          {loading ? "Procesando..." : "Registrar"}
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/app/dashboard/almacenes/page.tsx
+++ b/src/app/dashboard/almacenes/page.tsx
@@ -79,6 +79,17 @@ export default function AlmacenesPage() {
   }, [registerCreate]);
 
   useEffect(() => {
+    if (!usuario) return;
+    const interval = setInterval(() => {
+      const fav = filter === "favoritos" ? "&favoritos=1" : "";
+      fetch(`/api/almacenes?usuarioId=${usuario.id}${fav}`)
+        .then(jsonOrNull)
+        .then((data) => setAlmacenes(data.almacenes || []));
+    }, 10000);
+    return () => clearInterval(interval);
+  }, [usuario, filter]);
+
+  useEffect(() => {
     if (loadingUsuario || !usuario || error) return;
     setLoading(true);
     const fav = filter === "favoritos" ? "&favoritos=1" : "";
@@ -181,7 +192,7 @@ export default function AlmacenesPage() {
             <div className="text-xs mt-1 flex gap-2">
               <span>📥 {a.entradas ?? 0}</span>
               <span>📤 {a.salidas ?? 0}</span>
-              <span>📦 {a.inventario ?? 0}</span>
+              <span className="font-semibold text-lg">📦 {a.inventario ?? 0}</span>
             </div>
             <div className="mt-auto flex justify-between items-end">
               <span className="text-xs text-[var(--dashboard-muted)]">
@@ -320,7 +331,7 @@ function SortableAlmacen({
       <div className="flex flex-col flex-1" onClick={onOpen}>
         <div className="flex justify-between items-center">
           <h3 className="font-semibold">{almacen.nombre}</h3>
-          <span className="text-sm">{almacen.inventario ?? 0} u.</span>
+          <span className="text-lg font-semibold text-[var(--dashboard-accent)]">{almacen.inventario ?? 0} u.</span>
         </div>
         {almacen.descripcion && (
           <p className="text-xs text-[var(--dashboard-muted)] mt-1">


### PR DESCRIPTION
## Summary
- permitimos eliminar almacenes con todas sus dependencias
- reescribimos la subida de imágenes al editar almacenes
- añadimos endpoint para registrar movimientos
- completamos la vista de operaciones
- el listado de almacenes se refresca de forma periódica y destacamos la cantidad de unidades

## Testing
- `npm run lint` *(fails: `next` not found)*

------
