### PR TITLE
Fix syntax error in board page

### DIFF
--- a/src/app/dashboard/paneles/[id]/page.tsx
+++ b/src/app/dashboard/paneles/[id]/page.tsx
@@ -1019,7 +1019,7 @@ const viewHist = () => {
             { label: 'Sugerencia IA', onClick: iaSuggest }
           ]}
         />
-      )
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- close the ContextMenu expression properly to stop syntax errors

## Testing
- `npm install`
- `npm test` *(fails: Invalid value undefined for datasource `db`)*

------
https://chatgpt.com/codex/tasks/task_e_6851b59aa07083288c3da7d4f0c65fa5