### PR TITLE
0.2.240

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.240
+- Corregimos el estado de builds fallidos para evitar bucles.
+
 ## 0.2.239
 - Añadimos API y página para descargar la app móvil.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.2.239",
+  "version": "0.2.240",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/build-mobile/route.ts
+++ b/src/app/api/build-mobile/route.ts
@@ -43,13 +43,16 @@ export async function POST(req: NextRequest) {
         logger.info('[BUILD_MOBILE] repository_dispatch sent')
       } catch (err) {
         logger.error('[BUILD_MOBILE] dispatch error', err)
+        await fs.writeFile(buildStatusPath, JSON.stringify({ building: false, progress: 0 }))
       }
     } else {
       logger.info('[BUILD_MOBILE] dispatch skipped, env missing')
+      await fs.writeFile(buildStatusPath, JSON.stringify({ building: false, progress: 0 }))
     }
     return NextResponse.json({ success: true, run_id: runId })
   } catch (err) {
     logger.error('[BUILD_MOBILE]', err)
+    await fs.writeFile(buildStatusPath, JSON.stringify({ building: false, progress: 0 }))
     return NextResponse.json({ error: 'failed' }, { status: 500 })
   }
 }

--- a/src/app/api/build-mobile/update/route.ts
+++ b/src/app/api/build-mobile/update/route.ts
@@ -6,7 +6,6 @@ import path from 'path'
 
 const appInfoPath = path.join(process.cwd(), 'lib', 'app-info.json')
 const buildStatusPath = path.join(process.cwd(), 'lib', 'build-status.json')
-const token = process.env.BUILD_TOKEN
 
 export async function POST(req: NextRequest) {
   let body: any
@@ -15,6 +14,7 @@ export async function POST(req: NextRequest) {
   } catch {
     return NextResponse.json({ error: 'invalid' }, { status: 400 })
   }
+  const token = process.env.BUILD_TOKEN
   if (!body || body.token !== token) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
   }

--- a/tests/buildMobile.test.ts
+++ b/tests/buildMobile.test.ts
@@ -1,9 +1,18 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { NextRequest } from 'next/server'
+import fs from 'fs/promises'
+import path from 'path'
 import * as auth from '../lib/auth'
 import { POST } from '../src/app/api/build-mobile/route'
 
-afterEach(() => vi.restoreAllMocks())
+const buildStatusPath = path.join(process.cwd(), 'lib', 'build-status.json')
+const envBackup = { repo: process.env.GITHUB_REPO, token: process.env.GITHUB_TOKEN }
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  process.env.GITHUB_REPO = envBackup.repo
+  process.env.GITHUB_TOKEN = envBackup.token
+})
 
 describe('build mobile endpoint', () => {
   it('rejects unauthorized user', async () => {
@@ -20,5 +29,16 @@ describe('build mobile endpoint', () => {
     expect(res.status).toBe(200)
     const data = await res.json()
     expect(data).toHaveProperty('run_id')
+  })
+
+  it('clears status when dispatch fails', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ tipoCuenta: 'admin' } as any)
+    process.env.GITHUB_REPO = ''
+    process.env.GITHUB_TOKEN = ''
+    const req = new NextRequest('http://localhost/api/build-mobile', { method: 'POST' })
+    await POST(req)
+    const statusRaw = await fs.readFile(buildStatusPath, 'utf8')
+    const status = JSON.parse(statusRaw)
+    expect(status.building).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- corregimos el estado de `build-status.json` cuando falla el webhook de GitHub
- permitimos que `BUILD_TOKEN` se lea en cada petición
- añadimos pruebas para verificar que el estado se restablece

## Testing
- `npm test`
- `npm run build`


------
