### PR TITLE
0.2.63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.2.63
+- Unificamos la carga de almacenes con un hook que refresca cada diez segundos.
 ## 0.2.62
 - Mostramos un estado vacío con opciones para crear o conectar almacenes.
 ## 0.2.61

--- a/src/hooks/useAlmacenes.ts
+++ b/src/hooks/useAlmacenes.ts
@@ -1,0 +1,40 @@
+import useSWR from 'swr'
+import { jsonOrNull } from '@lib/http'
+
+export interface Almacen {
+  id: number
+  nombre: string
+  descripcion?: string | null
+  imagenUrl?: string | null
+  ultimaActualizacion?: string | null
+  entradas?: number
+  salidas?: number
+  inventario?: number
+  encargado?: string | null
+  correo?: string | null
+  notificaciones?: boolean
+}
+
+const fetcher = (url: string) => fetch(url).then(jsonOrNull)
+
+export default function useAlmacenes(opts?: {
+  usuarioId?: number
+  favoritos?: boolean
+}) {
+  const params = new URLSearchParams()
+  if (opts?.usuarioId) params.set('usuarioId', String(opts.usuarioId))
+  if (opts?.favoritos) params.set('favoritos', '1')
+  const url = `/api/almacenes${params.toString() ? `?${params.toString()}` : ''}`
+
+  const { data, error, isLoading, mutate } = useSWR(url, fetcher, {
+    refreshInterval: 10000,
+    revalidateOnFocus: true,
+  })
+
+  return {
+    almacenes: (data?.almacenes as Almacen[]) || [],
+    loading: isLoading,
+    error,
+    mutate,
+  }
+}


### PR DESCRIPTION
## Summary
- añadimos el hook `useAlmacenes` con recarga automática
- reemplazamos los efectos manuales en la vista de almacenes
- registramos la actualización en el changelog

## Testing
- `npx next lint` *(fails: Need to install the following packages: next@15.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_684547f6d89c8328ad614d1bd7355328