### PR TITLE
0.2.165

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.2.164
 - Eliminamos el cliente Prisma del repo y generamos en postinstall para evitar errores de plataforma.
 
+## 0.2.165
+- Forzamos el remount de formularios al cambiar la selección de material o unidad para evitar errores en React.
+
 ## 0.2.162
 - Devolvemos 409 cuando la unidad ya existe al crearla o actualizarla.
 

--- a/src/app/dashboard/almacenes/[id]/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/page.tsx
@@ -253,6 +253,7 @@ export default function AlmacenPage() {
         <section className="md:w-1/2 p-4 border-r border-white/10 overflow-y-auto">
           {panel === 'material' && (
             <MaterialForm
+              key={selectedId ?? 'new'}
               material={selectedMaterial}
               onChange={(campo, valor) =>
                 selectedId && actualizar(selectedId, campo, valor)
@@ -265,6 +266,7 @@ export default function AlmacenPage() {
           )}
           {panel === 'unidad' && (
             <UnidadForm
+              key={unidadSel?.id ?? 'unidad'}
               unidad={unidadSel}
               onChange={(campo, valor) =>
                 setUnidadSel((d) => (d ? { ...d, [campo]: valor } : d))


### PR DESCRIPTION
## Summary
- force remount of MaterialForm and UnidadForm when selection changes
- document the fix in the changelog

## Testing
- `npm test` *(fails: vitest not found)*

------
