### PR TITLE
0.2.155

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 ## 0.2.154
 - Añadimos la relación `archivosUnidad` en el modelo `Usuario` para enlazar los archivos de unidad.
 
+## 0.2.155
+- Unificamos las llamadas fetch con apiFetch incluyendo las credenciales.
+
 ## 0.2.150
 - Guardamos correctamente los cambios de la unidad desde el panel de edición.
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -4,3 +4,10 @@ export function apiPath(path: string): string {
   if (!path.startsWith('/')) path = '/' + path;
   return `${BASE_PATH}${path}`;
 }
+
+export function apiFetch(
+  path: string,
+  options: RequestInit = {},
+): Promise<Response> {
+  return fetch(apiPath(path), { credentials: 'include', ...options });
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import useSession, { clearSessionCache } from "@/hooks/useSession";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -55,7 +56,7 @@ export default function LoginPage() {
     setCargando(true);
     try {
       clearSessionCache();
-      const res = await fetch("/api/login", {
+      const res = await apiFetch("/api/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(datos),

--- a/src/app/(auth)/registro/page.tsx
+++ b/src/app/(auth)/registro/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import useSession from "@/hooks/useSession";
@@ -45,7 +46,7 @@ export default function RegistroPage() {
     }
 
     try {
-      const res = await fetch("/api/registro", {
+      const res = await apiFetch("/api/registro", {
         method: "POST",
         body: formData,
       });

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import type { Usuario } from "@/types/usuario";
 import useSession from "@/hooks/useSession";
 import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
@@ -36,7 +37,7 @@ export default function AdminPage() {
   useEffect(() => {
     if (loadingUsuario || !usuario || error) return;
     setLoading(true);
-    fetch("/api/admin")
+    apiFetch("/api/admin")
       .then(jsonOrNull)
       .then((d) => setStats(d.stats || null))
       .catch(() => setError("Error al cargar datos"))

--- a/src/app/dashboard/alertas/page.tsx
+++ b/src/app/dashboard/alertas/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import type { Usuario } from "@/types/usuario";
 import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
 import Spinner from "@/components/Spinner";
@@ -19,7 +20,7 @@ export default function AlertasPage() {
   const [error, setError] = useState("");
 
   useEffect(() => {
-    fetch("/api/login", { credentials: "include" })
+    apiFetch("/api/login")
       .then(jsonOrNull)
       .then((data) => {
         if (!data?.success) throw new Error();
@@ -38,7 +39,7 @@ export default function AlertasPage() {
   useEffect(() => {
     if (!usuario) return;
     setLoading(true);
-    fetch(`/api/alertas?usuarioId=${usuario.id}`)
+    apiFetch(`/api/alertas?usuarioId=${usuario.id}`)
       .then(jsonOrNull)
       .then((data) => setAlertas(data.alertas || []))
       .catch(() => setError("Error al cargar datos"))

--- a/src/app/dashboard/almacenes/nuevo/page.tsx
+++ b/src/app/dashboard/almacenes/nuevo/page.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { useToast } from "@/components/Toast";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import { useRouter } from "next/navigation";
 
 export default function NuevoAlmacenPage() {
@@ -24,7 +25,7 @@ export default function NuevoAlmacenPage() {
       form.append('funciones', funciones);
       form.append('permisosPredeterminados', permisos);
       if (imagen) form.append('imagen', imagen);
-      const res = await fetch('/api/almacenes', { method: 'POST', body: form });
+      const res = await apiFetch('/api/almacenes', { method: 'POST', body: form });
       const data = await jsonOrNull(res);
       if (res.ok) {
         toast.show("Almacén creado", "success");

--- a/src/app/dashboard/app-center/page.tsx
+++ b/src/app/dashboard/app-center/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import type { Usuario } from "@/types/usuario";
 import useSession from "@/hooks/useSession";
 import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
@@ -36,7 +37,7 @@ export default function AppCenterPage() {
   useEffect(() => {
     if (loadingUsuario || !usuario || error) return;
     setLoading(true);
-    fetch("/api/app-center")
+    apiFetch("/api/app-center")
       .then(jsonOrNull)
       .then((d) => setApps(d.apps || []))
       .catch(() => setError("Error al cargar datos"))

--- a/src/app/dashboard/billing/page.tsx
+++ b/src/app/dashboard/billing/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import type { Usuario } from "@/types/usuario";
 import useSession from "@/hooks/useSession";
 import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
@@ -38,7 +39,7 @@ export default function BillingPage() {
   useEffect(() => {
     if (loadingUsuario || !usuario || error) return;
     setLoading(true);
-    fetch("/api/billing")
+    apiFetch("/api/billing")
       .then(jsonOrNull)
       .then((d) => setInvoices(d.invoices || []))
       .catch(() => setError("Error al cargar datos"))

--- a/src/app/dashboard/components/NavbarDashboard.tsx
+++ b/src/app/dashboard/components/NavbarDashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef } from "react";
+import { apiFetch } from "@lib/api";
 import Link from "next/link";
 import {
   Home,
@@ -22,7 +23,7 @@ export default function NavbarDashboard({ usuario }: { usuario: Usuario }) {
     useDashboardUI();
 
   const logout = async (redirectUrl?: string) => {
-    await fetch("/api/login", { method: "DELETE" });
+    await apiFetch("/api/login", { method: "DELETE" });
     if (redirectUrl) window.location.href = redirectUrl;
   };
 

--- a/src/app/dashboard/components/widgets/AlmacenesWidget.tsx
+++ b/src/app/dashboard/components/widgets/AlmacenesWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 
 export default function AlmacenesWidget({ usuario }: { usuario: any }) {
   const [cantidad, setCantidad] = useState<number | null>(null);
@@ -8,7 +9,7 @@ export default function AlmacenesWidget({ usuario }: { usuario: any }) {
 
   useEffect(() => {
     if (!usuario) return;
-    fetch("/api/almacenes")
+    apiFetch("/api/almacenes")
       .then(jsonOrNull)
       .then((d) =>
         setCantidad(Array.isArray(d.almacenes) ? d.almacenes.length : 0),

--- a/src/app/dashboard/components/widgets/GraficaWidget.tsx
+++ b/src/app/dashboard/components/widgets/GraficaWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import Spinner from "@/components/Spinner";
 import {
   Chart as ChartJS,
@@ -26,7 +27,7 @@ export default function GraficaWidget({ usuario }: { usuario: any }) {
   const [metrics, setMetrics] = useState<any>(null);
 
   useEffect(() => {
-    fetch("/api/metrics")
+    apiFetch("/api/metrics")
       .then(jsonOrNull)
       .then(setMetrics)
       .catch(() => setMetrics(null));

--- a/src/app/dashboard/components/widgets/NovedadesWidget.tsx
+++ b/src/app/dashboard/components/widgets/NovedadesWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import Spinner from "@/components/Spinner";
 
 export default function NovedadesWidget({ usuario }: { usuario: any }) {
@@ -13,7 +14,7 @@ export default function NovedadesWidget({ usuario }: { usuario: any }) {
   useEffect(() => {
     if (!usuario) return;
     setLoading(true);
-    fetch("/api/novedades")
+    apiFetch("/api/novedades")
       .then(jsonOrNull)
       .then((d) => setItems(d.novedades || []))
       .catch((e) => setErr(e.message))

--- a/src/app/dashboard/network/page.tsx
+++ b/src/app/dashboard/network/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import type { Usuario } from "@/types/usuario";
 import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
 import Spinner from "@/components/Spinner";
@@ -18,7 +19,7 @@ export default function NetworkPage() {
   const [error, setError] = useState("");
 
   useEffect(() => {
-    fetch("/api/login", { credentials: "include" })
+    apiFetch("/api/login")
       .then(jsonOrNull)
       .then((data) => {
         if (!data?.success) throw new Error();
@@ -34,7 +35,7 @@ export default function NetworkPage() {
   useEffect(() => {
     if (!usuario) return;
     setLoading(true);
-    fetch("/api/network")
+    apiFetch("/api/network")
       .then(jsonOrNull)
       .then((d) => setPeers(d.peers || []))
       .catch(() => setError("Error al cargar datos"))

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import type { Usuario } from "@/types/usuario";
 import useSession from "@/hooks/useSession";
 
@@ -41,7 +42,7 @@ export default function DashboardPage() {
     async function loadWidgets() {
       try {
         const plan = usuario.plan?.nombre || "Free";
-        const res = await fetch("/api/widgets");
+        const res = await apiFetch("/api/widgets");
         const data = await jsonOrNull(res);
 
         const permitidos = data.widgets.filter(
@@ -77,7 +78,7 @@ export default function DashboardPage() {
 
         let saved: { widgets: string[]; layout: Layout[] } | null = null;
         try {
-          const resLayout = await fetch("/api/dashboard/layout");
+          const resLayout = await apiFetch("/api/dashboard/layout");
           if (resLayout.ok) saved = await jsonOrNull(resLayout);
         } catch {}
 
@@ -112,7 +113,7 @@ export default function DashboardPage() {
   useEffect(() => {
     if (!usuario) return;
     const data = { widgets, layout };
-    fetch("/api/dashboard/layout", {
+    apiFetch("/api/dashboard/layout", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data),

--- a/src/app/dashboard/plantillas/page.tsx
+++ b/src/app/dashboard/plantillas/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import type { Usuario } from "@/types/usuario";
 import useSession from "@/hooks/useSession";
 import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
@@ -36,7 +37,7 @@ export default function PlantillasPage() {
   useEffect(() => {
     if (loadingUsuario || !usuario || error) return;
     setLoading(true);
-    fetch("/api/plantillas")
+    apiFetch("/api/plantillas")
       .then(jsonOrNull)
       .then((d) => setPlantillas(d.plantillas || []))
       .catch(() => setError("Error al cargar datos"))

--- a/src/app/dashboard/reportes/page.tsx
+++ b/src/app/dashboard/reportes/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import type { Usuario } from "@/types/usuario";
 import useSession from "@/hooks/useSession";
 import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
@@ -36,7 +37,7 @@ export default function ReportesPage() {
   useEffect(() => {
     if (loadingUsuario || !usuario || error) return;
     setLoading(true);
-    fetch("/api/reportes")
+    apiFetch("/api/reportes")
       .then(jsonOrNull)
       .then((d) => setReportes(d.reportes || []))
       .catch(() => setError("Error al cargar datos"))

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, ReactNode, useRef } from "react";
 import Image from "next/image";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import clsx from "clsx";
 
 // ========================
@@ -178,7 +179,7 @@ function KpiSection() {
 
   useEffect(() => {
     setLoading(true);
-    fetch("/api/metrics")
+    apiFetch("/api/metrics")
       .then(jsonOrNull)
       .then((d) => setData(d || null))
       .catch(() =>

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -19,7 +19,7 @@ import Image from "next/image";
 import clsx from "clsx";
 import { usePathname, useRouter } from "next/navigation";
 import { jsonOrNull } from "@lib/http";
-import { apiPath } from "@lib/api";
+import { apiPath, apiFetch } from "@lib/api";
 import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
 import { clearSessionCache } from "@/hooks/useSession";
 
@@ -62,7 +62,7 @@ export default function UserMenu({
       let temaGuardado = localStorage.getItem("tema");
       if (usuario) {
         try {
-          const res = await fetch("/api/preferences", { credentials: "include" });
+          const res = await apiFetch("/api/preferences");
           if (res.ok) {
             const prefs = await res.json();
             if (prefs.theme) temaGuardado = prefs.theme;
@@ -90,7 +90,7 @@ export default function UserMenu({
   useEffect(() => {
     async function checkAdmin() {
       try {
-        const res = await fetch("/api/login", { credentials: "include" });
+        const res = await apiFetch("/api/login");
         const data = await jsonOrNull(res);
         if (data?.success && data.usuario) {
           const rol = getMainRole(data.usuario)?.toLowerCase();
@@ -157,10 +157,9 @@ export default function UserMenu({
       const tema = nextIsDark ? "dark" : "light";
       localStorage.setItem("tema", tema);
       if (usuario) {
-        fetch("/api/preferences", {
+        apiFetch("/api/preferences", {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          credentials: "include",
           body: JSON.stringify({ theme: tema }),
         }).catch(() => {});
       }
@@ -171,7 +170,7 @@ export default function UserMenu({
   // --- Nuevo logout sin contexto ---
   const cerrarSesion = async () => {
     setOpen(false);
-    await fetch("/api/login", { method: "DELETE" });
+    await apiFetch("/api/login", { method: "DELETE" });
     clearSessionCache();
     router.replace("/login");
   };

--- a/src/hooks/useAlmacenesLogic.ts
+++ b/src/hooks/useAlmacenesLogic.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { jsonOrNull } from '@lib/http'
+import { apiFetch } from '@lib/api'
 import { useToast } from '@/components/Toast'
 import useSession from '@/hooks/useSession'
 import useAlmacenes, { Almacen } from '@/hooks/useAlmacenes'
@@ -51,7 +52,7 @@ export default function useAlmacenesLogic() {
 
   const crearAlmacen = async (nombre: string, descripcion: string) => {
     try {
-      const res = await fetch('/api/almacenes', {
+      const res = await apiFetch('/api/almacenes', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ nombre, descripcion }),
@@ -85,7 +86,7 @@ export default function useAlmacenesLogic() {
 
   useEffect(() => {
     if (!usuario) return
-    fetch('/api/preferences', { credentials: 'include' })
+    apiFetch('/api/preferences')
       .then(jsonOrNull)
       .then((prefs) => {
         if (prefs && Array.isArray(prefs.favoritosAlmacenes)) {
@@ -128,7 +129,7 @@ export default function useAlmacenesLogic() {
   const handleDragEnd = useCallback(async () => {
     setDragId(null)
     try {
-      await fetch('/api/almacenes/orden', {
+      await apiFetch('/api/almacenes/orden', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ids: almacenes.map((a) => a.id) }),
@@ -152,10 +153,9 @@ export default function useAlmacenesLogic() {
     setFavoritos((prev) => {
       const exists = prev.includes(id)
       const updated = exists ? prev.filter((f) => f !== id) : [...prev, id]
-      fetch('/api/preferences', {
+      apiFetch('/api/preferences', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
         body: JSON.stringify({ favoritosAlmacenes: updated }),
       }).catch(() => {})
       return updated


### PR DESCRIPTION
## Summary
- add `apiFetch` helper
- unify API calls to use `apiFetch` with credentials

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
