### PR TITLE
Add admin user controls

### DIFF
--- a/src/app/api/admin/usuarios/[id]/route.ts
+++ b/src/app/api/admin/usuarios/[id]/route.ts
@@ -1,0 +1,45 @@
+export const runtime = 'nodejs'
+
+import { NextRequest, NextResponse } from 'next/server'
+import bcrypt from 'bcryptjs'
+import prisma from '@lib/prisma'
+import { getUsuarioFromSession } from '@lib/auth'
+import { getMainRole, normalizeTipoCuenta } from '@lib/permisos'
+import * as logger from '@lib/logger'
+
+function getUserId(req: NextRequest): number | null {
+  const parts = req.nextUrl.pathname.split('/')
+  const idx = parts.findIndex(p => p === 'usuarios')
+  const id = idx !== -1 && parts.length > idx + 1 ? Number(parts[idx + 1]) : null
+  return id && !Number.isNaN(id) ? id : null
+}
+
+function isAdmin(u: any): boolean {
+  const rol = getMainRole(u)?.toLowerCase()
+  const tipo = normalizeTipoCuenta(u?.tipoCuenta)
+  return rol === 'admin' || rol === 'administrador' || tipo === 'admin'
+}
+
+export async function PUT(req: NextRequest) {
+  try {
+    const usuario = await getUsuarioFromSession(req)
+    if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
+    if (!isAdmin(usuario)) return NextResponse.json({ error: 'No autorizado' }, { status: 403 })
+
+    const id = getUserId(req)
+    if (!id) return NextResponse.json({ error: 'ID inválido' }, { status: 400 })
+
+    const body = await req.json()
+    const data: any = {}
+    if (body.correo) data.correo = body.correo
+    if (body.contrasena) data.contrasena = await bcrypt.hash(body.contrasena, 10)
+    if (body.tipoCuenta) data.tipoCuenta = body.tipoCuenta
+    if (body.estado) data.estado = body.estado
+
+    await prisma.usuario.update({ where: { id }, data })
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    logger.error('PUT /api/admin/usuarios/[id]', err)
+    return NextResponse.json({ error: 'Error' }, { status: 500 })
+  }
+}

