### PR TITLE
Add use-debounce dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "swr": "^2.3.3",
         "tailwind-merge": "^3.3.0",
         "tailwindcss-animate": "^1.0.7",
+        "use-debounce": "^10.0.5",
         "use-sound": "^5.0.0",
         "uuid": "^11.1.0",
         "xlsx": "^0.18.5",
@@ -12916,6 +12917,18 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.5.tgz",
+      "integrity": "sha512-Q76E3lnIV+4YT9AHcrHEHYmAd9LKwUAbPXDm7FlqVGDHiSOhX3RDjT8dm0AxbJup6WgOb1YEcKyCr11kBJR5KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/use-sound": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "swr": "^2.3.3",
     "tailwind-merge": "^3.3.0",
     "tailwindcss-animate": "^1.0.7",
+    "use-debounce": "^10.0.5",
     "use-sound": "^5.0.0",
     "uuid": "^11.1.0",
     "xlsx": "^0.18.5",


### PR DESCRIPTION
## Summary
- add `use-debounce` to solve missing module for WidgetsTable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685321c77b7883288448395d69f73111