### PR TITLE
0.2.79

### DIFF
--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -2,8 +2,16 @@ import useSWR, { mutate } from 'swr'
 import { jsonOrNull } from '@lib/http'
 import type { Usuario } from '@/types/usuario'
 
-const fetcher = (url: string) =>
-  fetch(url, { credentials: 'include' }).then(jsonOrNull)
+export async function sessionFetcher(url: string) {
+  const res = await fetch(url, { credentials: 'include' })
+  if (res.status === 401) {
+    // 401 indica falta de sesión, no es un error real
+    return { success: false }
+  }
+  return jsonOrNull(res)
+}
+
+const fetcher = sessionFetcher
 
 export function clearSessionCache() {
   mutate('/api/login', undefined, { revalidate: false })

--- a/tests/useSession.test.ts
+++ b/tests/useSession.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import useSession, { sessionFetcher } from '../src/hooks/useSession'
+import useSWR from 'swr'
+
+vi.mock('swr', () => ({
+  default: vi.fn(),
+  mutate: vi.fn(),
+}))
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('useSession', () => {
+  it('devuelve usuario null cuando /api/login responde 401', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response('{"success":false}', { status: 401, headers: { 'Content-Type': 'application/json' } })
+    ))
+    const swr = useSWR as unknown as ReturnType<typeof vi.fn>
+    const data = await sessionFetcher('/api/login')
+    swr.mockReturnValue({ data, isLoading: false })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { usuario } = useSession()
+
+    expect(usuario).toBeNull()
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- detect and silence 401 errors in `useSession`
- document normal 401 response
- add a unit test for 401 behavior

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npm test` *(fails: @prisma/client did not initialize yet)*

------
