### PR TITLE
0.2.231

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.2.231
+- Corregimos la ruta de importación de widgets en la vista de paneles.
 ## 0.2.227
 - Ajustamos permisos en menú y sidebar para mostrar Auditorías a todos.
 - Al crear una auditoría se registra la fecha actual.

--- a/src/app/dashboard/paneles/[id]/page.tsx
+++ b/src/app/dashboard/paneles/[id]/page.tsx
@@ -59,7 +59,7 @@ export default function PanelPage() {
         permitidos.forEach((widget: WidgetMeta) => {
           mapa[widget.key] = dynamic(
             () =>
-              import(`../components/widgets/${widget.file}`).catch(() => {
+              import(`../../components/widgets/${widget.file}`).catch(() => {
                 // Si falla la importación, marca error
                 setErrores((prev) => ({ ...prev, [widget.key]: true }));
                 return {


### PR DESCRIPTION
## Summary
- corrige la ruta de widgets en `paneles/[id]`
- actualiza el changelog

## Testing
- `npm test` *(falla: PrismaClientConstructorValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_6850cac9e2fc83289674a4066cea3d08