### PR TITLE
0.2.155

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.155
+- Liberamos URLs de imagen en el menú de usuario y en la página de configuración.
+- Evitamos fugas al revocar los object URLs cuando cambian.
+
 ## 0.2.151
 - Eliminamos una migración vacía que interrumpía la generación.
 

--- a/src/app/configuracion/page.tsx
+++ b/src/app/configuracion/page.tsx
@@ -25,6 +25,7 @@ export default function Configuracion() {
   });
   const [foto, setFoto] = useState<File | null>(null);
   const [fotoPreview, setFotoPreview] = useState<string | null>(null);
+  const fotoPreviewRef = useRef<string | null>(null);
   const [cargando, setCargando] = useState(true);
   const [guardando, setGuardando] = useState(false);
   const [mensaje, setMensaje] = useState<{
@@ -50,6 +51,10 @@ export default function Configuracion() {
             nuevaContrasena: "",
           });
           if (data.usuario.fotoPerfilNombre) {
+            if (fotoPreviewRef.current) {
+              URL.revokeObjectURL(fotoPreviewRef.current);
+              fotoPreviewRef.current = null;
+            }
             setFotoPreview(
               apiPath(
                 `/api/perfil/foto?nombre=${encodeURIComponent(
@@ -77,10 +82,23 @@ export default function Configuracion() {
   function handleFotoChange(e: React.ChangeEvent<HTMLInputElement>) {
     if (e.target.files && e.target.files[0]) {
       const file = e.target.files[0];
+      if (fotoPreviewRef.current) {
+        URL.revokeObjectURL(fotoPreviewRef.current);
+      }
+      const url = URL.createObjectURL(file);
+      fotoPreviewRef.current = url;
       setFoto(file);
-      setFotoPreview(URL.createObjectURL(file));
+      setFotoPreview(url);
     }
   }
+
+  useEffect(() => {
+    return () => {
+      if (fotoPreviewRef.current) {
+        URL.revokeObjectURL(fotoPreviewRef.current);
+      }
+    };
+  }, [fotoPreview]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -56,6 +56,7 @@ export default function UserMenu({
 
   // Avatar image url (si existe)
   const [fotoPerfil, setFotoPerfil] = useState<string | null>(null);
+  const fotoPerfilRef = useRef<string | null>(null);
 
   useEffect(() => {
     async function cargarTema() {
@@ -133,21 +134,44 @@ export default function UserMenu({
 
   useEffect(() => {
     if (usuario?.imagen) {
+      if (fotoPerfilRef.current) {
+        URL.revokeObjectURL(fotoPerfilRef.current);
+        fotoPerfilRef.current = null;
+      }
       setFotoPerfil(usuario.imagen);
     } else if (usuario?.correo) {
       fetch(
         apiPath(`/api/perfil/foto?correo=${encodeURIComponent(usuario.correo)}`),
-        { cache: 'no-store', credentials: 'include' },
+        { cache: "no-store", credentials: "include" },
       )
         .then((r) => (r.ok ? r.blob() : null))
         .then((blob) => {
-          if (blob) setFotoPerfil(URL.createObjectURL(blob));
+          if (blob) {
+            if (fotoPerfilRef.current) {
+              URL.revokeObjectURL(fotoPerfilRef.current);
+            }
+            const url = URL.createObjectURL(blob);
+            fotoPerfilRef.current = url;
+            setFotoPerfil(url);
+          }
         })
         .catch(() => {});
     } else {
+      if (fotoPerfilRef.current) {
+        URL.revokeObjectURL(fotoPerfilRef.current);
+        fotoPerfilRef.current = null;
+      }
       setFotoPerfil(null);
     }
   }, [usuario]);
+
+  useEffect(() => {
+    return () => {
+      if (fotoPerfilRef.current) {
+        URL.revokeObjectURL(fotoPerfilRef.current);
+      }
+    };
+  }, []);
 
   const alternarTema = () => {
     setTemaOscuro((prev) => {


### PR DESCRIPTION
## Summary
- guardamos las URLs generadas en refs y las liberamos al cambiar de imagen
- prevenimos fugas de memoria al revocar object URLs en `UserMenu` y `configuracion`

## Testing
- `npx vitest run` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_68489758dfc88328a55db986e29c195c