### PR TITLE
Fix zoom on board only

### DIFF
--- a/src/app/dashboard/paneles/[id]/page.tsx
+++ b/src/app/dashboard/paneles/[id]/page.tsx
@@ -74,6 +74,7 @@ export default function PanelPage() {
     toggleGrid,
     gridSize,
     setGridSize,
+    setZoom,
     zoom,
     buscar,
   } = usePanelOps();
@@ -730,13 +731,6 @@ const viewHist = () => {
         }
       }}
       onContextMenu={handleBoardContext}
-      onWheel={e => {
-        if (e.ctrlKey) {
-          e.preventDefault()
-          const delta = e.deltaY > 0 ? -0.1 : 0.1
-          setZoom(z => Math.min(2, Math.max(0.5, Math.round((z + delta)*10)/10)))
-        }
-      }}
     >
       <div
         className="flex items-center justify-between mb-5"
@@ -772,7 +766,17 @@ const viewHist = () => {
         </div>
       </div>
 
-      <div id="panel-area" style={{ transform: `scale(${zoom})`, transformOrigin: 'top left' }}>
+      <div
+        id="panel-area"
+        onWheel={e => {
+          if (e.ctrlKey) {
+            e.preventDefault()
+            const delta = e.deltaY > 0 ? -0.1 : 0.1
+            setZoom(z => Math.min(2, Math.max(0.5, Math.round((z + delta) * 10) / 10)))
+          }
+        }}
+        style={{ transform: `scale(${zoom})`, transformOrigin: 'top left' }}
+      >
       <GridLayout
         layout={layout}
         cols={12}


### PR DESCRIPTION
## Summary
- restrict zoom handler to the board
- expose `setZoom` in panel page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522b2a7aa8832883f5a8f27def8192