### PR TITLE
0.2.230

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Añadimos buscador y secciones extra al navbar del dashboard.
 - Panel principal ahora permite desplazamiento infinito y widgets superpuestos.
 - Las capas y posiciones se guardan en la base de datos.
+## 0.2.230
+- Panel principal muestra métricas y gráficas del usuario.
+- Movimos la zona de widgets a la nueva sección Pizarra con navbar propio.
 ## 0.2.225
 - Añadimos vista general de auditorías con filtros en tiempo real.
 - Unificamos nombres de objetos al listar auditorías.

--- a/src/app/api/dashboard/resumen/route.ts
+++ b/src/app/api/dashboard/resumen/route.ts
@@ -1,0 +1,20 @@
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import prisma from '@lib/prisma';
+import * as logger from '@lib/logger';
+
+export async function GET() {
+  try {
+    const [almacenes, materiales, unidades, movimientos] = await Promise.all([
+      prisma.almacen.count(),
+      prisma.material.count(),
+      prisma.materialUnidad.count(),
+      prisma.movimiento.count(),
+    ]);
+    return NextResponse.json({ almacenes, materiales, unidades, movimientos });
+  } catch (err) {
+    logger.error('GET /api/dashboard/resumen', err);
+    return NextResponse.json({ error: 'Error' }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/components/Sidebar.tsx
+++ b/src/app/dashboard/components/Sidebar.tsx
@@ -34,6 +34,13 @@ const sidebarMenu = [
     allowed: ["admin", "administrador", "institucional", "empresarial", "individual"],
   },
   {
+    key: "pizarra",
+    label: "Pizarra",
+    icon: <Bell className="dashboard-sidebar-icon" data-oid="piz-ico" />,
+    path: "/dashboard/pizarra",
+    allowed: ["admin", "administrador", "institucional", "empresarial", "individual"],
+  },
+  {
     key: "almacenes",
     label: "Almacenes",
     icon: <Boxes className="dashboard-sidebar-icon" data-oid="fhr-clw" />,

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import useSession from "@/hooks/useSession";
 import Sidebar from "./components/Sidebar";
 import NavbarDashboard from "./components/NavbarDashboard";
+import NavbarPizarra from "./pizarra/components/NavbarPizarra";
 import Spinner from "@/components/Spinner";
 import { DashboardUIProvider, useDashboardUI } from "./ui";
 import {
@@ -67,6 +68,7 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
   // Altura del navbar
   const navbarHeight = NAVBAR_HEIGHT;
   const isAlmacenDetail = /^\/dashboard\/almacenes\/\d+(\/|$)/.test(pathname);
+  const isPizarra = pathname.startsWith('/dashboard/pizarra');
 
   return (
     <div
@@ -87,7 +89,13 @@ function ProtectedDashboard({ children }: { children: React.ReactNode }) {
           }}
           data-oid="taw.mzt"
         >
-          {usuario && <NavbarDashboard usuario={usuario} data-oid="m6qmdem" />}
+          {usuario && (
+            isPizarra ? (
+              <NavbarPizarra />
+            ) : (
+              <NavbarDashboard usuario={usuario} data-oid="m6qmdem" />
+            )
+          )}
         </div>
       )}
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,308 +1,93 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { jsonOrNull } from "@lib/http";
-import { apiFetch } from "@lib/api";
-import type { Usuario } from "@/types/usuario";
 import useSession from "@/hooks/useSession";
-
+import { apiFetch } from "@lib/api";
+import { jsonOrNull } from "@lib/http";
+import Spinner from "@/components/Spinner";
 import dynamic from "next/dynamic";
-import GridLayout, { Layout } from "react-grid-layout";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
 
-type LayoutItem = Layout & { z?: number };
-import "react-grid-layout/css/styles.css";
-import "react-resizable/css/styles.css";
+const Bar = dynamic(() => import("react-chartjs-2").then(m => m.Bar), { ssr: false });
 
-// Tipos
-interface WidgetMeta {
-  key: string;
-  title: string;
-  file: string;
-  category?: string;
-  w?: number;
-  h?: number;
-  minW?: number;
-  minH?: number;
-  plans?: string[];
-}
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
-
-export default function DashboardPage() {
+export default function DashboardHome() {
   const { usuario, loading } = useSession();
+  const [resumen, setResumen] = useState<any>(null);
+  const [metrics, setMetrics] = useState<any>(null);
 
-  const [catalogo, setCatalogo] = useState<WidgetMeta[]>([]);
-  const [widgets, setWidgets] = useState<string[]>([]);
-  const [layout, setLayout] = useState<LayoutItem[]>([]);
-  const [componentes, setComponentes] = useState<{ [key: string]: any }>({});
-  const [errores, setErrores] = useState<{ [key: string]: boolean }>({});
-
-
-  // 2. Cargar catálogo y componentes de widgets
   useEffect(() => {
-    if (!usuario) return;
+    apiFetch("/api/dashboard/resumen")
+      .then(jsonOrNull)
+      .then(setResumen)
+      .catch(() => setResumen(null));
+    apiFetch("/api/metrics")
+      .then(jsonOrNull)
+      .then(setMetrics)
+      .catch(() => setMetrics(null));
+  }, []);
 
-    async function loadWidgets() {
-      try {
-        const plan = usuario.plan?.nombre || "Free";
-        const res = await apiFetch("/api/widgets");
-        const data = await jsonOrNull(res);
-
-        const permitidos = data.widgets.filter(
-          (w: WidgetMeta) => !w.plans || w.plans.includes(plan),
-        );
-        setCatalogo(permitidos);
-
-        const mapa: Record<string, any> = {};
-        permitidos.forEach((widget: WidgetMeta) => {
-          mapa[widget.key] = dynamic(
-            () =>
-              import(`./components/widgets/${widget.file}`).catch(() => {
-                // Si falla la importación, marca error
-                setErrores((prev) => ({ ...prev, [widget.key]: true }));
-                return {
-                  default: () => null,
-                };
-              }),
-            { ssr: false },
-          );
-        });
-        setComponentes(mapa);
-
-        const defaultLayout = permitidos.map((w: WidgetMeta, i: number) => ({
-          i: w.key,
-          x: (i * 2) % 6,
-          y: Math.floor(i / 3) * 2,
-          w: w.w || 2,
-          h: w.h || 2,
-          minW: w.minW || 2,
-          minH: w.minH || 2,
-          z: i + 1,
-        }));
-        let saved: { widgets: string[]; layout: LayoutItem[] } | null = null;
-        try {
-          const resLayout = await apiFetch("/api/dashboard/layout");
-          if (resLayout.ok) saved = await jsonOrNull(resLayout);
-        } catch {}
-
-        if (
-          saved &&
-          Array.isArray(saved.widgets) &&
-          Array.isArray(saved.layout)
-        ) {
-          const validKeys = permitidos.map((w) => w.key);
-          const filteredWidgets = saved.widgets.filter((k) =>
-            validKeys.includes(k),
-          );
-          const filteredLayout = saved.layout.filter((item) =>
-            validKeys.includes(item.i),
-          );
-
-          setLayout(filteredLayout.length ? filteredLayout : defaultLayout);
-          setWidgets(filteredWidgets.length ? filteredWidgets : validKeys);
-        } else {
-          setLayout(defaultLayout);
-          setWidgets(permitidos.map((w: WidgetMeta) => w.key));
-        }
-      } catch (err) {
-        console.error("Error al cargar widgets:", err);
-      }
-    }
-
-    loadWidgets();
-  }, [usuario]);
-
-  // Guardar en DB cada que cambian widgets o layout
-  useEffect(() => {
-    if (!usuario) return;
-    const data = { widgets, layout };
-    apiFetch("/api/dashboard/layout", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(data),
-    }).catch(() => {});
-  }, [widgets, layout, usuario]);
-
-  // Agregar widget
-  const handleAddWidget = (key: string) => {
-    if (widgets.includes(key)) return;
-    const widget = catalogo.find((w) => w.key === key);
-    if (!widget) return;
-
-    const nextY = layout.reduce(
-      (max, item) => Math.max(max, item.y + (item.h || 0)),
-      0,
-    );
-
-    setWidgets([...widgets, key]);
-    const maxZ = layout.reduce((m, it) => Math.max(m, it.z || 0), 0);
-    setLayout([
-      ...layout,
-      {
-        i: key,
-        x: 0,
-        y: nextY,
-        w: widget.w || 2,
-        h: widget.h || 2,
-        minW: widget.minW || 2,
-        minH: widget.minH || 2,
-        z: maxZ + 1,
-      },
-    ]);
-  };
-
-  const bringToFront = (id: string) => {
-    setLayout((prev) => {
-      const maxZ = prev.reduce((m, it) => Math.max(m, it.z || 0), 0);
-      return prev.map((it) =>
-        it.i === id ? { ...it, z: maxZ + 1 } : it,
-      );
-    });
-  };
-
-  // Quitar widget
-  const handleRemoveWidget = (key: string) => {
-    setWidgets(widgets.filter((k) => k !== key));
-    setLayout(layout.filter((item) => item.i !== key));
-    setErrores((prev) => {
-      const { [key]: _, ...rest } = prev;
-      return rest;
-    });
-  };
-
-  // Loading/errores de sesión
-  if (loading) return <div data-oid="_0v3rjj">Cargando usuario...</div>;
+  if (loading)
+    return <div className="p-4" data-oid="home-loading"><Spinner /></div>;
   if (!usuario)
     return (
-      <div data-oid="k1:t11_">
-        Sesión inválida{' '}
-        <a href="/login" data-oid="si54zbn">
-          Iniciar sesión
-        </a>
+      <div className="p-4" data-oid="home-nosession">
+        Sesión inválida <a href="/login">Iniciar sesión</a>
       </div>
     );
 
   return (
-    <div className="min-h-screen p-4 sm:p-8 overflow-auto" data-oid="japsa91">
-      <div
-        className="flex items-center justify-between mb-5"
-        data-oid="zm1.jco"
-      >
-        <h1 className="text-2xl font-bold" data-oid="ulnh9zq">
-          Panel principal
-        </h1>
-        <div className="flex items-center gap-2" data-oid="kuayohc">
-          <select
-            onChange={(e) => handleAddWidget(e.target.value)}
-            value=""
-            data-oid="1cmvbl6"
-          >
-            <option disabled value="" data-oid="mdilp3j">
-              Agregar widget...
-            </option>
-            {catalogo
-              .filter((w) => !widgets.includes(w.key))
-              .map((w) => (
-                <option key={w.key} value={w.key} data-oid="i6tnk:1">
-                  {w.title}
-                </option>
-              ))}
-          </select>
+    <div className="p-4 space-y-6" data-oid="home-root">
+      <h1 className="text-2xl font-bold">Panel principal</h1>
+      {resumen ? (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="p-4 rounded-lg bg-white/5">
+            <span className="block text-sm text-[var(--dashboard-muted)]">Almacenes</span>
+            <span className="text-2xl font-bold">{resumen.almacenes}</span>
+          </div>
+          <div className="p-4 rounded-lg bg-white/5">
+            <span className="block text-sm text-[var(--dashboard-muted)]">Materiales</span>
+            <span className="text-2xl font-bold">{resumen.materiales}</span>
+          </div>
+          <div className="p-4 rounded-lg bg-white/5">
+            <span className="block text-sm text-[var(--dashboard-muted)]">Unidades</span>
+            <span className="text-2xl font-bold">{resumen.unidades}</span>
+          </div>
+          <div className="p-4 rounded-lg bg-white/5">
+            <span className="block text-sm text-[var(--dashboard-muted)]">Movimientos</span>
+            <span className="text-2xl font-bold">{resumen.movimientos}</span>
+          </div>
         </div>
-      </div>
+      ) : (
+        <div className="text-[var(--dashboard-muted)]" data-oid="home-reserr">No disponible</div>
+      )}
 
-      <GridLayout
-        layout={layout}
-        cols={12}
-        rowHeight={95}
-        width={1600}
-        isResizable
-        isDraggable
-        preventCollision={false}
-        compactType={null}
-        allowOverlap
-        autoSize={false}
-        onLayoutChange={(l) =>
-          setLayout((prev) =>
-            l.map((it) => {
-              const found = prev.find((p) => p.i === it.i);
-              return { ...found, ...it } as LayoutItem;
-            }),
-          )
-        }
-        draggableHandle=".dashboard-widget-card"
-        margin={[18, 18]}
-        data-oid="hxrbk.e"
-        style={{ minHeight: "100vh" }}
-      >
-        {widgets.map((key) => {
-          const Widget = componentes[key];
-          const widgetMeta = catalogo.find((w) => w.key === key);
-
-          // No renderiza hasta que esté listo el componente dinámico
-          if (!Widget) {
-            return (
-              <div
-                key={key}
-                className="dashboard-widget-card flex items-center justify-center"
-                style={{ minHeight: 90 }}
-                data-oid="yt4xd_q"
-              >
-                <span className="text-sm text-gray-500" data-oid="puzy-ax">
-                  Cargando widget{" "}
-                  <b data-oid="w85xvu2">{widgetMeta?.title || key}</b>...
-                </span>
-              </div>
-            );
-          }
-
-          // Si hubo error cargando ese widget
-          if (errores[key]) {
-            return (
-              <div
-                key={key}
-                className="dashboard-widget-card flex items-center justify-center bg-red-100 border border-red-300"
-                style={{ minHeight: 90 }}
-                data-oid="0-85dzh"
-              >
-                <span className="text-sm text-red-600" data-oid="wqbhms5">
-                  Widget <b data-oid="9spv7ji">{widgetMeta?.title || key}</b> no
-                  disponible.
-                </span>
-                <button
-                  className="ml-4 text-xs text-red-500 underline"
-                  onClick={() => handleRemoveWidget(key)}
-                  title="Quitar widget problemático"
-                  data-oid="2.9u:_t"
-                >
-                  Quitar
-                </button>
-              </div>
-            );
-          }
-
-          // Si todo bien, renderiza el widget
-          const item = layout.find((l) => l.i === key);
-          return (
-            <div
-              key={key}
-              className="dashboard-widget-card"
-              style={{ zIndex: item?.z || 1 }}
-              onMouseDown={() => bringToFront(key)}
-              data-oid="ldgxhem"
-            >
-              <Widget usuario={usuario} data-oid="c3illgc" />
-              <button
-                onClick={() => handleRemoveWidget(key)}
-                title="Eliminar widget"
-                className="absolute top-2 right-2 text-lg text-gray-400 hover:text-red-600"
-                data-oid="9b3gzg4"
-              >
-                ✕
-              </button>
-            </div>
-          );
-        })}
-      </GridLayout>
+      {metrics && Bar ? (
+        <Bar
+          options={{ responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true } } }}
+          data={{
+            labels: ["Entradas", "Salidas", "Usuarios", "Almacenes"],
+            datasets: [
+              {
+                label: "Total",
+                data: [metrics.entradas, metrics.salidas, metrics.usuarios, metrics.almacenes],
+                backgroundColor: "#fbbf24",
+              },
+            ],
+          }}
+        />
+      ) : (
+        <div className="text-[var(--dashboard-muted)]" data-oid="home-merr">Cargando gráficas...</div>
+      )}
     </div>
   );
 }

