### PR TITLE
0.2.234

### DIFF
--- a/Instrucciones2.txt
+++ b/Instrucciones2.txt
@@ -1,17 +1,17 @@
 A. Experiencia de Navegación y Barra Superior (Navbar dedicado de pizarra)
-Modo pantalla completa automático al entrar a una pizarra.
+Modo pantalla completa automático al entrar a una pizarra. (Completado)
 
-Ocultamiento de sidebar y navbar global para enfoque total.
+Ocultamiento de sidebar y navbar global para enfoque total. (Completado)
 
-Barra superior propia de la pizarra (navbar dedicado, sticky y minimalista).
+Barra superior propia de la pizarra (navbar dedicado, sticky y minimalista). (Completado)
 
-Botón “Volver a paneles”: siempre visible a la izquierda para regresar a la lista de pizarras.
+Botón “Volver a paneles”: siempre visible a la izquierda para regresar a la lista de pizarras. (Completado)
 
-Logo mini y nombre editable: muestra logo HoneyLabs reducido y permite editar el nombre de la pizarra en línea.
+Logo mini y nombre editable: muestra logo HoneyLabs reducido y permite editar el nombre de la pizarra en línea. (Completado)
 
-Botón de “Guardar”: permite guardar manualmente, aunque el autosave esté activo.
+Botón de “Guardar”: permite guardar manualmente, aunque el autosave esté activo. (Completado)
 
-Indicador de estado de guardado: muestra “Guardando.../Guardado” en tiempo real.
+Indicador de estado de guardado: muestra “Guardando.../Guardado” en tiempo real. (Completado)
 
 Botón “Exportar”: abre menú para descargar la pizarra (PDF, PNG, SVG, JSON).
 

--- a/src/app/dashboard/paneles/PanelOpsContext.tsx
+++ b/src/app/dashboard/paneles/PanelOpsContext.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { createContext, useContext, useState } from "react";
+
+interface Ops {
+  guardar: () => void;
+  setGuardar: (fn: () => void) => void;
+}
+
+const PanelOpsContext = createContext<Ops>({
+  guardar: () => {},
+  setGuardar: () => {},
+});
+
+export function PanelOpsProvider({ children }: { children: React.ReactNode }) {
+  const [guardarFn, setGuardarFn] = useState<() => void>(() => {});
+  return (
+    <PanelOpsContext.Provider value={{ guardar: guardarFn, setGuardar: setGuardarFn }}>
+      {children}
+    </PanelOpsContext.Provider>
+  );
+}
+
+export function usePanelOps() {
+  return useContext(PanelOpsContext);
+}

--- a/src/app/dashboard/paneles/[id]/layout.tsx
+++ b/src/app/dashboard/paneles/[id]/layout.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { useDashboardUI } from "../../ui";
 import { useRouter } from "next/navigation";
 import PanelDetailNavbar from "../components/PanelDetailNavbar";
+import { PanelOpsProvider } from "../PanelOpsContext";
 import Spinner from "@/components/Spinner";
 import useSession from "@/hooks/useSession";
 
@@ -45,5 +46,9 @@ function ProtectedPanel({ children }: { children: React.ReactNode }) {
 }
 
 export default function PanelLayout({ children }: { children: React.ReactNode }) {
-  return <ProtectedPanel>{children}</ProtectedPanel>;
+  return (
+    <PanelOpsProvider>
+      <ProtectedPanel>{children}</ProtectedPanel>
+    </PanelOpsProvider>
+  );
 }

--- a/src/app/dashboard/paneles/[id]/page.tsx
+++ b/src/app/dashboard/paneles/[id]/page.tsx
@@ -6,6 +6,7 @@ import { apiFetch } from "@lib/api";
 import type { Usuario } from "@/types/usuario";
 import useSession from "@/hooks/useSession";
 import { useParams } from "next/navigation";
+import { usePanelOps } from "../PanelOpsContext";
 
 import dynamic from "next/dynamic";
 import GridLayout, { Layout } from "react-grid-layout";
@@ -38,6 +39,7 @@ export default function PanelPage() {
   const [layout, setLayout] = useState<LayoutItem[]>([]);
   const [componentes, setComponentes] = useState<{ [key: string]: any }>({});
   const [errores, setErrores] = useState<{ [key: string]: boolean }>({});
+  const { setGuardar } = usePanelOps();
 
 
   // 2. Cargar catálogo y componentes de widgets
@@ -114,17 +116,24 @@ export default function PanelPage() {
     loadWidgets();
   }, [usuario, panelId]);
 
