### PR TITLE
0.2.242

### DIFF
--- a/src/app/api/build-mobile/route.ts
+++ b/src/app/api/build-mobile/route.ts
@@ -43,9 +43,11 @@ export async function POST(req: NextRequest) {
         logger.info('[BUILD_MOBILE] repository_dispatch sent')
       } catch (err) {
         logger.error('[BUILD_MOBILE] dispatch error', err)
+        await fs.writeFile(buildStatusPath, JSON.stringify({ building: false, progress: 0 }))
       }
     } else {
       logger.info('[BUILD_MOBILE] dispatch skipped, env missing')
+      await fs.writeFile(buildStatusPath, JSON.stringify({ building: false, progress: 0 }))
     }
     return NextResponse.json({ success: true, run_id: runId })
   } catch (err) {

--- a/src/app/api/build-mobile/update/route.ts
+++ b/src/app/api/build-mobile/update/route.ts
@@ -6,9 +6,8 @@ import path from 'path'
 
 const appInfoPath = path.join(process.cwd(), 'lib', 'app-info.json')
 const buildStatusPath = path.join(process.cwd(), 'lib', 'build-status.json')
-const token = process.env.BUILD_TOKEN
-
 export async function POST(req: NextRequest) {
+  const token = process.env.BUILD_TOKEN
   let body: any
   try {
     body = await req.json()

--- a/tests/buildMobile.test.ts
+++ b/tests/buildMobile.test.ts
@@ -1,9 +1,26 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { NextRequest } from 'next/server'
+import fs from 'fs/promises'
+import path from 'path'
 import * as auth from '../lib/auth'
 import { POST } from '../src/app/api/build-mobile/route'
 
-afterEach(() => vi.restoreAllMocks())
+const buildStatusPath = path.join(process.cwd(), 'lib', 'build-status.json')
+
+let statusBackup: string | null = null
+
+beforeEach(async () => {
+  try {
+    statusBackup = await fs.readFile(buildStatusPath, 'utf8')
+  } catch {
+    statusBackup = null
+  }
+})
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  if (statusBackup !== null) await fs.writeFile(buildStatusPath, statusBackup)
+})
 
 describe('build mobile endpoint', () => {
   it('rejects unauthorized user', async () => {
@@ -20,5 +37,15 @@ describe('build mobile endpoint', () => {
     expect(res.status).toBe(200)
     const data = await res.json()
     expect(data).toHaveProperty('run_id')
+  })
+
+  it('resets status when dispatch not configured', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ tipoCuenta: 'admin' } as any)
+    const req = new NextRequest('http://localhost/api/build-mobile', { method: 'POST' })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const status = JSON.parse(await fs.readFile(buildStatusPath, 'utf8'))
+    expect(status.building).toBe(false)
+    expect(status.progress).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
- fix build-mobile status if dispatch fails or env vars missing
- read BUILD_TOKEN at request time and update tests
- test status file reset on dispatch skipped

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68649c34092c8328bf1b72632a60909c