### PR TITLE
Fix useEffect dependencies in panel

### DIFF
--- a/src/app/dashboard/paneles/[id]/page.tsx
+++ b/src/app/dashboard/paneles/[id]/page.tsx
@@ -319,19 +319,19 @@ export default function PanelPage() {
 
   useEffect(() => {
     setMostrarHistorial(() => () => setOpenHist(true));
-  }, [setMostrarHistorial]);
+  }, []);
 
   useEffect(() => {
     setMostrarCambios(() => () => setOpenDiff(true));
-  }, [setMostrarCambios]);
+  }, []);
 
   useEffect(() => {
     setMostrarComentarios(() => () => setOpenComments(true));
-  }, [setMostrarComentarios]);
+  }, []);
 
   useEffect(() => {
     setMostrarChat(() => () => setOpenChat(true));
-  }, [setMostrarChat]);
+  }, []);
 
   
 

--- a/src/app/dashboard/paneles/components/ChatPanel.tsx
+++ b/src/app/dashboard/paneles/components/ChatPanel.tsx
@@ -34,7 +34,7 @@ export default function ChatPanel({ canalId }: { canalId: number }) {
   useEffect(() => {
     const id = setInterval(() => mutate(), 4000);
     return () => clearInterval(id);
-  }, [mutate]);
+  }, [canalId]);
 
   useEffect(() => {
     const el = listRef.current

--- a/src/app/dashboard/paneles/components/CommentsPanel.tsx
+++ b/src/app/dashboard/paneles/components/CommentsPanel.tsx
@@ -41,7 +41,7 @@ export default function CommentsPanel({ comentarios, onAdd, widgetId }: { coment
     }
     window.addEventListener('keydown', esc)
     return () => window.removeEventListener('keydown', esc)
-  }, [setMostrarComentarios])
+  }, [])
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-40" onClick={() => setMostrarComentarios(() => {})}>
       <div className="bg-[var(--dashboard-card)] p-4 rounded max-h-[80vh] overflow-auto w-80" onClick={e => e.stopPropagation()}>


### PR DESCRIPTION
## Summary
- adjust intervals in `ChatPanel`
- clean up escape handler in `CommentsPanel`
- stabilize action handlers in panel page

## Testing
- `npm test` *(fails: Prisma datasource undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6851d87c5d908328b676be9a2f3569d9