### PR TITLE
0.2.69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.2.69
+- Reemplazamos el emoji de notificaciones por una etiqueta con conteo.
+- El listado de almacenes indica cuántas alertas no se han leído.
 ## 0.2.68
 - Añadimos animaciones al arrastrar almacenes para mejor feedback visual.
 ## 0.2.67

--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -46,7 +46,6 @@ export async function GET(req: NextRequest) {
         },
         notificaciones: {
           where: { leida: false },
-          take: 1,
           select: { id: true },
         },
       },
@@ -74,7 +73,7 @@ export async function GET(req: NextRequest) {
       encargado: a.usuarios[0]?.usuario.nombre ?? null,
       correo: a.usuarios[0]?.usuario.correo ?? null,
       ultimaActualizacion: a.movimientos[0]?.fecha ?? null,
-      notificaciones: a.notificaciones.length > 0,
+      notificaciones: a.notificaciones.length,
       entradas: counts[a.id].entradas,
       salidas: counts[a.id].salidas,
       inventario: counts[a.id].entradas - counts[a.id].salidas,

--- a/src/app/dashboard/almacenes/components/AlmacenesGrid.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenesGrid.tsx
@@ -39,8 +39,13 @@ export default function AlmacenesGrid({ almacenes, onOpen }: { almacenes: Almace
                 {a.encargado || 'Sin encargado'}
                 {a.correo ? ` - ${a.correo}` : ''}
               </span>
-              {a.notificaciones && (
-                <span title="Notificaciones activas" className="text-[var(--dashboard-accent)]">🔔</span>
+              {a.notificaciones && a.notificaciones > 0 && (
+                <span
+                  title={`${a.notificaciones} notificaciones sin leer`}
+                  className="text-xs px-2 py-0.5 rounded-full bg-[var(--dashboard-accent)] text-[#101014] font-semibold"
+                >
+                  {a.notificaciones}
+                </span>
               )}
             </div>
           </div>

--- a/src/hooks/useAlmacenes.ts
+++ b/src/hooks/useAlmacenes.ts
@@ -12,7 +12,7 @@ export interface Almacen {
   inventario?: number
   encargado?: string | null
   correo?: string | null
-  notificaciones?: boolean
+  notificaciones?: number
 }
 
 const fetcher = (url: string) => fetch(url).then(jsonOrNull)


### PR DESCRIPTION
## Summary
- reemplazamos el emoji de alertas por un badge numerado
- contamos las notificaciones sin leer al consultar los almacenes
- mostramos ese conteo en el grid

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npm ci` *(fails: 403 Forbidden)*
- `npm run lint` *(fails with many lint errors)*

------
