### PR TITLE
0.2.112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.2.110
 - Nuevo endpoint `/api/materiales` para listar materiales de todos los almacenes.
 
+## 0.2.112
+- Evitamos fallos al cargar `lib/auth` sin `JWT_SECRET`.
+
 ## 0.2.111
 - Renombramos `producto` a `nombre` en los formularios y listas.
 - Ajustamos el hook `useMateriales` para enviar y recibir este campo.

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -4,11 +4,10 @@ import prisma from '@lib/prisma'
 import { SESSION_COOKIE } from '@lib/constants'
 
 const JWT_SECRET = process.env.JWT_SECRET
-if (!JWT_SECRET) {
-  throw new Error('JWT_SECRET no definido en el entorno')
-}
 
 export async function getUsuarioFromSession() {
+  if (!JWT_SECRET) return null
+
   const cookieStore = cookies()
   const token = cookieStore.get(SESSION_COOKIE)?.value
 


### PR DESCRIPTION
## Summary
- manejar falta de JWT_SECRET en lib/auth
- actualizar changelog

## Testing
- `npx vitest run` *(fails: @prisma/client did not initialize)*

------
https://chatgpt.com/codex/tasks/task_e_68467cab84408328ad30c0116aa42661