### PR TITLE
0.2.242

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.242
+- Registramos el service worker de PWA solo en producción.
+
 ## 0.2.240
 - Corregimos el estado de builds fallidos para evitar bucles.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.236
+0.2.242
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "honeylabs",
-  "version": "0.2.240",
+  "version": "0.2.242",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "honeylabs",
-      "version": "0.2.240",
+      "version": "0.2.242",
       "hasInstallScript": true,
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.2.240",
+  "version": "0.2.242",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/PwaRegister.tsx
+++ b/src/components/PwaRegister.tsx
@@ -1,6 +1,11 @@
 'use client'
-import 'next-pwa/register'
+import { useEffect } from 'react'
 
 export default function PwaRegister() {
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      void import('next-pwa/register')
+    }
+  }, [])
   return null
 }


### PR DESCRIPTION
## Summary
- register service worker only when `NODE_ENV` is production
- bump version to 0.2.242

## Testing
- `npm test`
- `npm run build`


------
