### PR TITLE
0.2.86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.2.86
+- Reemplazamos medidas fijas por variables CSS en el dashboard.
+- Definimos valores con `clamp()` para adaptar el layout.
 ## 0.2.85
 - Implementé redirección automática al login cuando no hay sesión.
 - Ajusté el layout para validar la autenticación en todas las vistas.

--- a/src/app/dashboard/constants.ts
+++ b/src/app/dashboard/constants.ts
@@ -1,5 +1,5 @@
-export const SIDEBAR_GLOBAL_WIDTH = 224;            // px, sidebar global expandido
-export const SIDEBAR_GLOBAL_COLLAPSED_WIDTH = 72;   // px, sidebar global colapsado
-export const SIDEBAR_TOOLS_WIDTH = 176;            // px, sidebar herramientas
-export const SIDEBAR_GAP = 12;                     // px, separacion entre sidebars
-export const NAVBAR_HEIGHT = 70;                    // px, navbar superior
+export const SIDEBAR_GLOBAL_WIDTH = 'var(--sidebar-width)';
+export const SIDEBAR_GLOBAL_COLLAPSED_WIDTH = 'var(--sidebar-collapsed-width)';
+export const SIDEBAR_TOOLS_WIDTH = 'var(--tools-sidebar-width)';
+export const SIDEBAR_GAP = 'var(--sidebar-gap)';
+export const NAVBAR_HEIGHT = 'var(--navbar-height)';

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -60,12 +60,12 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
     ? sidebarGlobalCollapsed
       ? SIDEBAR_GLOBAL_COLLAPSED_WIDTH
       : SIDEBAR_GLOBAL_WIDTH
-    : 0;
-  const toolsWidth = toolsSidebarVisible ? SIDEBAR_TOOLS_WIDTH : 0;
-  const gapWidth = toolsSidebarVisible ? SIDEBAR_GAP : 0;
+    : '0px';
+  const toolsWidth = toolsSidebarVisible ? SIDEBAR_TOOLS_WIDTH : '0px';
+  const gapWidth = toolsSidebarVisible ? SIDEBAR_GAP : '0px';
 
   // Altura del navbar
-  const navbarHeight = `${NAVBAR_HEIGHT}px`;
+  const navbarHeight = NAVBAR_HEIGHT;
   const isAlmacenDetail = /^\/dashboard\/almacenes\/\d+(\/|$)/.test(pathname);
 
   return (
@@ -83,7 +83,7 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
             height: navbarHeight,
             paddingLeft:
               !fullscreen && sidebarGlobalVisible
-                ? sidebarWidth + toolsWidth + gapWidth
+                ? `calc(${sidebarWidth} + ${toolsWidth} + ${gapWidth})`
                 : '0',
             transition: 'padding-left 0.3s ease'
           }}
@@ -102,7 +102,7 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
             left: 0,
             top: 0,
             height: '100vh',
-            transform: isMobile && !sidebarGlobalVisible ? `translateX(-${sidebarWidth}px)` : 'none',
+            transform: isMobile && !sidebarGlobalVisible ? `translateX(calc(-1 * ${sidebarWidth}))` : 'none',
             paddingTop: isAlmacenDetail ? 0 : navbarHeight // Asegura que el contenido del sidebar no se oculte bajo el navbar
           }}
           className={`fixed z-40 border-r border-[var(--dashboard-border)] bg-[var(--dashboard-sidebar)] transition-all duration-300 dashboard-sidebar`}
@@ -118,7 +118,7 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
           style={{
             width: toolsWidth,
             minWidth: toolsWidth,
-            left: sidebarWidth + gapWidth,
+            left: `calc(${sidebarWidth} + ${gapWidth})`,
             top: 0,
             height: '100vh',
             paddingTop: isAlmacenDetail ? 0 : navbarHeight,
@@ -135,7 +135,9 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
         className="flex flex-col min-h-screen transition-all duration-300 w-full"
         style={{
           paddingTop: isAlmacenDetail ? 0 : navbarHeight,
-          paddingLeft: !fullscreen ? sidebarWidth + toolsWidth + gapWidth : 0,
+          paddingLeft: !fullscreen
+            ? `calc(${sidebarWidth} + ${toolsWidth} + ${gapWidth})`
+            : 0,
           transition: 'padding-left 0.3s ease',
         }}
         data-oid="ou.:qgb"
@@ -149,7 +151,7 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
             animate-fade-in
             transition-colors duration-300
           "
-          style={{ minHeight: `calc(100vh - ${isAlmacenDetail ? 0 : NAVBAR_HEIGHT}px)` }}
+          style={{ minHeight: `calc(100vh - ${isAlmacenDetail ? '0px' : navbarHeight})` }}
           data-oid="xvd._xa"
         >
           {children}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,6 +23,13 @@
   --dashboard-glass: rgba(255,255,255,0.11);
   --dashboard-widget-glow: 0 8px 24px 0 #ffe06630;
   --dashboard-widget-resize: #ffe066cc;
+
+  /* Layout variables */
+  --sidebar-width: clamp(12rem, 15vw, 14rem);
+  --sidebar-collapsed-width: clamp(4rem, 5vw, 4.5rem);
+  --tools-sidebar-width: clamp(10rem, 12vw, 11rem);
+  --sidebar-gap: clamp(0.5rem, 1vw, 0.75rem);
+  --navbar-height: clamp(3.5rem, 5vh, 4.375rem);
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
- reemplazamos los valores fijos del dashboard por variables CSS
- definimos variables con `clamp()` en los estilos globales
- usamos `calc()` en el layout para sumar anchos

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
