### PR TITLE
0.2.108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.2.108
+- Permitimos guardar códigos de barra y QR en materiales.
+- Extendimos el formulario y la API para manejarlos.
 ## 0.2.107
 - Calculamos el inventario como total de materiales y actualizamos las vistas.
 ## 0.2.106

--- a/prisma/migrations/20250610000000_material_codigos/migration.sql
+++ b/prisma/migrations/20250610000000_material_codigos/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Material" ADD COLUMN "codigoBarra" TEXT;
+ALTER TABLE "Material" ADD COLUMN "codigoQR" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -438,6 +438,8 @@ model Material {
   proveedor         String?
   estado            String?
   observaciones     String?
+  codigoBarra       String?
+  codigoQR          String?
   minimo            Float?
   maximo            Float?
   fechaRegistro     DateTime @default(now())

--- a/src/app/api/almacenes/[id]/materiales/route.ts
+++ b/src/app/api/almacenes/[id]/materiales/route.ts
@@ -39,6 +39,8 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
         proveedor: true,
         estado: true,
         observaciones: true,
+        codigoBarra: true,
+        codigoQR: true,
         minimo: true,
         maximo: true,
         fechaRegistro: true,
@@ -83,6 +85,8 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     let observaciones: string | null = null
     let minimo: number | null = null
     let maximo: number | null = null
+    let codigoBarra: string | null = null
+    let codigoQR: string | null = null
 
     if (req.headers.get('content-type')?.includes('multipart/form-data')) {
       const formData = await req.formData()
@@ -98,6 +102,8 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
       observaciones = String(formData.get('observaciones') ?? '').trim() || null
       minimo = formData.get('minimo') ? Number(formData.get('minimo')) : null
       maximo = formData.get('maximo') ? Number(formData.get('maximo')) : null
+      codigoBarra = String(formData.get('codigoBarra') ?? '').trim() || null
+      codigoQR = String(formData.get('codigoQR') ?? '').trim() || null
       const archivo = formData.get('miniatura') as File | null
       if (archivo) {
         const buffer = Buffer.from(await archivo.arrayBuffer())
@@ -119,6 +125,8 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
       observaciones = body.observaciones || null
       minimo = body.minimo ?? null
       maximo = body.maximo ?? null
+      codigoBarra = body.codigoBarra || null
+      codigoQR = body.codigoQR || null
       miniaturaNombre = body.miniaturaNombre ?? null
     }
 
@@ -139,6 +147,8 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
         proveedor,
         estado,
         observaciones,
+        codigoBarra,
+        codigoQR,
         minimo,
         maximo,
         almacenId,

--- a/src/app/api/materiales/[id]/route.ts
+++ b/src/app/api/materiales/[id]/route.ts
@@ -30,6 +30,8 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
         proveedor: true,
         estado: true,
         observaciones: true,
+        codigoBarra: true,
+        codigoQR: true,
         minimo: true,
         maximo: true,
         fechaRegistro: true,
@@ -79,6 +81,8 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
       if (formData.has('proveedor')) datos.proveedor = String(formData.get('proveedor'))
       if (formData.has('estado')) datos.estado = String(formData.get('estado'))
       if (formData.has('observaciones')) datos.observaciones = String(formData.get('observaciones'))
+      if (formData.has('codigoBarra')) datos.codigoBarra = String(formData.get('codigoBarra'))
+      if (formData.has('codigoQR')) datos.codigoQR = String(formData.get('codigoQR'))
       if (formData.has('minimo')) datos.minimo = Number(formData.get('minimo'))
       if (formData.has('maximo')) datos.maximo = Number(formData.get('maximo'))
       const archivo = formData.get('miniatura') as File | null

--- a/src/app/dashboard/almacenes/[id]/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/page.tsx
@@ -86,16 +86,18 @@ export default function AlmacenPage() {
     if (seleccion === null) return;
     const m = materiales[seleccion];
     const form = new FormData();
-    form.append('nombre', m.producto);
-    if (m.descripcion) form.append('descripcion', m.descripcion);
-    form.append('cantidad', String(m.cantidad));
-    if (m.unidad) form.append('unidad', m.unidad);
-    if (m.lote) form.append('lote', m.lote);
-    if (m.fechaCaducidad) form.append('fechaCaducidad', m.fechaCaducidad);
-    if (m.ubicacion) form.append('ubicacion', m.ubicacion);
-    if (m.proveedor) form.append('proveedor', m.proveedor);
-    if (m.estado) form.append('estado', m.estado);
-    if (m.observaciones) form.append('observaciones', m.observaciones);
+   form.append('nombre', m.producto);
+   if (m.descripcion) form.append('descripcion', m.descripcion);
+   form.append('cantidad', String(m.cantidad));
+   if (m.unidad) form.append('unidad', m.unidad);
+   if (m.lote) form.append('lote', m.lote);
+   if (m.fechaCaducidad) form.append('fechaCaducidad', m.fechaCaducidad);
+   if (m.ubicacion) form.append('ubicacion', m.ubicacion);
+   if (m.proveedor) form.append('proveedor', m.proveedor);
+   if (m.estado) form.append('estado', m.estado);
+    if (m.codigoBarra) form.append('codigoBarra', m.codigoBarra);
+    if (m.codigoQR) form.append('codigoQR', m.codigoQR);
+   if (m.observaciones) form.append('observaciones', m.observaciones);
     if (typeof m.minimo === 'number') form.append('minimo', String(m.minimo));
     if (typeof m.maximo === 'number') form.append('maximo', String(m.maximo));
     if (m.miniatura) form.append('miniatura', m.miniatura);
@@ -212,6 +214,8 @@ export default function AlmacenPage() {
                   cantidad: 0,
                   lote: '',
                   unidad: '',
+                  codigoBarra: '',
+                  codigoQR: '',
                   minimo: 0,
                   maximo: 0,
                   miniatura: null,

--- a/src/app/dashboard/almacenes/components/MaterialForm.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialForm.tsx
@@ -121,6 +121,24 @@ export default function MaterialForm({
       </div>
       <div className="grid grid-cols-2 gap-2">
         <div>
+          <label className="text-xs text-[var(--dashboard-muted)]">Código de barras</label>
+          <input
+            value={material.codigoBarra ?? ""}
+            onChange={handle("codigoBarra")}
+            className="dashboard-input w-full mt-1"
+          />
+        </div>
+        <div>
+          <label className="text-xs text-[var(--dashboard-muted)]">Código QR</label>
+          <input
+            value={material.codigoQR ?? ""}
+            onChange={handle("codigoQR")}
+            className="dashboard-input w-full mt-1"
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
           <label className="text-xs text-[var(--dashboard-muted)]">Mínimo</label>
           <input
             type="number"

--- a/src/app/dashboard/almacenes/components/MaterialRow.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialRow.tsx
@@ -12,6 +12,8 @@ export interface Material {
   proveedor?: string;
   estado?: string;
   observaciones?: string;
+  codigoBarra?: string;
+  codigoQR?: string;
   unidad?: string;
   minimo?: number;
   maximo?: number;


### PR DESCRIPTION
## Summary
- permitimos guardar códigos de barra y QR en los materiales
- extendemos el formulario y la API para manejarlos

## Testing
- `npm test` *(fails: vitest not found)*
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68466f0bf03083289f2268d0a2a20b7c