### PR TITLE
Fix invalid hook usage in pinch zoom

### DIFF
--- a/src/hooks/useTouchZoom.ts
+++ b/src/hooks/useTouchZoom.ts
@@ -1,14 +1,15 @@
 "use client"
-import { useEffect } from 'react'
 import { usePinch } from '@use-gesture/react'
 
-export default function useTouchZoom(ref: React.RefObject<HTMLElement>, onZoom: (z: number) => void) {
-  useEffect(() => {
-    if (!ref.current) return
-    const bind = usePinch(({ offset: [d] }) => {
+export default function useTouchZoom(
+  ref: React.RefObject<HTMLElement>,
+  onZoom: (z: number) => void,
+) {
+  usePinch(
+    ({ offset: [d] }) => {
       const scale = Math.min(3, Math.max(0.5, 1 + d / 200))
       onZoom(parseFloat(scale.toFixed(2)))
-    }, { target: ref.current, eventOptions: { passive: false } })
-    return () => { bind?.() }
-  }, [ref, onZoom])
+    },
+    { target: ref, eventOptions: { passive: false } },
+  )
 }


### PR DESCRIPTION
## Summary
- adjust touch zoom hook to use `usePinch` directly

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
