### PR TITLE
0.2.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.2.70
+- Guardamos el orden de los almacenes por usuario.
+- Se creó el endpoint `/api/almacenes/orden` para actualizarlo.
 ## 0.2.69
 - Reemplazamos el emoji de notificaciones por una etiqueta con conteo.
 - El listado de almacenes indica cuántas alertas no se han leído.

--- a/src/app/api/almacenes/orden/route.ts
+++ b/src/app/api/almacenes/orden/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@lib/prisma'
+import { getUsuarioFromSession } from '@lib/auth'
+
+export async function GET() {
+  try {
+    const usuario = await getUsuarioFromSession()
+    if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
+    const prefs = usuario.preferencias ? JSON.parse(usuario.preferencias) : {}
+    const orden = Array.isArray(prefs.ordenAlmacenes) ? prefs.ordenAlmacenes : []
+    return NextResponse.json({ orden })
+  } catch (err) {
+    console.error('GET /api/almacenes/orden', err)
+    return NextResponse.json({ error: 'Error' }, { status: 500 })
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const usuario = await getUsuarioFromSession()
+    if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
+    const { ids } = await req.json()
+    if (!Array.isArray(ids) || !ids.every((n) => typeof n === 'number')) {
+      return NextResponse.json({ error: 'Datos inválidos' }, { status: 400 })
+    }
+    const prefs = usuario.preferencias ? JSON.parse(usuario.preferencias) : {}
+    prefs.ordenAlmacenes = ids
+    await prisma.usuario.update({
+      where: { id: usuario.id },
+      data: { preferencias: JSON.stringify(prefs) },
+    })
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    console.error('POST /api/almacenes/orden', err)
+    return NextResponse.json({ error: 'Error' }, { status: 500 })
+  }
+}

--- a/src/hooks/useAlmacenesLogic.ts
+++ b/src/hooks/useAlmacenesLogic.ts
@@ -108,9 +108,18 @@ export default function useAlmacenesLogic() {
     [dragId, almacenes],
   )
 
-  const handleDragEnd = useCallback(() => {
+  const handleDragEnd = useCallback(async () => {
     setDragId(null)
-  }, [])
+    try {
+      await fetch('/api/almacenes/orden', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: almacenes.map((a) => a.id) }),
+      })
+    } catch {
+      // no-op
+    }
+  }, [almacenes])
 
   const moveItem = useCallback(
     (id: number, dir: -1 | 1) => {


### PR DESCRIPTION
## Summary
- guardamos el orden de los almacenes en preferencias
- creamos el endpoint `/api/almacenes/orden`
- enviamos la secuencia al servidor al finalizar el arrastre
- cargamos los almacenes respetando el orden

## Testing
- `npm run lint` *(fails: next not found)*

----