### PR TITLE
0.2.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.2.60
+- Reemplazamos alertas por notificaciones emergentes reutilizables.
+- Las eliminaciones ahora solicitan confirmación en pantalla.
+- Añadimos avisos de éxito y error en las operaciones.
 ## 0.2.59
 - Sincronizamos el avatar del usuario en tiempo real.
 - Almacenes guardan sus imágenes en la base de datos.

--- a/src/app/dashboard/almacenes/[id]/editar/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/editar/page.tsx
@@ -2,10 +2,12 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import { useParams, useRouter } from "next/navigation";
+import { useToast } from "@/components/Toast";
 
 export default function EditarAlmacenPage() {
   const { id } = useParams();
   const router = useRouter();
+  const toast = useToast();
   const [nombre, setNombre] = useState("");
   const [descripcion, setDescripcion] = useState("");
   const [imagenUrl, setImagenUrl] = useState("");
@@ -48,12 +50,13 @@ export default function EditarAlmacenPage() {
       });
       const data = await jsonOrNull(res);
       if (res.ok) {
+        toast.show("Almacén actualizado", "success");
         router.push(`/dashboard/almacenes/${id}`);
       } else {
-        alert(data.error || "Error al actualizar");
+        toast.show(data.error || "Error al actualizar", "error");
       }
     } catch {
-      alert("Error de red");
+      toast.show("Error de red", "error");
     } finally {
       setLoading(false);
     }

--- a/src/app/dashboard/almacenes/components/AlmacenDetailNavbar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenDetailNavbar.tsx
@@ -5,11 +5,13 @@ import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import { useDashboardUI } from "../../ui";
 import { NAVBAR_HEIGHT } from "../../constants";
