### PR TITLE
0.2.119

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ## 0.2.118
 - Cerramos la cámara al salir de la página de escaneo.
 
+## 0.2.119
+- Leemos las cookies desde la petición para evitar fallos de sesión.
+
 ## 0.2.114
 - Generamos id único al duplicar materiales y seleccionamos la copia.
 - Agregamos "(copia)" al nombre y limpiamos el lote.

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,14 +1,14 @@
-import { cookies } from 'next/headers'
+import { cookies, type RequestCookies } from 'next/headers'
 import jwt from 'jsonwebtoken'
 import prisma from '@lib/prisma'
 import { SESSION_COOKIE } from '@lib/constants'
 
 const JWT_SECRET = process.env.JWT_SECRET
 
-export async function getUsuarioFromSession() {
+export async function getUsuarioFromSession(req?: { cookies: RequestCookies }) {
   if (!JWT_SECRET) return null
 
-  const cookieStore = cookies()
+  const cookieStore = req?.cookies ?? cookies()
   const token = cookieStore.get(SESSION_COOKIE)?.value
 
   if (!token) return null

--- a/src/app/api/almacenes/[id]/materiales/route.ts
+++ b/src/app/api/almacenes/[id]/materiales/route.ts
@@ -9,7 +9,7 @@ import * as logger from '@lib/logger'
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const usuario = await getUsuarioFromSession()
+    const usuario = await getUsuarioFromSession(req)
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     const almacenId = Number(params.id)
     if (Number.isNaN(almacenId)) {
@@ -57,7 +57,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const usuario = await getUsuarioFromSession()
+    const usuario = await getUsuarioFromSession(req)
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     const almacenId = Number(params.id)
     if (Number.isNaN(almacenId)) {

--- a/src/app/api/almacenes/[id]/movimientos/route.ts
+++ b/src/app/api/almacenes/[id]/movimientos/route.ts
@@ -8,7 +8,7 @@ import * as logger from '@lib/logger'
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const usuario = await getUsuarioFromSession();
+    const usuario = await getUsuarioFromSession(req);
     if (!usuario) {
       return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
     }

--- a/src/app/api/almacenes/[id]/route.ts
+++ b/src/app/api/almacenes/[id]/route.ts
@@ -19,7 +19,7 @@ const IMAGE_TYPES = [
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const usuario = await getUsuarioFromSession();
+    const usuario = await getUsuarioFromSession(req);
     if (!usuario) {
       return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
     }
@@ -119,7 +119,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
 
 export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const usuario = await getUsuarioFromSession();
+    const usuario = await getUsuarioFromSession(req);
     if (!usuario) {
       return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
     }
@@ -155,7 +155,7 @@ export async function DELETE(req: NextRequest, { params }: { params: { id: strin
 
 export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const usuario = await getUsuarioFromSession();
+    const usuario = await getUsuarioFromSession(req);
     if (!usuario) {
       return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
     }

--- a/src/app/api/almacenes/orden/route.ts
+++ b/src/app/api/almacenes/orden/route.ts
@@ -18,7 +18,7 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
-    const usuario = await getUsuarioFromSession()
+    const usuario = await getUsuarioFromSession(req)
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     const { ids } = await req.json()
     if (!Array.isArray(ids) || !ids.every((n) => typeof n === 'number')) {

--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -131,7 +131,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const usuario = await getUsuarioFromSession();
+    const usuario = await getUsuarioFromSession(req);
     if (!usuario) {
       return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
     }

--- a/src/app/api/dashboard/layout/route.ts
+++ b/src/app/api/dashboard/layout/route.ts
@@ -17,7 +17,7 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
-    const usuario = await getUsuarioFromSession();
+    const usuario = await getUsuarioFromSession(req);
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
     const data = await req.json();
     const prefs = usuario.preferencias ? JSON.parse(usuario.preferencias) : {};

--- a/src/app/api/materiales/[id]/archivos/[archivoId]/route.ts
+++ b/src/app/api/materiales/[id]/archivos/[archivoId]/route.ts
@@ -17,7 +17,7 @@ const MIME_BY_EXT: Record<string, string> = {
 
 export async function GET(req: NextRequest, { params }: { params: { id: string; archivoId: string } }) {
   try {
-    const usuario = await getUsuarioFromSession()
+    const usuario = await getUsuarioFromSession(req)
     if (!usuario) return new NextResponse('No autenticado', { status: 401 })
     const archivoId = Number(params.archivoId)
     if (Number.isNaN(archivoId)) return new NextResponse('ID inválido', { status: 400 })
@@ -45,7 +45,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string; 
 
 export async function DELETE(req: NextRequest, { params }: { params: { id: string; archivoId: string } }) {
   try {
-    const usuario = await getUsuarioFromSession()
+    const usuario = await getUsuarioFromSession(req)
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     const archivoId = Number(params.archivoId)
     if (Number.isNaN(archivoId)) {

--- a/src/app/api/materiales/[id]/archivos/route.ts
+++ b/src/app/api/materiales/[id]/archivos/route.ts
@@ -9,7 +9,7 @@ import * as logger from '@lib/logger'
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const usuario = await getUsuarioFromSession()
+    const usuario = await getUsuarioFromSession(req)
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     const materialId = Number(params.id)
     if (Number.isNaN(materialId)) {
@@ -44,7 +44,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const usuario = await getUsuarioFromSession()
+    const usuario = await getUsuarioFromSession(req)
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     const materialId = Number(params.id)
     if (Number.isNaN(materialId)) {

--- a/src/app/api/materiales/[id]/historial/route.ts
+++ b/src/app/api/materiales/[id]/historial/route.ts
@@ -8,7 +8,7 @@ import * as logger from '@lib/logger';
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const usuario = await getUsuarioFromSession();
+    const usuario = await getUsuarioFromSession(req);
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
     const id = Number(params.id);
     if (Number.isNaN(id)) {
@@ -36,7 +36,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const usuario = await getUsuarioFromSession();
+    const usuario = await getUsuarioFromSession(req);
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
     const id = Number(params.id);
     if (Number.isNaN(id)) {

--- a/src/app/api/materiales/[id]/route.ts
+++ b/src/app/api/materiales/[id]/route.ts
@@ -9,7 +9,7 @@ import * as logger from '@lib/logger'
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const usuario = await getUsuarioFromSession()
+    const usuario = await getUsuarioFromSession(req)
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     const id = Number(params.id)
     if (Number.isNaN(id)) {
@@ -51,7 +51,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
 
 export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const usuario = await getUsuarioFromSession()
+    const usuario = await getUsuarioFromSession(req)
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     const id = Number(params.id)
     if (Number.isNaN(id)) {
@@ -109,7 +109,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
 
 export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const usuario = await getUsuarioFromSession()
+    const usuario = await getUsuarioFromSession(req)
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     const id = Number(params.id)
     if (Number.isNaN(id)) {

--- a/src/app/api/materiales/route.ts
+++ b/src/app/api/materiales/route.ts
@@ -30,7 +30,7 @@ const MATERIAL_SELECT = {
 
 export async function GET(req: NextRequest) {
   try {
-    const usuario = await getUsuarioFromSession()
+    const usuario = await getUsuarioFromSession(req)
     if (!usuario) {
       return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     }

--- a/src/app/api/pacman/score.ts
+++ b/src/app/api/pacman/score.ts
@@ -4,7 +4,7 @@ import { getUsuarioFromSession } from '@lib/auth'
 
 export async function POST(req: NextRequest) {
   try {
-    const usuario = await getUsuarioFromSession()
+    const usuario = await getUsuarioFromSession(req)
     if (!usuario) return NextResponse.json({ ok: false, error: "No autenticado" }, { status: 401 })
 
     const { score } = await req.json()

--- a/src/app/api/preferences/route.ts
+++ b/src/app/api/preferences/route.ts
@@ -21,7 +21,7 @@ export async function GET() {
 
 export async function PUT(req: NextRequest) {
   try {
-    const usuario = await getUsuarioFromSession();
+    const usuario = await getUsuarioFromSession(req);
     if (!usuario) {
       return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
     }


### PR DESCRIPTION
## Summary
- read cookies from request in `getUsuarioFromSession`
- pass request cookies in API routes
- document the fix in the changelog

## Testing
- `npm test` *(fails: @prisma/client did not initialize)*

------
https://chatgpt.com/codex/tasks/task_e_6846f76e3bd8832899b12841a50a202e