### PR TITLE
0.2.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.2.58
+- Guardamos imágenes en base64 cuando no es posible escribir archivos.
 ## 0.2.57
 - Permitimos eliminar almacenes junto con sus registros relacionados.
 - Las imágenes editadas ahora reemplazan correctamente la anterior.

--- a/src/app/api/almacenes/[id]/route.ts
+++ b/src/app/api/almacenes/[id]/route.ts
@@ -115,9 +115,13 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
         }
         const nombreArchivo = `${crypto.randomUUID()}_${archivo.name}`;
         const dir = path.join(process.cwd(), 'public/almacenes');
-        await fs.mkdir(dir, { recursive: true });
-        await fs.writeFile(path.join(dir, nombreArchivo), buffer);
-        imagenUrl = `/almacenes/${nombreArchivo}`;
+        try {
+          await fs.mkdir(dir, { recursive: true });
+          await fs.writeFile(path.join(dir, nombreArchivo), buffer);
+          imagenUrl = `/almacenes/${nombreArchivo}`;
+        } catch {
+          imagenUrl = `data:${archivo.type};base64,${buffer.toString('base64')}`;
+        }
       }
     } else {
       const body = await req.json();

--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -125,9 +125,13 @@ export async function POST(req: NextRequest) {
         }
         const nombreArchivo = `${crypto.randomUUID()}_${archivo.name}`;
         const dir = path.join(process.cwd(), 'public/almacenes');
-        await fs.mkdir(dir, { recursive: true });
-        await fs.writeFile(path.join(dir, nombreArchivo), buffer);
-        imagenUrl = `/almacenes/${nombreArchivo}`;
+        try {
+          await fs.mkdir(dir, { recursive: true });
+          await fs.writeFile(path.join(dir, nombreArchivo), buffer);
+          imagenUrl = `/almacenes/${nombreArchivo}`;
+        } catch {
+          imagenUrl = `data:${archivo.type};base64,${buffer.toString('base64')}`;
+        }
       }
     } else {
       const body = await req.json();


### PR DESCRIPTION
## Summary
- store uploaded images as base64 when the filesystem is read-only

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden fetching Prisma engine)*

------
