### PR TITLE
0.1.1

### DIFF
--- a/src/app/dashboard/components/widgets/MarkdownWidget.tsx
+++ b/src/app/dashboard/components/widgets/MarkdownWidget.tsx
@@ -1,26 +1,13 @@
 "use client";
-import { useEffect, useState } from "react";
-import markedKatex from 'marked-katex-extension';
-import 'katex/dist/katex.min.css';
+import { useState } from "react";
+import { marked } from "marked";
+import markedKatex from "marked-katex-extension";
+import "katex/dist/katex.min.css";
 
-let cachedMarked: any;
-
-async function loadMarked() {
-  if (!cachedMarked) {
-    const mod = await import('marked');
-    mod.marked.use(markedKatex());
-    cachedMarked = mod.marked;
-  }
-  return cachedMarked;
-}
+marked.use(markedKatex());
 
 export default function MarkdownWidget() {
   const [text, setText] = useState("# Titulo\nEscribe **markdown** aquí...");
-  const [parser, setParser] = useState<any>(null);
-
-  useEffect(() => {
-    loadMarked().then(setParser);
-  }, []);
 
   return (
     <div className="flex flex-col h-full">
@@ -31,7 +18,7 @@ export default function MarkdownWidget() {
       />
       <div
         className="prose prose-sm overflow-auto flex-1"
-        dangerouslySetInnerHTML={{ __html: parser ? parser.parse(text) : "" }}
+        dangerouslySetInnerHTML={{ __html: marked.parse(text) }}
       />
     </div>
   );

--- a/src/app/dashboard/paneles/[id]/page.tsx
+++ b/src/app/dashboard/paneles/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { jsonOrNull } from "@lib/http";
 import { apiFetch } from "@lib/api";
 import type { Usuario } from "@/types/usuario";
@@ -282,7 +282,7 @@ export default function PanelPage() {
     loadWidgets();
   }, [usuario, panelId]);
 
-  const guardar = async () => {
+  const guardar = useCallback(async () => {
     if (!usuario || !panelId) return;
     const data = { widgets, layout };
     if (!navigator.onLine) {
@@ -294,8 +294,8 @@ export default function PanelPage() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data),
     }).catch(() => {});
-    setUnsaved(false)
-  };
+    setUnsaved(false);
+  }, [usuario, panelId, widgets, layout, setUnsaved]);
 
   // Guardar en DB y registrar historial local
   useEffect(() => {
@@ -314,7 +314,7 @@ export default function PanelPage() {
 
   useEffect(() => {
     setGuardar(() => guardar);
-  }, [guardar, setGuardar]);
+  }, [guardar]);
 
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- prevent Markdown widget crash by loading marked directly
- stabilize panel save handler to avoid infinite loops

## Testing
- `npm test` *(fails: Invalid value undefined for datasource "db")*

------
