### PR TITLE
0.2.137

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.137
+- Solucioné el acceso prematuro a `guardar` en la vista de almacén.
+
 ## 0.2.136
 - Implementé `generarUUID` con verificación segura.
 - Reemplacé usos directos de `randomUUID` en las vistas de materiales.

--- a/src/app/dashboard/almacenes/[id]/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/page.tsx
@@ -68,6 +68,25 @@ export default function AlmacenPage() {
 
   const routerNav = useNextRouter()
 
+  const guardar = async () => {
+    if (!selectedId) return
+    const m = materiales.find((mat) => mat.id === selectedId)
+    if (!m) return
+    const res = m.dbId ? await actualizarMaterial(m) : await crear(m)
+    if (res?.error) {
+      toast.show(res.error, 'error')
+      return
+    }
+    toast.show('Guardado', 'success')
+    setDirty(false)
+  };
+
+  const cancelar = () => {
+    mutate()
+    setSelectedId(null)
+    setDirty(false)
+  };
+
   useEffect(() => {
     if (!dirty) return
     let blocked = false
@@ -127,23 +146,6 @@ export default function AlmacenPage() {
     setDirty(true)
   }
 
-  const guardar = async () => {
-    if (!selectedId) return
-    const m = materiales.find((mat) => mat.id === selectedId)
-    if (!m) return
-    const res = m.dbId ? await actualizarMaterial(m) : await crear(m)
-    if (res?.error) {
-      toast.show(res.error, 'error')
-      return
-    }
-    toast.show('Guardado', 'success')
-    setDirty(false)
-  };
-  const cancelar = () => {
-    mutate()
-    setSelectedId(null)
-    setDirty(false)
-  };
   const eliminar = async () => {
     if (!selectedId) return
     const m = materiales.find((mat) => mat.id === selectedId)


### PR DESCRIPTION
## Summary
- solucioné el acceso prematuro a `guardar` moviendo su definición antes del efecto
- actualicé el CHANGELOG

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: packages missing)*

------
