### PR TITLE
0.2.82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.2.82
+- Ajusté las rutas de perfil para resolver el alias de `http`.
 ## 0.2.81
 - Mejoré los logs del backend y unifiqué las respuestas de error.
 - Ajusté `/api/perfil` y la ruta de foto para mayor estabilidad.

--- a/src/app/api/perfil/foto/route.ts
+++ b/src/app/api/perfil/foto/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@lib/prisma'
 import { createHash } from 'crypto'
 import * as logger from '@lib/logger'
-import { respuestaError } from '@/lib/http'
+import { respuestaError } from '@lib/http'
 
 // Mime types permitidos para evitar servir archivos no deseados
 const MIME_BY_EXT: Record<string, string> = {

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -5,7 +5,7 @@ import jwt from 'jsonwebtoken';
 import { SESSION_COOKIE, sessionCookieOptions } from '@lib/constants';
 import prisma from '@lib/prisma';
 import * as logger from '@lib/logger'
-import { respuestaError } from '@/lib/http'
+import { respuestaError } from '@lib/http'
 
 const JWT_SECRET = process.env.JWT_SECRET;
 if (!JWT_SECRET) {


### PR DESCRIPTION
## Summary
- ajusté el alias de `http` en las rutas de perfil
- actualicé el changelog

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
