### PR TITLE
0.2.64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## 0.2.63
 - Unificamos la carga de almacenes con un hook que refresca cada diez segundos.
+## 0.2.64
+- Extraemos la lógica de la página de almacenes a un nuevo hook de utilidad.
 ## 0.2.62
 - Mostramos un estado vacío con opciones para crear o conectar almacenes.
 ## 0.2.61

--- a/src/hooks/useAlmacenesLogic.ts
+++ b/src/hooks/useAlmacenesLogic.ts
@@ -1,0 +1,127 @@
+import { useEffect, useState, useCallback } from 'react'
+import { jsonOrNull } from '@lib/http'
+import { useToast } from '@/components/Toast'
+import useSession from '@/hooks/useSession'
+import useAlmacenes, { Almacen } from '@/hooks/useAlmacenes'
+import { getMainRole, normalizeTipoCuenta } from '@lib/permisos'
+import { useAlmacenesUI } from '@/app/dashboard/almacenes/ui'
+
+function arrayMove<T>(arr: T[], from: number, to: number): T[] {
+  const newArr = arr.slice()
+  const [item] = newArr.splice(from, 1)
+  newArr.splice(to, 0, item)
+  return newArr
+}
+
+export default function useAlmacenesLogic() {
+  const allowed = ['admin', 'administrador', 'institucional', 'empresarial', 'individual']
+  const { usuario, loading: loadingUsuario } = useSession()
+  const { filter, registerCreate } = useAlmacenesUI()
+  const toast = useToast()
+
+  const [almacenes, setAlmacenes] = useState<Almacen[]>([])
+  const [error, setError] = useState('')
+  const [dragId, setDragId] = useState<number | null>(null)
+
+  const {
+    almacenes: fetchedAlmacenes,
+    loading: loadingAlmacenes,
+    error: fetchError,
+    mutate,
+  } = useAlmacenes(
+    usuario ? { usuarioId: usuario.id, favoritos: filter === 'favoritos' } : undefined,
+  )
+
+  useEffect(() => {
+    if (loadingUsuario) return
+    if (!usuario) {
+      setError('Debes iniciar sesión')
+      return
+    }
+    const rol = getMainRole(usuario)?.toLowerCase()
+    const tipo = normalizeTipoCuenta(usuario.tipoCuenta)
+    if (rol !== 'admin' && rol !== 'administrador' && !allowed.includes(tipo)) {
+      setError('No autorizado')
+      return
+    }
+    setError('')
+  }, [usuario, loadingUsuario])
+
+  const crearAlmacen = async (nombre: string, descripcion: string) => {
+    try {
+      const res = await fetch('/api/almacenes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nombre, descripcion }),
+      })
+      const data = await jsonOrNull(res)
+      if (res.ok && data.almacen) {
+        mutate()
+        toast.show('Almacén creado', 'success')
+      } else {
+        toast.show(data.error || 'Error al crear', 'error')
+      }
+    } catch {
+      toast.show('Error de red', 'error')
+    }
+  }
+
+  useEffect(() => {
+    registerCreate(crearAlmacen)
+  }, [registerCreate])
+
+  useEffect(() => {
+    setAlmacenes(fetchedAlmacenes)
+  }, [fetchedAlmacenes])
+
+  useEffect(() => {
+    if (fetchError) setError('Error al cargar datos')
+  }, [fetchError])
+
+  const eliminar = useCallback(
+    async (id: number) => {
+      const ok = await toast.confirm('¿Eliminar almacén?')
+      if (!ok) return
+      const res = await fetch(`/api/almacenes/${id}`, { method: 'DELETE' })
+      if (res.ok) {
+        mutate()
+        toast.show('Almacén eliminado', 'success')
+      } else {
+        toast.show('Error al eliminar', 'error')
+      }
+    },
+    [toast],
+  )
+
+  const handleDragStart = useCallback((id: number) => {
+    setDragId(id)
+  }, [])
+
+  const handleDragEnter = useCallback(
+    (id: number) => {
+      if (dragId === null || dragId === id) return
+      const oldIndex = almacenes.findIndex((a) => a.id === dragId)
+      const newIndex = almacenes.findIndex((a) => a.id === id)
+      setAlmacenes((items) => arrayMove(items, oldIndex, newIndex))
+      setDragId(id)
+    },
+    [dragId, almacenes],
+  )
+
+  const handleDragEnd = useCallback(() => {
+    setDragId(null)
+  }, [])
+
+  const loading = loadingAlmacenes || loadingUsuario
+
+  return {
+    usuario,
+    almacenes,
+    loading,
+    error,
+    handleDragStart,
+    handleDragEnter,
+    handleDragEnd,
+    eliminar,
+  }
+}


### PR DESCRIPTION
## Summary
- extraemos la lógica de almacenes a un hook reutilizable
- simplificamos la página de almacenes usando el nuevo hook

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684549feeeb483289d09ee7f0dda7af4