### PR TITLE
0.1.2

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,6 +78,7 @@ model Usuario {
   eventosCreados       EventoAlmacen[]        @relation("EventosCreados")
   historialAlmacenes   HistorialAlmacen[]
   historialLotes       HistorialLote[]
+  historialUnidades   HistorialUnidad[]
   incidenciasCreadas   Incidencia[]           @relation("IncidenciasCreadas")
   incidenciasResueltas Incidencia[]           @relation("IncidenciasResueltas")
   materiales           Material[]
@@ -344,10 +345,22 @@ model HistorialLote {
   descripcion String?
   ubicacion   String?
   cantidad    Float?
+  estado      Json?
   fecha       DateTime @default(now())
   usuarioId   Int?
   material    Material @relation(fields: [materialId], references: [id])
   usuario     Usuario? @relation(fields: [usuarioId], references: [id])
+}
+
+model HistorialUnidad {
+  id          Int      @id @default(autoincrement())
+  unidadId    Int
+  descripcion String?
+  estado      Json?
+  fecha       DateTime @default(now())
+  usuarioId   Int?
+  unidad      MaterialUnidad @relation(fields: [unidadId], references: [id], onDelete: Cascade)
+  usuario     Usuario?       @relation(fields: [usuarioId], references: [id])
 }
 
 model MaterialUnidad {
@@ -387,6 +400,7 @@ model MaterialUnidad {
   imagen             Bytes?
   imagenNombre       String?
   archivos           ArchivoUnidad[]
+  historial          HistorialUnidad[]
   material           Material        @relation(fields: [materialId], references: [id])
 
   @@unique([materialId, nombre])


### PR DESCRIPTION
## Summary
- store complete material state in HistorialLote and add HistorialUnidad model
- link new history model to Usuario and MaterialUnidad
- log snapshots of material creation, update and removal within the same transaction

## Testing
- `npm run build` *(fails: PrismaClientConstructorValidationError)*
- `npm test`

------
