### PR TITLE
0.1.1

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -99,7 +99,7 @@ export function middleware(req: NextRequest) {
     return NextResponse.redirect(loginUrl)
   }
 
-  let res = intl(req)
+  let res = path.startsWith('/api') ? NextResponse.next() : intl(req)
   if (!res) res = NextResponse.next()
   if (requiresSession) {
     res.headers.set('Cache-Control', 'no-store')


### PR DESCRIPTION
## Summary
- avoid locale handling for API routes in middleware

## Testing
- `npm test` *(fails: vitest not found)*

------
