### PR TITLE
0.2.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.2.75
+- Añadimos `vitest.config.ts` para resolver alias en las pruebas.
 ## 0.2.73
 - Permitimos scripts de analytics de Vercel en la CSP.
 ## 0.2.72

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+      '@lib': path.resolve(__dirname, 'lib'),
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
- añadimos `vitest.config.ts` para soportar los alias en los tests

## Testing
- `npx vitest run` *(falla: @prisma/client no está inicializado)*

------
