### PR TITLE
0.2.73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.2.73
+- Permitimos scripts de analytics de Vercel en la CSP.
 ## 0.2.72
 - Ordenamos los almacenes por ID para evitar fallos al consultar la lista.
 ## 0.2.71

--- a/lib/securityHeaders.ts
+++ b/lib/securityHeaders.ts
@@ -3,7 +3,7 @@ const dev = process.env.NODE_ENV !== 'production';
 export const ContentSecurityPolicy = dev
   ? `
     default-src 'self' http://localhost:*;
-    script-src 'self' 'unsafe-inline' 'unsafe-eval' vitals.vercel-insights.com http://localhost:*;
+    script-src 'self' 'unsafe-inline' 'unsafe-eval' vitals.vercel-insights.com va.vercel-scripts.com http://localhost:*;
     style-src 'self' 'unsafe-inline';
     img-src 'self' http: https: data: blob:;
     connect-src 'self' http://localhost:* ws://localhost:*;
@@ -11,7 +11,7 @@ export const ContentSecurityPolicy = dev
   `
   : `
     default-src 'self';
-    script-src 'self' 'unsafe-inline' vitals.vercel-insights.com;
+    script-src 'self' 'unsafe-inline' vitals.vercel-insights.com va.vercel-scripts.com;
     style-src 'self' 'unsafe-inline';
     img-src 'self' https: data: blob:;
     connect-src 'self';


### PR DESCRIPTION
## Summary
- allow Vercel analytics scripts in the CSP

## Testing
- `npm test` *(fails: vitest not found)*

------
