### PR TITLE
Add read-only presentation mode

### DIFF
--- a/Instrucciones2.txt
+++ b/Instrucciones2.txt
@@ -21,7 +21,7 @@ Botón “Historial”: accede al historial de cambios y versiones. (Completado)
 
 Botón “Deshacer/Rehacer”: permite revertir o rehacer acciones recientes. (Completado)
 
-Botón “Presentar”: activa el modo presentación para mostrar la pizarra a otros.
+Botón “Presentar”: activa el modo presentación para mostrar la pizarra a otros. (Completado)
 
 Botón de “Vista de cambios”: compara dos versiones diferentes en paralelo.
 
@@ -42,7 +42,7 @@ Selector de vista/zoom: controla el zoom, ajusta vista al área activa o toda la
 B. Lógica de Acciones dentro de la Pizarra (UX, interacción y flujo)
 Autosave avanzado: guardado automático con versiones de respaldo. (Completado)
 
-Modo solo lectura/presentación: la pizarra se bloquea y solo puede ser vista, ideal para presentaciones.
+Modo solo lectura/presentación: la pizarra se bloquea y solo puede ser vista, ideal para presentaciones. (Completado)
 
 Edición colaborativa en tiempo real: cambios sincronizados instantáneamente.
 

--- a/src/app/dashboard/paneles/PanelOpsContext.tsx
+++ b/src/app/dashboard/paneles/PanelOpsContext.tsx
@@ -10,6 +10,8 @@ interface Ops {
   setUndo: (fn: () => void) => void
   redo: () => void
   setRedo: (fn: () => void) => void
+  readOnly: boolean
+  toggleReadOnly: () => void
 }
 
 const PanelOpsContext = createContext<Ops>({
@@ -21,6 +23,8 @@ const PanelOpsContext = createContext<Ops>({
   setUndo: () => {},
   redo: () => {},
   setRedo: () => {},
+  readOnly: false,
+  toggleReadOnly: () => {},
 })
 
 export function PanelOpsProvider({ children }: { children: React.ReactNode }) {
@@ -28,6 +32,7 @@ export function PanelOpsProvider({ children }: { children: React.ReactNode }) {
   const [mostrarFn, setMostrarFn] = useState<() => void>(() => {});
   const [undoFn, setUndoFn] = useState<() => void>(() => {});
   const [redoFn, setRedoFn] = useState<() => void>(() => {});
+  const [readOnly, setReadOnly] = useState(false);
   return (
     <PanelOpsContext.Provider
       value={{
@@ -39,6 +44,8 @@ export function PanelOpsProvider({ children }: { children: React.ReactNode }) {
         setUndo: setUndoFn,
         redo: redoFn,
         setRedo: setRedoFn,
+        readOnly,
+        toggleReadOnly: () => setReadOnly((v) => !v),
       }}
     >
       {children}

--- a/src/app/dashboard/paneles/[id]/page.tsx
+++ b/src/app/dashboard/paneles/[id]/page.tsx
@@ -44,7 +44,7 @@ export default function PanelPage() {
   const [layout, setLayout] = useState<LayoutItem[]>([]);
   const [componentes, setComponentes] = useState<{ [key: string]: any }>({});
   const [errores, setErrores] = useState<{ [key: string]: boolean }>({});
-  const { setGuardar, setMostrarHistorial, setUndo, setRedo } = usePanelOps();
+  const { setGuardar, setMostrarHistorial, setUndo, setRedo, readOnly } = usePanelOps();
   const [openHist, setOpenHist] = useState(false);
   const [historial, setHistorial] = useState<HistEntry[]>([]);
   const [undoHist, setUndoHist] = useState<{ widgets: string[]; layout: LayoutItem[] }[]>([])
@@ -274,22 +274,24 @@ export default function PanelPage() {
           Panel
         </h1>
         <div className="flex items-center gap-2" data-oid="kuayohc">
-          <select
-            onChange={(e) => handleAddWidget(e.target.value)}
-            value=""
-            data-oid="1cmvbl6"
-          >
-            <option disabled value="" data-oid="mdilp3j">
-              Agregar widget...
-            </option>
-            {catalogo
-              .filter((w) => !widgets.includes(w.key))
-              .map((w) => (
-                <option key={w.key} value={w.key} data-oid="i6tnk:1">
-                  {w.title}
-                </option>
-              ))}
-          </select>
+          {!readOnly && (
+            <select
+              onChange={(e) => handleAddWidget(e.target.value)}
+              value=""
+              data-oid="1cmvbl6"
+            >
+              <option disabled value="" data-oid="mdilp3j">
+                Agregar widget...
+              </option>
+              {catalogo
+                .filter((w) => !widgets.includes(w.key))
+                .map((w) => (
+                  <option key={w.key} value={w.key} data-oid="i6tnk:1">
+                    {w.title}
+                  </option>
+                ))}
+            </select>
+          )}
         </div>
       </div>
 
@@ -298,8 +300,8 @@ export default function PanelPage() {
         cols={12}
         rowHeight={95}
         width={1600}
-        isResizable
-        isDraggable
+        isResizable={!readOnly}
+        isDraggable={!readOnly}
         preventCollision={false}
         compactType={null}
         allowOverlap
@@ -351,14 +353,16 @@ export default function PanelPage() {
                   Widget <b data-oid="9spv7ji">{widgetMeta?.title || key}</b> no
                   disponible.
                 </span>
-                <button
-                  className="ml-4 text-xs text-red-500 underline"
-                  onClick={() => handleRemoveWidget(key)}
-                  title="Quitar widget problemático"
-                  data-oid="2.9u:_t"
-                >
-                  Quitar
-                </button>
+                {!readOnly && (
+                  <button
+                    className="ml-4 text-xs text-red-500 underline"
+                    onClick={() => handleRemoveWidget(key)}
+                    title="Quitar widget problemático"
+                    data-oid="2.9u:_t"
+                  >
+                    Quitar
+                  </button>
+                )}
               </div>
             );
           }
@@ -374,14 +378,16 @@ export default function PanelPage() {
               data-oid="ldgxhem"
             >
               <Widget usuario={usuario} data-oid="c3illgc" />
-              <button
-                onClick={() => handleRemoveWidget(key)}
-                title="Eliminar widget"
-                className="absolute top-2 right-2 text-lg text-gray-400 hover:text-red-600"
-                data-oid="9b3gzg4"
-              >
-                ✕
-              </button>
+              {!readOnly && (
+                <button
+                  onClick={() => handleRemoveWidget(key)}
+                  title="Eliminar widget"
+                  className="absolute top-2 right-2 text-lg text-gray-400 hover:text-red-600"
+                  data-oid="9b3gzg4"
+                >
+                  ✕
+                </button>
+              )}
             </div>
           );
         })}

--- a/src/app/dashboard/paneles/components/PanelDetailNavbar.tsx
+++ b/src/app/dashboard/paneles/components/PanelDetailNavbar.tsx
@@ -19,7 +19,7 @@ export default function PanelDetailNavbar({ onShowHistory }: { onShowHistory?: (
   const [saving, setSaving] = useState<"idle" | "saving" | "saved">("idle");
   const [openExport, setOpenExport] = useState(false);
   const [openShare, setOpenShare] = useState(false);
-  const { guardar, undo, redo } = usePanelOps();
+  const { guardar, undo, redo, readOnly, toggleReadOnly } = usePanelOps();
   const router = useRouter();
 
   useEffect(() => {
@@ -171,6 +171,9 @@ export default function PanelDetailNavbar({ onShowHistory }: { onShowHistory?: (
         </button>
         <button onClick={redo} className="px-3 py-1 rounded bg-white/10 text-sm" title="Rehacer">
           ↷
+        </button>
+        <button onClick={toggleReadOnly} className="px-3 py-1 rounded bg-white/10 text-sm">
+          {readOnly ? 'Editar' : 'Presentar'}
         </button>
         <button onClick={onShowHistory} className="px-3 py-1 rounded bg-white/10 text-sm">
           Historial


### PR DESCRIPTION
## Summary
- implement readOnly toggle in panel context
- allow boards to switch between edit and presentation modes
- hide editing controls when readOnly is active
- mark tasks as completed in instructions

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: vitest not found)*

------
