### PR TITLE
0.2.191

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.191
+- Cerré el contenedor principal en `MaterialForm` para evitar errores de compilación.
+- Eliminé una función sin uso.
+
 ## 0.2.189
 - Ajustamos el historial para abrir respaldos completos.
 - Hicimos más grandes las tarjetas del inventario.

--- a/src/app/dashboard/almacenes/components/MaterialForm.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialForm.tsx
@@ -4,7 +4,6 @@ import { useToast } from "@/components/Toast";
 import ImageModal from "@/components/ImageModal";
 
 const MAX_FILE_MB = 20;
-const isImageFile = (f: File) => f.type.startsWith('image/');
 import type { Material } from "./MaterialRow";
 import MaterialCodes from "./MaterialCodes";
 import { generarUUID } from "@/lib/uuid";
@@ -382,6 +381,7 @@ export default function MaterialForm({
       {preview && (
         <ImageModal src={preview} onClose={() => setPreview(null)} />
       )}
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- corrijo la clausura del formulario de materiales
- elimino funcion sin uso

## Testing
- `npm test` *(fails: vitest not found)*

------