-  // Guardar en DB cada que cambian widgets o layout
-  useEffect(() => {
-    if (!usuario) return;
+  const guardar = async () => {
+    if (!usuario || !panelId) return;
     const data = { widgets, layout };
-    if (!panelId) return;
-    apiFetch(`/api/paneles/${panelId}`, {
+    await apiFetch(`/api/paneles/${panelId}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data),
     }).catch(() => {});
-  }, [widgets, layout, usuario, panelId]);
+  };
+
+  // Guardar en DB cada que cambian widgets o layout
+  useEffect(() => {
+    guardar();
+  }, [widgets, layout]);
+
+  useEffect(() => {
+    setGuardar(() => guardar);
+  }, [guardar, setGuardar]);
 
   // Agregar widget
   const handleAddWidget = (key: string) => {

--- a/src/app/dashboard/paneles/components/PanelDetailNavbar.tsx
+++ b/src/app/dashboard/paneles/components/PanelDetailNavbar.tsx
@@ -1,11 +1,44 @@
 "use client";
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
 import useSession from "@/hooks/useSession";
+import { apiFetch } from "@lib/api";
+import { jsonOrNull } from "@lib/http";
+import { usePanelOps } from "../PanelOpsContext";
 
 export default function PanelDetailNavbar() {
   const { usuario } = useSession();
   const plan = usuario?.plan?.nombre || "Free";
+  const params = useParams();
+  const panelId = Array.isArray(params?.id) ? params.id[0] : (params as any)?.id;
+  const [nombre, setNombre] = useState("");
+  const [edit, setEdit] = useState(false);
+  const [saving, setSaving] = useState<"idle" | "saving" | "saved">("idle");
+  const { guardar } = usePanelOps();
+
+  useEffect(() => {
+    if (!panelId) return;
+    apiFetch(`/api/paneles/${panelId}`)
+      .then(jsonOrNull)
+      .then((d) => setNombre(d.panel?.nombre || "Sin título"))
+      .catch(() => {});
+  }, [panelId]);
+
+  const guardarNombre = async () => {
+    if (!panelId) return;
+    setSaving("saving");
+    await apiFetch(`/api/paneles/${panelId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ nombre }),
+    });
+    setSaving("saved");
+    setTimeout(() => setSaving("idle"), 2000);
+  };
+
   return (
     <header
       className="flex items-center justify-between h-[3.5rem] min-h-[3.5rem] px-4 border-b border-[var(--dashboard-border)] bg-[var(--dashboard-navbar)] fixed left-0 right-0 z-30"
@@ -14,10 +47,37 @@ export default function PanelDetailNavbar() {
         <Link href="/dashboard/paneles" className="p-2 text-gray-400 hover:bg-white/10 rounded-lg" title="Volver">
           <ArrowLeft className="w-5 h-5" />
         </Link>
-        <span className="relative font-semibold text-sm select-none">
-          HoneyLabs
-          <span className="absolute left-0 -bottom-4 text-xs text-gray-400">{plan}</span>
-        </span>
+        <Image src="/logo-honeylabs.png" alt="HoneyLabs" width={20} height={20} />
+        {edit ? (
+          <input
+            className="bg-transparent border-b outline-none text-sm"
+            value={nombre}
+            onChange={(e) => setNombre(e.target.value)}
+            onBlur={() => {
+              setEdit(false);
+              guardarNombre();
+            }}
+            autoFocus
+          />
+        ) : (
+          <span className="font-semibold text-sm cursor-text" onClick={() => setEdit(true)}>
+            {nombre}
+          </span>
+        )}
+        <span className="absolute left-0 -bottom-4 text-xs text-gray-400">{plan}</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => {
+            guardar();
+            guardarNombre();
+          }}
+          className="px-3 py-1 rounded bg-white/10 text-sm"
+        >
+          Guardar
+        </button>
+        {saving === "saving" && <span className="text-xs text-gray-400">Guardando...</span>}
+        {saving === "saved" && <span className="text-xs text-green-500">Guardado</span>}
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- mark completed steps in Instrucciones2.txt
- add PanelOps context to share board save logic
- wrap panel detail layout with provider
- support inline board name editing and manual save with status indicator

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
