### PR TITLE
0.1.1

### DIFF
--- a/src/app/dashboard/paneles/components/PanelDetailNavbar.tsx
+++ b/src/app/dashboard/paneles/components/PanelDetailNavbar.tsx
@@ -483,8 +483,8 @@ export default function PanelDetailNavbar({ onShowHistory }: { onShowHistory?: (
               </div>
             )}
           </div>
-      </nav>
         </div>
+      </nav>
         {saving === 'saving' && <span className="text-xs text-gray-400">Guardando...</span>}
         {saving === 'saved' && <span className="text-xs text-green-500">Guardado</span>}
     </header>


### PR DESCRIPTION
## Summary
- fix missing closing div in `PanelDetailNavbar`

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Invalid value undefined for datasource "db" provided to PrismaClient constructor)*

------
https://chatgpt.com/codex/tasks/task_e_685212d7dd608328a8496b11db606f15