### PR TITLE
0.2.173

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.173
+- Ajustamos la vista de unidades para usar imagenUrl y evitar el valor vacío en src.
+
 ## 0.2.172
 - Prevenimos errores al mostrar la imagen de la unidad.
 

--- a/src/app/dashboard/almacenes/components/UnidadForm.tsx
+++ b/src/app/dashboard/almacenes/components/UnidadForm.tsx
@@ -392,7 +392,7 @@ export default function UnidadForm({ unidad, onChange, onGuardar, onCancelar }: 
             onChange={handleFile('imagen')}
             className="dashboard-input w-full mt-1"
           />
-          {unidad.imagen && (
+          {(unidad.imagen || unidad.imagenUrl) && (
             <div className="mt-2 flex items-start gap-2">
               <img
                 src={
@@ -400,7 +400,7 @@ export default function UnidadForm({ unidad, onChange, onGuardar, onCancelar }: 
                     ? URL.createObjectURL(unidad.imagen)
                     : typeof unidad.imagen === 'string'
                       ? unidad.imagen
-                      : ''
+                      : unidad.imagenUrl ?? undefined
                 }
                 alt="preview"
                 className="w-24 h-24 object-cover rounded"


### PR DESCRIPTION
## Summary
- evitamos valores vacíos al renderizar la imagen de una unidad

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ba79ab548328962166e6a1fe3c57