### PR TITLE
Check WebSocket state before leaving panel

### DIFF
--- a/src/hooks/usePanelSocket.ts
+++ b/src/hooks/usePanelSocket.ts
@@ -24,7 +24,9 @@ export default function usePanelSocket(panelId?: string | null, onUpdate?: (data
     socket.addEventListener('message', handleMessage)
 
     return () => {
-      socket.send(JSON.stringify({ action: 'leave', panelId }))
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({ action: 'leave', panelId }))
+      }
       socket.removeEventListener('message', handleMessage)
       socket.close()
       socketRef.current = null


### PR DESCRIPTION
## Summary
- avoid sending `leave` before the socket is open

## Testing
- `npm run lint` *(fails: next lint not happy)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68533b4f86408328a0aefbaa15d8581a