### PR TITLE
Fix missing next-intl config

### DIFF
--- a/next-intl.config.ts
+++ b/next-intl.config.ts
@@ -1,0 +1,5 @@
+export default {
+  locales: ['es', 'en'],
+  defaultLocale: 'es',
+  localePrefix: 'as-needed',
+} as const;


### PR DESCRIPTION
## Summary
- add `next-intl.config.ts` with locales and default locale

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523e8325f88328848de9f6485b3818