### PR TITLE
0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.227
+- Ajustamos permisos en menú y sidebar para mostrar Auditorías a todos.
+- Al crear una auditoría se registra la fecha actual.
 ## 0.2.225
 - Añadimos vista general de auditorías con filtros en tiempo real.
 - Unificamos nombres de objetos al listar auditorías.

--- a/src/app/api/auditorias/route.ts
+++ b/src/app/api/auditorias/route.ts
@@ -58,8 +58,9 @@ export async function POST(req: NextRequest) {
       include: { archivos: true }
     })
     if (!original) return NextResponse.json({ error: 'No encontrado' }, { status: 404 })
-    const { id, archivos, ...data } = original as any
-    const copia = await prisma.reporte.create({ data })
+  const { id, archivos, ...data } = original as any
+  data.fecha = new Date()
+  const copia = await prisma.reporte.create({ data })
     if (archivos && archivos.length) {
       await Promise.all(
         archivos.map(a =>

--- a/src/app/dashboard/components/Sidebar.tsx
+++ b/src/app/dashboard/components/Sidebar.tsx
@@ -52,7 +52,13 @@ const sidebarMenu = [
     label: "Auditorías",
     icon: <FileStack className="dashboard-sidebar-icon" data-oid="audits" />,
     path: "/dashboard/auditorias",
-    allowed: ["admin", "administrador", "institucional", "empresarial"],
+    allowed: [
+      "admin",
+      "administrador",
+      "institucional",
+      "empresarial",
+      "individual",
+    ],
   },
   {
     key: "admin",

--- a/src/app/dashboard/components/ToolsMenu.tsx
+++ b/src/app/dashboard/components/ToolsMenu.tsx
@@ -83,7 +83,13 @@ const toolsMenu = [
     label: "Auditorías",
     icon: <FileStack className="dashboard-sidebar-icon" />,
     path: "/dashboard/auditorias",
-    allowed: ["admin", "administrador", "institucional", "empresarial"],
+    allowed: [
+      "admin",
+      "administrador",
+      "institucional",
+      "empresarial",
+      "individual",
+    ],
   },
   {
     key: "almacen-archivos",


### PR DESCRIPTION
## Summary
- mostramos Auditorías en el menú principal
- habilitamos Auditorías también en el sidebar
- registramos la fecha actual al duplicar reportes

## Testing
- `npm test` *(fails: vitest not found)*

------
