### PR TITLE
0.2.107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.2.107
+- Calculamos el inventario como total de materiales y actualizamos las vistas.
 ## 0.2.106
 - Agregamos endpoints para adjuntos de materiales.
 

--- a/src/app/api/almacenes/[id]/route.ts
+++ b/src/app/api/almacenes/[id]/route.ts
@@ -71,6 +71,8 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
       if (r.tipo === "salida") salidas = r._sum.cantidad ?? 0;
     }
 
+    const totalMateriales = await prisma.material.count({ where: { almacenId: id } });
+
     const materiales = await prisma.material.findMany({
       where: { almacenId: id },
       orderBy: { id: 'asc' },
@@ -105,7 +107,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
         ultimaActualizacion: almacen.movimientos[0]?.fecha ?? null,
         entradas,
         salidas,
-        inventario: entradas - salidas,
+        inventario: totalMateriales,
         materiales,
       },
     })

--- a/src/app/dashboard/almacenes/[id]/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/page.tsx
@@ -178,7 +178,7 @@ export default function AlmacenPage() {
       )}
       {typeof almacen.inventario === 'number' && (
         <p className="text-xs text-[var(--dashboard-muted)]">
-          Inventario actual: {almacen.inventario} u.
+          Total de materiales: {almacen.inventario}
         </p>
       )}
 

--- a/src/app/dashboard/almacenes/components/AlmacenesList.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenesList.tsx
@@ -125,7 +125,7 @@ const SortableAlmacen = memo(function SortableAlmacen({
       <div className="flex flex-col flex-1" onClick={onOpen}>
         <div className="flex justify-between items-center gap-2">
           <h3 className="font-semibold">{almacen.nombre}</h3>
-          <span className="text-lg font-semibold text-[var(--dashboard-accent)]">{almacen.inventario ?? 0} u.</span>
+          <span className="text-lg font-semibold text-[var(--dashboard-accent)]">{almacen.inventario ?? 0} mat.</span>
           <span
             className={cn(
               "px-2 py-0.5 rounded-full text-xs",


### PR DESCRIPTION
## Summary
- calculamos los materiales por almacén usando Prisma
- devolvemos el inventario como total de materiales
- actualizamos los textos de inventario en las vistas

## Testing
- `npm test` *(fails: Prisma client not generated)*

------
https://chatgpt.com/codex/tasks/task_e_68466d614eb083288d404c0935d0c8de