### PR TITLE
0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.2.103
+- Manejamos casos sin nombre al filtrar materiales para evitar fallos al guardar.
 ## 0.2.102
 - Añadimos la migración para crear `Material` y sus tablas relacionadas.
 ## 0.2.101

--- a/src/app/dashboard/almacenes/[id]/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/page.tsx
@@ -52,7 +52,7 @@ export default function AlmacenPage() {
   }, [id])
 
   const filtrados = materiales
-    .filter((m) => m.producto.toLowerCase().includes(busqueda.toLowerCase()))
+    .filter((m) => (m?.producto ?? "").toLowerCase().includes(busqueda.toLowerCase()))
     .sort((a, b) =>
       orden === "producto" ? a.producto.localeCompare(b.producto) : a.cantidad - b.cantidad,
     );

--- a/src/app/dashboard/almacenes/components/MaterialList.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialList.tsx
@@ -25,7 +25,7 @@ export default function MaterialList({
   onDuplicar,
 }: Props) {
   const filtrados = materiales
-    .filter((m) => m.producto.toLowerCase().includes(busqueda.toLowerCase()))
+    .filter((m) => (m?.producto ?? "").toLowerCase().includes(busqueda.toLowerCase()))
     .sort((a, b) =>
       orden === "producto" ? a.producto.localeCompare(b.producto) : a.cantidad - b.cantidad
     );


### PR DESCRIPTION
Corregí un fallo al filtrar materiales sin nombre definido que provocaba un error al guardar.

## Testing
- `npm test` *(falló: vitest no está disponible)*

------
