### PR TITLE
0.2.163

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.2.162
 - Devolvemos 409 cuando la unidad ya existe al crearla o actualizarla.
 
+## 0.2.163
+- Permitimos guardar el código QR proporcionado en las rutas de unidades y lo omitimos si viene vacío.
+
 ## 0.2.161
 - Validamos el ID de unidad antes de eliminarla desde el hook.
 

--- a/src/app/api/materiales/[id]/unidades/[unidadId]/route.ts
+++ b/src/app/api/materiales/[id]/unidades/[unidadId]/route.ts
@@ -114,7 +114,9 @@ export async function PUT(req: NextRequest) {
       proyecto: str(body.proyecto),
       observaciones: str(body.observaciones),
       imagenNombre: str(body.imagenNombre),
+      codigoQR: str(body.codigoQR) ?? undefined,
     }
+    if (data.codigoQR == null) delete data.codigoQR
     if (imagenBuffer !== undefined) data.imagen = imagenBuffer
     try {
       const actualizado = await prisma.materialUnidad.update({

--- a/src/app/api/materiales/[id]/unidades/route.ts
+++ b/src/app/api/materiales/[id]/unidades/route.ts
@@ -87,6 +87,7 @@ export async function POST(req: NextRequest) {
       codigoBarra: str(body.codigoBarra),
       lote: str(body.lote),
       qrGenerado: str(body.qrGenerado),
+      codigoQR: str(body.codigoQR) ?? undefined,
       unidadMedida: str(body.unidadMedida),
       peso: num(body.peso),
       volumen: num(body.volumen),
@@ -114,6 +115,7 @@ export async function POST(req: NextRequest) {
       imagenNombre: str(body.imagenNombre),
       materialId,
     }
+    if (data.codigoQR == null) delete data.codigoQR
     if (imagenBuffer !== undefined) data.imagen = imagenBuffer
     try {
       const creado = await prisma.materialUnidad.create({


### PR DESCRIPTION
## Summary
- guardamos codigoQR en unidades cuando se envía desde el formulario

## Testing
- `npx vitest run` *(fails: needs package installation)*

------
https://chatgpt.com/codex/tasks/task_e_6848bb761870832891545ec38377e4fd