+import { useToast } from "@/components/Toast";
 
 export default function AlmacenDetailNavbar() {
   const router = useRouter();
   const { id } = useParams();
   const { fullscreen } = useDashboardUI();
+  const toast = useToast();
   const [nombre, setNombre] = useState("");
   const [original, setOriginal] = useState("");
   const [guardando, setGuardando] = useState(false);
@@ -38,15 +40,17 @@ export default function AlmacenDetailNavbar() {
     });
     if (res.ok) {
       setOriginal(nombre);
+      toast.show("Almacén actualizado", "success");
     } else {
-      alert("Error al guardar");
+      toast.show("Error al guardar", "error");
     }
     setGuardando(false);
   };
 
   const volver = async () => {
     if (cambios) {
-      if (confirm("¿Guardar cambios antes de salir?")) {
+      const ok = await toast.confirm("¿Guardar cambios antes de salir?");
+      if (ok) {
         await guardar();
       }
     }

--- a/src/app/dashboard/almacenes/nuevo/page.tsx
+++ b/src/app/dashboard/almacenes/nuevo/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { useToast } from "@/components/Toast";
 import { jsonOrNull } from "@lib/http";
 import { useRouter } from "next/navigation";
 
@@ -11,9 +12,10 @@ export default function NuevoAlmacenPage() {
   const [imagen, setImagen] = useState<File | null>(null);
   const [loading, setLoading] = useState(false);
   const router = useRouter();
+  const toast = useToast();
 
   const crear = async () => {
-    if (!nombre.trim()) return alert("Nombre requerido");
+    if (!nombre.trim()) return toast.show("Nombre requerido", "error");
     setLoading(true);
     try {
       const form = new FormData();
@@ -25,12 +27,13 @@ export default function NuevoAlmacenPage() {
       const res = await fetch('/api/almacenes', { method: 'POST', body: form });
       const data = await jsonOrNull(res);
       if (res.ok) {
+        toast.show("Almacén creado", "success");
         router.push(`/dashboard/almacenes/${data.almacen.id}`);
       } else {
-        alert(data.error || "Error al crear");
+        toast.show(data.error || "Error al crear", "error");
       }
     } catch {
-      alert("Error de red");
+      toast.show("Error de red", "error");
     } finally {
       setLoading(false);
     }

--- a/src/app/dashboard/almacenes/operaciones/page.tsx
+++ b/src/app/dashboard/almacenes/operaciones/page.tsx
@@ -2,11 +2,13 @@
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import useSession from "@/hooks/useSession";
+import { useToast } from "@/components/Toast";
 
 interface Almacen { id: number; nombre: string }
 
 export default function OperacionesPage() {
   const { usuario } = useSession();
+  const toast = useToast();
   const [almacenes, setAlmacenes] = useState<Almacen[]>([]);
   const [almacenId, setAlmacenId] = useState("");
   const [tipo, setTipo] = useState<"entrada" | "salida">("entrada");
@@ -21,8 +23,9 @@ export default function OperacionesPage() {
   }, [usuario]);
 
   const registrar = async () => {
-    if (!almacenId) return alert("Selecciona un almacén");
-    if (!cantidad || cantidad <= 0) return alert("Ingresa una cantidad válida");
+    if (!almacenId) return toast.show("Selecciona un almacén", "error");
+    if (!cantidad || cantidad <= 0)
+      return toast.show("Ingresa una cantidad válida", "error");
     setLoading(true);
     const res = await fetch(`/api/almacenes/${almacenId}/movimientos`, {
       method: "POST",
@@ -33,9 +36,9 @@ export default function OperacionesPage() {
     setLoading(false);
     if (res.ok) {
       setCantidad(0);
-      alert("Movimiento registrado");
+      toast.show("Movimiento registrado", "success");
     } else {
-      alert(data.error || "Error al registrar");
+      toast.show(data.error || "Error al registrar", "error");
     }
   };
 

--- a/src/app/dashboard/almacenes/page.tsx
+++ b/src/app/dashboard/almacenes/page.tsx
@@ -9,6 +9,7 @@ import { useAlmacenesUI } from "./ui";
 import type { Usuario } from "@/types/usuario";
 import { getMainRole, hasManagePerms, normalizeTipoCuenta } from "@lib/permisos";
 import useSession from "@/hooks/useSession";
+import { useToast } from "@/components/Toast";
 
 interface Almacen {
   id: number;
@@ -38,6 +39,7 @@ export default function AlmacenesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const router = useRouter();
+  const toast = useToast();
   const { view, filter, registerCreate } = useAlmacenesUI();
   const [dragId, setDragId] = useState<number | null>(null);
 
@@ -66,11 +68,12 @@ export default function AlmacenesPage() {
       const data = await jsonOrNull(res);
       if (res.ok && data.almacen) {
         setAlmacenes((a) => [...a, data.almacen]);
+        toast.show("Almacén creado", "success");
       } else {
-        alert(data.error || "Error al crear");
+        toast.show(data.error || "Error al crear", "error");
       }
     } catch {
-      alert("Error de red");
+      toast.show("Error de red", "error");
     }
   };
 
@@ -101,14 +104,16 @@ export default function AlmacenesPage() {
   }, [usuario, loadingUsuario, filter, error]);
 
   const eliminar = useCallback(async (id: number) => {
-    if (!confirm("¿Eliminar almacén?")) return;
+    const ok = await toast.confirm("¿Eliminar almacén?");
+    if (!ok) return;
     const res = await fetch(`/api/almacenes/${id}`, { method: "DELETE" });
     if (res.ok) {
       setAlmacenes((a) => a.filter((x) => x.id !== id));
+      toast.show("Almacén eliminado", "success");
     } else {
-      alert("Error al eliminar");
+      toast.show("Error al eliminar", "error");
     }
-  }, []);
+  }, [toast]);
 
   const handleDragStart = useCallback((id: number) => {
     setDragId(id);
@@ -241,9 +246,10 @@ export default function AlmacenesPage() {
 function FloatingAdd({ allowCreate }: { allowCreate: boolean }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  const toast = useToast();
 
   const conectar = () => {
-    alert("Función de conexión pendiente");
+    toast.show("Función de conexión pendiente", "info");
   };
 
   return (

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -13,6 +13,7 @@ import {
   NAVBAR_HEIGHT,
 } from "./constants";
 import { useRouter, usePathname } from "next/navigation";
+import { ToastProvider } from "@/components/Toast";
 
 function ProtectedDashboard({ children }: { children: React.ReactNode }) {
   // Añade en tu context esta propiedad si quieres permitir colapsar
@@ -169,7 +170,9 @@ export default function DashboardLayout({
 }) {
   return (
     <DashboardUIProvider data-oid="-kp1hi9">
-      <ProtectedDashboard data-oid="khrpzeo">{children}</ProtectedDashboard>
+      <ToastProvider>
+        <ProtectedDashboard data-oid="khrpzeo">{children}</ProtectedDashboard>
+      </ToastProvider>
     </DashboardUIProvider>
   );
 }

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,97 @@
+import React, { createContext, useContext, useState, ReactNode } from "react";
+
+interface ToastItem {
+  id: number;
+  message: string;
+  type: "success" | "error" | "info" | "confirm";
+  actions?: { label: string; onClick: () => void }[];
+}
+
+interface ToastContextValue {
+  show: (message: string, type?: "success" | "error" | "info") => void;
+  confirm: (message: string) => Promise<boolean>;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const remove = (id: number) =>
+    setToasts((t) => t.filter((toast) => toast.id !== id));
+
+  const show = (
+    message: string,
+    type: "success" | "error" | "info" = "info",
+  ) => {
+    const id = Date.now();
+    setToasts((t) => [...t, { id, message, type }]);
+    setTimeout(() => remove(id), 3000);
+  };
+
+  const confirmToast = (message: string) =>
+    new Promise<boolean>((resolve) => {
+      const id = Date.now();
+      const yes = () => {
+        remove(id);
+        resolve(true);
+      };
+      const no = () => {
+        remove(id);
+        resolve(false);
+      };
+      setToasts((t) => [
+        ...t,
+        {
+          id,
+          message,
+          type: "confirm",
+          actions: [
+            { label: "Sí", onClick: yes },
+            { label: "No", onClick: no },
+          ],
+        },
+      ]);
+    });
+
+  return (
+    <ToastContext.Provider value={{ show, confirm: confirmToast }}>
+      {children}
+      <div className="fixed bottom-4 right-4 space-y-2 z-50">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className={`px-4 py-3 rounded-md text-sm bg-white/10 backdrop-blur ${
+              t.type === "success"
+                ? "text-green-300"
+                : t.type === "error"
+                  ? "text-red-400"
+                  : "text-white"
+            }`}
+          >
+            <p>{t.message}</p>
+            {t.type === "confirm" && t.actions && (
+              <div className="flex gap-2 mt-2">
+                {t.actions.map((a) => (
+                  <button
+                    key={a.label}
+                    onClick={a.onClick}
+                    className="px-2 py-1 bg-white/20 rounded hover:bg-white/30"
+                  >
+                    {a.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used within ToastProvider");
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- implement reusable Toast component
- show toasts for create, update and delete actions
- ask for confirmation when leaving or deleting
- wrap dashboard in ToastProvider

## Testing
- `npm run lint` *(fails: next not found)*

------
