### PR TITLE
0.2.117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.2.116
 - Al crear o duplicar un material se selecciona automáticamente para editarlo.
 
+## 0.2.117
+- Evitamos actualizaciones repetidas al sincronizar los almacenes.
+
 ## 0.2.114
 - Generamos id único al duplicar materiales y seleccionamos la copia.
 - Agregamos "(copia)" al nombre y limpiamos el lote.

--- a/src/hooks/useAlmacenesLogic.ts
+++ b/src/hooks/useAlmacenesLogic.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { jsonOrNull } from '@lib/http'
 import { useToast } from '@/components/Toast'
 import useSession from '@/hooks/useSession'
@@ -23,6 +23,7 @@ export default function useAlmacenesLogic() {
   const [error, setError] = useState('')
   const [dragId, setDragId] = useState<number | null>(null)
   const [favoritos, setFavoritos] = useState<number[]>([])
+  const prevAlmacenes = useRef<Almacen[]>([])
 
   const {
     almacenes: fetchedAlmacenes,
@@ -72,7 +73,10 @@ export default function useAlmacenesLogic() {
   }, [registerCreate])
 
   useEffect(() => {
-    setAlmacenes(fetchedAlmacenes)
+    if (prevAlmacenes.current !== fetchedAlmacenes) {
+      prevAlmacenes.current = fetchedAlmacenes
+      setAlmacenes(fetchedAlmacenes)
+    }
   }, [fetchedAlmacenes])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- prevent repeated updates when syncing warehouses
- keep `useAlmacenesLogic` state stable

## Testing
- `npm test` *(fails: vitest not found)*

------
