### PR TITLE
Fix next-intl config usage

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import { securityHeaders } from './lib/securityHeaders';
+import createNextIntlPlugin from 'next-intl/plugin';
 
 /** @type {import('next').NextConfig} */
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
+
+const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const nextConfig = {
   eslint: {
@@ -24,4 +27,4 @@ const nextConfig = {
   },
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,0 +1,5 @@
+import { getRequestConfig } from 'next-intl/server';
+
+export default getRequestConfig(async ({ locale }) => ({
+  messages: (await import(`../messages/${locale}.json`)).default
+}));


### PR DESCRIPTION
## Summary
- activate next-intl plugin with custom request config
- load locale messages dynamically via `getRequestConfig`

## Testing
- `npm test` *(fails: Invalid value undefined for datasource "db" provided to PrismaClient constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68523f945eb083288c534f231faa6a28