--- a/src/app/dashboard/admin/usuarios/page.tsx
+++ b/src/app/dashboard/admin/usuarios/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+import { useState } from "react";
+import useSession from "@/hooks/useSession";
+import useAdminUsuarios from "@/hooks/useAdminUsuarios";
+import { apiFetch } from "@lib/api";
+import { getMainRole, normalizeTipoCuenta } from "@lib/permisos";
+
+export default function AdminUsuariosPage() {
+  const { usuario, loading } = useSession();
+  const { usuarios, loading: loadingUsers, mutate } = useAdminUsuarios();
+  const [savingId, setSavingId] = useState<number | null>(null);
+  const [error, setError] = useState("");
+
+  if (loading) return <div className="p-4">Cargando...</div>;
+  if (!usuario) return <div className="p-4 text-red-500">Debes iniciar sesión</div>;
+  const rol = getMainRole(usuario)?.toLowerCase();
+  const tipo = normalizeTipoCuenta(usuario.tipoCuenta);
+  if (rol !== "admin" && rol !== "administrador" && tipo !== "admin") {
+    return <div className="p-4 text-red-500">No autorizado</div>;
+  }
+
+  const updateUser = async (id: number, data: any) => {
+    setSavingId(id);
+    setError("");
+    try {
+      await apiFetch(`/api/admin/usuarios/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      mutate();
+    } catch {
+      setError("Error guardando");
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Usuarios</h1>
+      {error && <div className="text-red-500">{error}</div>}
+      {savingId && <span className="text-sm text-gray-500">Guardando...</span>}
+      {loadingUsers ? (
+        <p>Cargando...</p>
+      ) : (
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr>
+              <th className="text-left">ID</th>
+              <th className="text-left">Nombre</th>
+              <th className="text-left">Correo</th>
+              <th className="text-left">Tipo</th>
+              <th className="text-left">Estado</th>
+              <th className="text-left">Contraseña</th>
+            </tr>
+          </thead>
+          <tbody>
+            {usuarios.map(u => (
+              <tr key={u.id} className="border-t border-white/10">
+                <td className="px-1 py-2">{u.id}</td>
+                <td className="px-1 py-2">{u.nombre}</td>
+                <td className="px-1 py-2">
+                  <input
+                    defaultValue={u.correo}
+                    className="bg-transparent p-1 border rounded"
+                    onBlur={e =>
+                      e.target.value !== u.correo &&
+                      updateUser(u.id, { correo: e.target.value })
+                    }
+                  />
+                </td>
+                <td className="px-1 py-2">
+                  <input
+                    defaultValue={u.tipoCuenta}
+                    className="bg-transparent p-1 border rounded"
+                    onBlur={e =>
+                      e.target.value !== u.tipoCuenta &&
+                      updateUser(u.id, { tipoCuenta: e.target.value })
+                    }
+                  />
+                </td>
+                <td className="px-1 py-2">
+                  <input
+                    defaultValue={u.estado}
+                    className="bg-transparent p-1 border rounded"
+                    onBlur={e =>
+                      e.target.value !== u.estado &&
+                      updateUser(u.id, { estado: e.target.value })
+                    }
+                  />
+                </td>
+                <td className="px-1 py-2">
+                  <input
+                    type="password"
+                    placeholder="Nueva"
+                    className="bg-transparent p-1 border rounded"
+                    onBlur={e =>
+                      e.target.value && updateUser(u.id, { contrasena: e.target.value })
+                    }
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useAdminUsuarios.ts
+++ b/src/hooks/useAdminUsuarios.ts
@@ -1,0 +1,26 @@
+import useSWR from 'swr'
+import { jsonOrNull } from '@lib/http'
+
+export interface AdminUsuario {
+  id: number
+  nombre: string
+  correo: string
+  tipoCuenta: string
+  estado: string
+}
+
+const fetcher = (url: string) => fetch(url).then(jsonOrNull)
+
+export default function useAdminUsuarios() {
+  const { data, error, isLoading, mutate } = useSWR('/api/admin/usuarios', fetcher, {
+    refreshInterval: 5000,
+    revalidateOnFocus: true,
+  })
+
+  return {
+    usuarios: (data?.usuarios as AdminUsuario[]) ?? [],
+    loading: isLoading,
+    error,
+    mutate,
+  }
+}

--- a/tests/adminUsuariosUpdate.test.ts
+++ b/tests/adminUsuariosUpdate.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import prisma from '../lib/prisma'
+import * as auth from '../lib/auth'
+
+const { PUT } = await import('../src/app/api/admin/usuarios/[id]/route')
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('admin actualizar usuario', () => {
+  it('requiere autenticacion', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue(null as any)
+    const req = new NextRequest('http://localhost/api/admin/usuarios/1', { method: 'PUT', body: '{}' })
+    const res = await PUT(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('requiere permisos de admin', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ tipoCuenta: 'individual' } as any)
+    const req = new NextRequest('http://localhost/api/admin/usuarios/1', { method: 'PUT', body: '{}' })
+    const res = await PUT(req)
+    expect(res.status).toBe(403)
+  })
+
+  it('actualiza datos', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ tipoCuenta: 'admin' } as any)
+    const update = vi.spyOn(prisma.usuario, 'update').mockResolvedValue({} as any)
+    const req = new NextRequest('http://localhost/api/admin/usuarios/1', {
+      method: 'PUT',
+      body: JSON.stringify({ correo: 'nuevo@x.com' }),
+    })
+    const res = await PUT(req)
+    expect(res.status).toBe(200)
+    expect(update).toHaveBeenCalled()
+  })
+})
+


### PR DESCRIPTION
## Summary
- add hook to fetch and refresh admin users
- allow updating users from `/api/admin/usuarios/[id]`
- create dashboard page to edit users
- cover admin user updates with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853078a6410832887d05f71dc211ee5