### PR TITLE
Fix i18n locale handling

### DIFF
--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,5 +1,9 @@
 import { getRequestConfig } from 'next-intl/server';
 
-export default getRequestConfig(async ({ locale }) => ({
-  messages: (await import(`../messages/${locale}.json`)).default
-}));
+export default getRequestConfig(async ({ locale }) => {
+  const available = ['es', 'en'];
+  const selected = locale && available.includes(locale) ? locale : 'es';
+  return {
+    messages: (await import(`../messages/${selected}.json`)).default,
+  };
+});


### PR DESCRIPTION
## Summary
- handle missing or invalid locale with sensible default

## Testing
- `npm test` *(fails: PrismaClientConstructorValidationError)*

------
