### PR TITLE
0.2.236

### DIFF
--- a/Analisis.txt
+++ b/Analisis.txt
@@ -10,11 +10,14 @@ ERRORES CORREGIDOS
 - La URL de imagen no se devolvía correctamente al crear o editar un almacén.
 - Se añadió la propiedad `imagenUrl` en las selecciones de Prisma para reflejar la ruta almacenada.
 - Se eliminó el casteo innecesario de buffers de imagen.
+- Se evitó la conexión a base de datos en pruebas automatizadas.
+- Se agregaron validaciones de cantidades y fechas en materiales.
+- Se validó el código recibido al importar QR.
 
 FALLAS PENDIENTES
-- Dependencia del servidor de base de datos para las pruebas automatizadas.
-- Validaciones de datos mínimas en campos numéricos y fechas.
-- Manejo limitado de errores al importar códigos QR.
+- Pruebas de integración más amplias para los módulos de almacenes.
+- Validación de permisos en operaciones de QR.
+- Optimización de paginación en listados grandes.
 
 MEJORAS PROPUESTAS
 1. **Validaciones estrictas** de campos en API (rangos, formatos y tamaños).
@@ -32,6 +35,10 @@ AÑADIDOS EXTRAS
 5. **Búsqueda avanzada** con autocompletado en todo el inventario.
 6. **Automatización de alertas** vía webhooks a sistemas externos.
 7. **Sección App** en el dashboard para descarga y versiones de la aplicación.
+8. **Paneles personalizables** con colores y vistas guardadas.
+9. **Modo kiosko** para consulta rápida en almacenes.
+10. **App offline login** con tokens temporales.
+11. **Panel de tendencias** para materiales más usados.
 
 
 Sistema para app:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.236
+- Eliminamos la conexion a base de datos en tests.
+- Validamos cantidad y fechas al crear materiales.
+- Mejoramos la verificacion de codigo en importacion QR.
+
 ## 0.2.235
 - Corrigimos la URL de imagen al crear y editar almacenes.
 - Ajustamos los campos seleccionados en las respuestas de almacenes.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.235
+0.2.236
 
 ---
 

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -24,7 +24,7 @@ export const prisma =
         : ['error'],
   })
 
-if (!globalForPrisma.prisma) {
+if (!globalForPrisma.prisma && !process.env.VITEST) {
   prisma.$connect().catch((e) =>
     console.error('Prisma connection error:', e),
   )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.1.0",
+  "version": "0.2.236",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/almacenes/[id]/materiales/route.ts
+++ b/src/app/api/almacenes/[id]/materiales/route.ts
@@ -185,6 +185,15 @@ export async function POST(req: NextRequest) {
 
     if (!nombre) return NextResponse.json({ error: 'Nombre requerido' }, { status: 400 })
 
+    if (Number.isNaN(cantidad) || cantidad < 0)
+      return NextResponse.json({ error: 'Cantidad inválida' }, { status: 400 })
+    if (minimo !== null && (Number.isNaN(minimo) || minimo < 0))
+      return NextResponse.json({ error: 'Mínimo inválido' }, { status: 400 })
+    if (maximo !== null && (Number.isNaN(maximo) || maximo < 0))
+      return NextResponse.json({ error: 'Máximo inválido' }, { status: 400 })
+    if (fechaCaducidad && Number.isNaN(fechaCaducidad.getTime()))
+      return NextResponse.json({ error: 'Fecha inválida' }, { status: 400 })
+
     const material = await prisma.$transaction(async (tx) => {
       const creado = await tx.material.create({
         data: {

--- a/src/app/api/qr/importar/route.ts
+++ b/src/app/api/qr/importar/route.ts
@@ -11,7 +11,9 @@ export async function POST(req: NextRequest) {
     const usuario = await getUsuarioFromSession(req)
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     const { codigo } = await req.json()
-    if (!codigo) return NextResponse.json({ error: 'Código requerido' }, { status: 400 })
+    if (typeof codigo !== 'string' || !codigo.trim()) {
+      return NextResponse.json({ error: 'Código requerido' }, { status: 400 })
+    }
 
     const unidad = await prisma.materialUnidad.findUnique({
       where: { codigoQR: codigo },

--- a/tests/materialesValidation.test.ts
+++ b/tests/materialesValidation.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { POST } from '../src/app/api/almacenes/[id]/materiales/route'
+import { NextRequest } from 'next/server'
+import prisma from '../lib/prisma'
+import * as auth from '../lib/auth'
+import * as permisos from '../lib/permisos'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('validaciones de materiales', () => {
+  const baseReq = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  } as any
+
+  it('rechaza cantidad negativa', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ id: 1 } as any)
+    vi.spyOn(prisma.usuarioAlmacen, 'findFirst').mockResolvedValue({ id: 1 } as any)
+    vi.spyOn(permisos, 'hasManagePerms').mockReturnValue(true)
+    const body = JSON.stringify({ nombre: 'test', cantidad: -1 })
+    const req = new NextRequest('http://localhost/api/almacenes/1/materiales', { ...baseReq, body })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('rechaza fecha invalida', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ id: 1 } as any)
+    vi.spyOn(prisma.usuarioAlmacen, 'findFirst').mockResolvedValue({ id: 1 } as any)
+    vi.spyOn(permisos, 'hasManagePerms').mockReturnValue(true)
+    const body = JSON.stringify({ nombre: 'test', cantidad: 1, fechaCaducidad: 'no-date' })
+    const req = new NextRequest('http://localhost/api/almacenes/1/materiales', { ...baseReq, body })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+})


### PR DESCRIPTION
## Summary
- disable prisma connection when testing
- validate materials data and QR code imports
- improve docs and changelog
- add unit tests for materials validation
- update roadmap notes with completed tasks

## Testing
- `npm run build` *(fails: Cannot find module '.prisma/client/default')*
- `npm test` *(fails: Cannot find module '.prisma/client/default')*

------
