### PR TITLE
0.2.114

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.114
+- Generamos id único al duplicar materiales y seleccionamos la copia.
+- Agregamos "(copia)" al nombre y limpiamos el lote.
+
 ## 0.2.113
 - Ajustamos `MaterialRow` para usar id en lugar de índice.
 - Las vistas de inventario actualizan materiales por id.

--- a/src/app/dashboard/almacenes/[id]/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/page.tsx
@@ -111,8 +111,17 @@ export default function AlmacenPage() {
   const duplicar = () => {
     if (!selectedId) return
     const orig = materiales.find((m) => m.id === selectedId)
-    if (orig)
-      setMateriales((ms) => [...ms, { ...orig, id: crypto.randomUUID(), dbId: undefined }])
+    if (orig) {
+      const copia = {
+        ...orig,
+        id: crypto.randomUUID(),
+        dbId: undefined,
+        nombre: `${orig.nombre} (copia)`,
+        lote: '',
+      }
+      setMateriales((ms) => [...ms, copia])
+      setSelectedId(copia.id)
+    }
   };
 
   const loadingTotal = loading || loadingMateriales

--- a/src/app/dashboard/almacenes/inventario/page.tsx
+++ b/src/app/dashboard/almacenes/inventario/page.tsx
@@ -38,7 +38,16 @@ export default function InventarioPage() {
   const duplicar = () => {
     if (!selectedId) return;
     const m = materiales.find((mat) => mat.id === selectedId);
-    if (m) setMateriales((ms) => [...ms, { ...m, id: crypto.randomUUID() }]);
+    if (m) {
+      const nuevo = {
+        ...m,
+        id: crypto.randomUUID(),
+        nombre: `${m.nombre} (copia)`,
+        lote: "",
+      };
+      setMateriales((ms) => [...ms, nuevo]);
+      setSelectedId(nuevo.id);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- generar id único y seleccionar material copiado automáticamente
- añadir "(copia)" al nombre al duplicar y limpiar lote

## Testing
- `npm test` *(fails: vitest not found)*

------