--- a/src/app/dashboard/pizarra/components/NavbarPizarra.tsx
+++ b/src/app/dashboard/pizarra/components/NavbarPizarra.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+export default function NavbarPizarra() {
+  return (
+    <header
+      className="dashboard-navbar flex items-center px-8 py-2 justify-between fixed top-0 left-0 right-0 z-20 shadow bg-[var(--dashboard-navbar)]"
+      style={{ minHeight: "70px", width: "100%" }}
+    >
+      <div className="flex gap-4 items-center">
+        <Link
+          href="/dashboard"
+          className="p-3 rounded-lg transition hover:bg-white/15 hover:backdrop-blur-sm focus:bg-white/25 active:bg-white/25"
+        >
+          <ArrowLeft className="w-6 h-6 text-[var(--dashboard-accent)]" />
+        </Link>
+        <span className="font-extrabold text-lg tracking-widest select-none">
+          Pizarra
+        </span>
+      </div>
+    </header>
+  );
+}

--- a/src/app/dashboard/pizarra/page.tsx
+++ b/src/app/dashboard/pizarra/page.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
+import type { Usuario } from "@/types/usuario";
+import useSession from "@/hooks/useSession";
+
+import dynamic from "next/dynamic";
+import GridLayout, { Layout } from "react-grid-layout";
+
+type LayoutItem = Layout & { z?: number };
+import "react-grid-layout/css/styles.css";
+import "react-resizable/css/styles.css";
+
+// Tipos
+interface WidgetMeta {
+  key: string;
+  title: string;
+  file: string;
+  category?: string;
+  w?: number;
+  h?: number;
+  minW?: number;
+  minH?: number;
+  plans?: string[];
+}
+
+
+export default function DashboardPage() {
+  const { usuario, loading } = useSession();
+
+  const [catalogo, setCatalogo] = useState<WidgetMeta[]>([]);
+  const [widgets, setWidgets] = useState<string[]>([]);
+  const [layout, setLayout] = useState<LayoutItem[]>([]);
+  const [componentes, setComponentes] = useState<{ [key: string]: any }>({});
+  const [errores, setErrores] = useState<{ [key: string]: boolean }>({});
+
+
+  // 2. Cargar catálogo y componentes de widgets
+  useEffect(() => {
+    if (!usuario) return;
+
+    async function loadWidgets() {
+      try {
+        const plan = usuario.plan?.nombre || "Free";
+        const res = await apiFetch("/api/widgets");
+        const data = await jsonOrNull(res);
+
+        const permitidos = data.widgets.filter(
+          (w: WidgetMeta) => !w.plans || w.plans.includes(plan),
+        );
+        setCatalogo(permitidos);
+
+        const mapa: Record<string, any> = {};
+        permitidos.forEach((widget: WidgetMeta) => {
+          mapa[widget.key] = dynamic(
+            () =>
+              import(`../components/widgets/${widget.file}`).catch(() => {
+                // Si falla la importación, marca error
+                setErrores((prev) => ({ ...prev, [widget.key]: true }));
+                return {
+                  default: () => null,
+                };
+              }),
+            { ssr: false },
+          );
+        });
+        setComponentes(mapa);
+
+        const defaultLayout = permitidos.map((w: WidgetMeta, i: number) => ({
+          i: w.key,
+          x: (i * 2) % 6,
+          y: Math.floor(i / 3) * 2,
+          w: w.w || 2,
+          h: w.h || 2,
+          minW: w.minW || 2,
+          minH: w.minH || 2,
+          z: i + 1,
+        }));
+        let saved: { widgets: string[]; layout: LayoutItem[] } | null = null;
+        try {
+          const resLayout = await apiFetch("/api/dashboard/layout");
+          if (resLayout.ok) saved = await jsonOrNull(resLayout);
+        } catch {}
+
+        if (
+          saved &&
+          Array.isArray(saved.widgets) &&
+          Array.isArray(saved.layout)
+        ) {
+          const validKeys = permitidos.map((w) => w.key);
+          const filteredWidgets = saved.widgets.filter((k) =>
+            validKeys.includes(k),
+          );
+          const filteredLayout = saved.layout.filter((item) =>
+            validKeys.includes(item.i),
+          );
+
+          setLayout(filteredLayout.length ? filteredLayout : defaultLayout);
+          setWidgets(filteredWidgets.length ? filteredWidgets : validKeys);
+        } else {
+          setLayout(defaultLayout);
+          setWidgets(permitidos.map((w: WidgetMeta) => w.key));
+        }
+      } catch (err) {
+        console.error("Error al cargar widgets:", err);
+      }
+    }
+
+    loadWidgets();
+  }, [usuario]);
+
+  // Guardar en DB cada que cambian widgets o layout
+  useEffect(() => {
+    if (!usuario) return;
+    const data = { widgets, layout };
+    apiFetch("/api/dashboard/layout", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    }).catch(() => {});
+  }, [widgets, layout, usuario]);
+
+  // Agregar widget
+  const handleAddWidget = (key: string) => {
+    if (widgets.includes(key)) return;
+    const widget = catalogo.find((w) => w.key === key);
+    if (!widget) return;
+
+    const nextY = layout.reduce(
+      (max, item) => Math.max(max, item.y + (item.h || 0)),
+      0,
+    );
+
+    setWidgets([...widgets, key]);
+    const maxZ = layout.reduce((m, it) => Math.max(m, it.z || 0), 0);
+    setLayout([
+      ...layout,
+      {
+        i: key,
+        x: 0,
+        y: nextY,
+        w: widget.w || 2,
+        h: widget.h || 2,
+        minW: widget.minW || 2,
+        minH: widget.minH || 2,
+        z: maxZ + 1,
+      },
+    ]);
+  };
+
+  const bringToFront = (id: string) => {
+    setLayout((prev) => {
+      const maxZ = prev.reduce((m, it) => Math.max(m, it.z || 0), 0);
+      return prev.map((it) =>
+        it.i === id ? { ...it, z: maxZ + 1 } : it,
+      );
+    });
+  };
+
+  // Quitar widget
+  const handleRemoveWidget = (key: string) => {
+    setWidgets(widgets.filter((k) => k !== key));
+    setLayout(layout.filter((item) => item.i !== key));
+    setErrores((prev) => {
+      const { [key]: _, ...rest } = prev;
+      return rest;
+    });
+  };
+
+  // Loading/errores de sesión
+  if (loading) return <div data-oid="_0v3rjj">Cargando usuario...</div>;
+  if (!usuario)
+    return (
+      <div data-oid="k1:t11_">
+        Sesión inválida{' '}
+        <a href="/login" data-oid="si54zbn">
+          Iniciar sesión
+        </a>
+      </div>
+    );
+
+  return (
+    <div className="min-h-screen p-4 sm:p-8 overflow-auto" data-oid="japsa91">
+      <div
+        className="flex items-center justify-between mb-5"
+        data-oid="zm1.jco"
+      >
+        <h1 className="text-2xl font-bold" data-oid="ulnh9zq">
+          Pizarra
+        </h1>
+        <div className="flex items-center gap-2" data-oid="kuayohc">
+          <select
+            onChange={(e) => handleAddWidget(e.target.value)}
+            value=""
+            data-oid="1cmvbl6"
+          >
+            <option disabled value="" data-oid="mdilp3j">
+              Agregar widget...
+            </option>
+            {catalogo
+              .filter((w) => !widgets.includes(w.key))
+              .map((w) => (
+                <option key={w.key} value={w.key} data-oid="i6tnk:1">
+                  {w.title}
+                </option>
+              ))}
+          </select>
+        </div>
+      </div>
+
+      <GridLayout
+        layout={layout}
+        cols={12}
+        rowHeight={95}
+        width={1600}
+        isResizable
+        isDraggable
+        preventCollision={false}
+        compactType={null}
+        allowOverlap
+        autoSize={false}
+        onLayoutChange={(l) =>
+          setLayout((prev) =>
+            l.map((it) => {
+              const found = prev.find((p) => p.i === it.i);
+              return { ...found, ...it } as LayoutItem;
+            }),
+          )
+        }
+        draggableHandle=".dashboard-widget-card"
+        margin={[18, 18]}
+        data-oid="hxrbk.e"
+        style={{ minHeight: "100vh" }}
+      >
+        {widgets.map((key) => {
+          const Widget = componentes[key];
+          const widgetMeta = catalogo.find((w) => w.key === key);
+
+          // No renderiza hasta que esté listo el componente dinámico
+          if (!Widget) {
+            return (
+              <div
+                key={key}
+                className="dashboard-widget-card flex items-center justify-center"
+                style={{ minHeight: 90 }}
+                data-oid="yt4xd_q"
+              >
+                <span className="text-sm text-gray-500" data-oid="puzy-ax">
+                  Cargando widget{" "}
+                  <b data-oid="w85xvu2">{widgetMeta?.title || key}</b>...
+                </span>
+              </div>
+            );
+          }
+
+          // Si hubo error cargando ese widget
+          if (errores[key]) {
+            return (
+              <div
+                key={key}
+                className="dashboard-widget-card flex items-center justify-center bg-red-100 border border-red-300"
+                style={{ minHeight: 90 }}
+                data-oid="0-85dzh"
+              >
+                <span className="text-sm text-red-600" data-oid="wqbhms5">
+                  Widget <b data-oid="9spv7ji">{widgetMeta?.title || key}</b> no
+                  disponible.
+                </span>
+                <button
+                  className="ml-4 text-xs text-red-500 underline"
+                  onClick={() => handleRemoveWidget(key)}
+                  title="Quitar widget problemático"
+                  data-oid="2.9u:_t"
+                >
+                  Quitar
+                </button>
+              </div>
+            );
+          }
+
+          // Si todo bien, renderiza el widget
+          const item = layout.find((l) => l.i === key);
+          return (
+            <div
+              key={key}
+              className="dashboard-widget-card"
+              style={{ zIndex: item?.z || 1 }}
+              onMouseDown={() => bringToFront(key)}
+              data-oid="ldgxhem"
+            >
+              <Widget usuario={usuario} data-oid="c3illgc" />
+              <button
+                onClick={() => handleRemoveWidget(key)}
+                title="Eliminar widget"
+                className="absolute top-2 right-2 text-lg text-gray-400 hover:text-red-600"
+                data-oid="9b3gzg4"
+              >
+                ✕
+              </button>
+            </div>
+          );
+        })}
+      </GridLayout>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- reorganize sidebar with new Pizarra entry
- show Pizarra navbar when visiting /dashboard/pizarra
- add analytics panel for dashboard home
- move widgets into /dashboard/pizarra and add its navbar
- expose new `/api/dashboard/resumen` endpoint

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c54152d483289848cf0dd2778a96