### PR TITLE
Fix missing undo/redo hook import

### DIFF
--- a/src/app/dashboard/paneles/[id]/page.tsx
+++ b/src/app/dashboard/paneles/[id]/page.tsx
@@ -23,6 +23,7 @@ import { usePrompt } from "@/hooks/usePrompt";
 import useSelection from "@/hooks/useSelection";
 import usePanelSocket from "@/hooks/usePanelSocket";
 import useTouchZoom from "@/hooks/useTouchZoom";
+import useUndoRedo, { type Snapshot } from "@/hooks/useUndoRedo";
 import type { PanelUpdate, HistEntry } from "@/types/panel";
 
 import dynamic from "next/dynamic";


### PR DESCRIPTION
## Summary
- import `useUndoRedo` hook in panel page

## Testing
- `npm test` *(fails: Prisma datasource undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68523a0e11bc83289d278084ab34ae8a