### PR TITLE
0.1.4

### DIFF
--- a/src/app/dashboard/components/widgets/MarkdownWidget.tsx
+++ b/src/app/dashboard/components/widgets/MarkdownWidget.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
 import { marked } from "marked";
-import { markedKatex } from 'marked-katex-extension'
+import markedKatex from 'marked-katex-extension'
 import 'katex/dist/katex.min.css'
 
 marked.use(markedKatex())

--- a/src/app/dashboard/paneles/components/PanelDetailNavbar.tsx
+++ b/src/app/dashboard/paneles/components/PanelDetailNavbar.tsx
@@ -10,7 +10,7 @@ import html2canvas from 'html2canvas';
 import { jsonOrNull } from "@lib/http";
 import { usePanelOps } from "../PanelOpsContext";
 import usePanelPresence from "@/hooks/usePanelPresence";
-import { buildEventoICS } from '@lib/calendar';
+import { buildEventoICS } from '@/lib/calendar';
 
 export default function PanelDetailNavbar({ onShowHistory }: { onShowHistory?: () => void }) {
   const { usuario } = useSession();


### PR DESCRIPTION
## Summary
- fix Markdown widget import for marked-katex-extension
- fix calendar module alias in panel navbar

## Testing
- `npm run build` *(fails: can't reach database and missing mail env vars)*

------
