### PR TITLE
0.2.133

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Endpoint `/api/materiales/[id]/movimientos` para crear y listar movimientos.
 - Panel con historial del material en el dashboard.
 
+## 0.2.133
+- Generamos identificadores de materiales usando `crypto.randomUUID` con reserva.
+- Pruebas para el hook `useMateriales` verifican el comportamiento.
+
 ## 0.2.128
 - Oculté los campos de unidad, estado y niveles mínimo y máximo en el formulario de materiales.
 

--- a/src/hooks/useMateriales.ts
+++ b/src/hooks/useMateriales.ts
@@ -1,11 +1,20 @@
 import useSWR from 'swr'
 import { jsonOrNull } from '@lib/http'
 import { useMemo } from 'react'
+import crypto from 'node:crypto'
+import { v4 as uuidv4 } from 'uuid'
 import type { Material } from '@/app/dashboard/almacenes/components/MaterialRow'
 
 const fetcher = (url: string) => fetch(url).then(jsonOrNull)
 
 const EMPTY_MATERIALS: Material[] = []
+
+const genId = () =>
+  globalThis.crypto?.randomUUID
+    ? globalThis.crypto.randomUUID()
+    : typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : uuidv4()
 
 export default function useMateriales(almacenId?: number | string) {
   const id = Number(almacenId)
@@ -74,7 +83,7 @@ export default function useMateriales(almacenId?: number | string) {
   const mats = useMemo(
     () =>
       (data?.materiales as any[] | undefined)?.map((m) => ({
-        id: String(m.id ?? crypto.randomUUID()),
+        id: String(m.id ?? genId()),
         dbId: m.id,
         ...m,
         fechaCaducidad: m.fechaCaducidad?.slice(0, 10) ?? '',

--- a/tests/useMateriales.test.ts
+++ b/tests/useMateriales.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import useMateriales from '../src/hooks/useMateriales'
+import useSWR from 'swr'
+import crypto from 'node:crypto'
+
+vi.mock('react', () => ({
+  useMemo: (fn: any) => fn(),
+}))
+
+vi.mock('swr', () => ({
+  default: vi.fn(),
+}))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useMateriales', () => {
+  it('usa randomUUID del navegador si está disponible', () => {
+    const rand = vi.fn().mockReturnValue('web-id')
+    const originalCrypto = globalThis.crypto
+    Object.defineProperty(globalThis, 'crypto', { value: { randomUUID: rand }, configurable: true })
+
+    const swr = useSWR as unknown as ReturnType<typeof vi.fn>
+    swr.mockReturnValue({
+      data: { materiales: [{ nombre: 'm1' }] },
+      error: null,
+      isLoading: false,
+      mutate: vi.fn(),
+    })
+
+    const { materiales } = useMateriales(1)
+
+    expect(materiales[0].id).toBe('web-id')
+    expect(rand).toHaveBeenCalled()
+    Object.defineProperty(globalThis, 'crypto', { value: originalCrypto, configurable: true })
+  })
+
+  it('usa crypto.randomUUID si no hay UUID global', () => {
+    const originalCrypto = globalThis.crypto
+    Object.defineProperty(globalThis, 'crypto', { value: undefined, configurable: true })
+    const nodeRand = vi.spyOn(crypto, 'randomUUID').mockReturnValue('node-id')
+
+    const swr = useSWR as unknown as ReturnType<typeof vi.fn>
+    swr.mockReturnValue({
+      data: { materiales: [{ nombre: 'm1' }] },
+      error: null,
+      isLoading: false,
+      mutate: vi.fn(),
+    })
+
+    const { materiales } = useMateriales(1)
+
+    expect(materiales[0].id).toBe('node-id')
+    expect(nodeRand).toHaveBeenCalled()
+    Object.defineProperty(globalThis, 'crypto', { value: originalCrypto, configurable: true })
+  })
+})


### PR DESCRIPTION
## Summary
- generamos identificadores usando `crypto.randomUUID` o `uuid`
- cubrimos `useMateriales` con pruebas
- anotamos el cambio en el historial

## Testing
- `npx vitest run tests/useMateriales.test.ts`
- `npx vitest run` *(falla: Cannot find module '.prisma/client/default')*

------
https://chatgpt.com/codex/tasks/task_e_684744ee695c83289f3d5218fa386cad