### PR TITLE
0.2.206

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.206
+- Mostramos el código QR de cada almacén en sus tarjetas.
+
 ## 0.2.205
 - Creamos la migración inicial para los modelos de chat.
 

--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -35,6 +35,7 @@ export async function GET(req: NextRequest) {
         descripcion: true,
         imagenUrl: true,
         imagenNombre: true,
+        codigoUnico: true,
         usuarios: {
           take: 1,
           select: {
@@ -100,6 +101,7 @@ export async function GET(req: NextRequest) {
       nombre: a.nombre,
       descripcion: a.descripcion,
       imagenUrl: a.imagenNombre ? `/api/almacenes/foto?nombre=${encodeURIComponent(a.imagenNombre)}` : a.imagenUrl,
+      codigoUnico: a.codigoUnico,
       encargado: a.usuarios[0]?.usuario.nombre ?? null,
       correo: a.usuarios[0]?.usuario.correo ?? null,
       ultimaActualizacion: a.movimientos[0]?.fecha ?? null,
@@ -214,7 +216,7 @@ export async function POST(req: NextRequest) {
           create: { usuarioId: usuario.id, rolEnAlmacen: 'propietario' },
         },
       },
-      select: { id: true, nombre: true, descripcion: true, imagenNombre: true },
+      select: { id: true, nombre: true, descripcion: true, imagenNombre: true, codigoUnico: true },
     });
 
     const resp = {

--- a/src/app/dashboard/almacenes/components/AlmacenesGrid.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenesGrid.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Image from "next/image";
 import { Star } from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
 import { cn } from "@/lib/utils";
 import type { Almacen } from "@/hooks/useAlmacenes";
 
@@ -83,6 +84,9 @@ export default function AlmacenesGrid({
                 </span>
               )}
             </div>
+          </div>
+          <div className="hidden sm:block ml-auto">
+            <QRCodeSVG value={a.codigoUnico ?? ''} size={56} />
           </div>
         </div>
       ))}

--- a/src/app/dashboard/almacenes/components/AlmacenesList.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenesList.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Image from "next/image";
 import { Pencil, Trash, ChevronUp, ChevronDown, Star } from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
 import { motion } from "framer-motion";
 import { memo, useState } from "react";
 import { cn } from "@/lib/utils";
@@ -153,6 +154,9 @@ const SortableAlmacen = memo(function SortableAlmacen({
         </div>
       </div>
       <div className="flex flex-col items-end ml-2">
+        <div className="mb-2">
+          <QRCodeSVG value={almacen.codigoUnico ?? ''} size={48} />
+        </div>
         <button
           onClick={onToggleFavorito}
           className={cn(

--- a/src/hooks/useAlmacenes.ts
+++ b/src/hooks/useAlmacenes.ts
@@ -13,6 +13,7 @@ export interface Almacen {
   encargado?: string | null
   correo?: string | null
   notificaciones?: number
+  codigoUnico?: string
 }
 
 const fetcher = (url: string) => fetch(url).then(jsonOrNull)


### PR DESCRIPTION
## Summary
- fetch `codigoUnico` for each almacen in the API
- show that code as a QR in grid and list views

## Testing
- `npm test` *(fails: vitest not found)*

------
