### PR TITLE
0.2.245

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.245
+- Compartimos la lógica de progreso de build en `useBuildProgress`.
+- Cambiamos el enlace de descarga a `/api/app/url`.
+- Mostramos "APK listo" con Toast cuando finaliza la generación.
+- Reemplazamos `bg-[var(--dashboard-accent)]` por `bg-accent-500`.
+
 ## 0.2.244
 - Simplificamos la vista de App eliminando `useReducer`.
 - Cancelamos peticiones de información con `AbortController` para evitar fugas.

--- a/lib/apiPaths.ts
+++ b/lib/apiPaths.ts
@@ -1,3 +1,4 @@
 export const API_APP = '/api/app';
+export const API_APP_URL = '/api/app/url';
 export const API_BUILD_MOBILE = '/api/build-mobile';
 export const API_BUILD_PROGRESS = '/api/build-mobile/progress';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.2.244",
+  "version": "0.2.245",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/app/url/route.ts
+++ b/src/app/api/app/url/route.ts
@@ -1,0 +1,18 @@
+export const runtime = 'nodejs'
+
+import { NextResponse } from 'next/server'
+import fs from 'fs/promises'
+import path from 'path'
+
+const appInfoPath = path.join(process.cwd(), 'lib', 'app-info.json')
+
+export async function GET() {
+  try {
+    const raw = await fs.readFile(appInfoPath, 'utf8')
+    const { url } = JSON.parse(raw) as { url: string }
+    if (!url) throw new Error('invalid')
+    return NextResponse.json({ url }, { headers: { 'Cache-Control': 'no-store' } })
+  } catch {
+    return NextResponse.json({ error: 'info_unavailable' }, { status: 500 })
+  }
+}

--- a/src/hooks/useBuildProgress.ts
+++ b/src/hooks/useBuildProgress.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { API_BUILD_PROGRESS } from '@lib/apiPaths'
+import type { AppInfo } from '@/types/app'
+
+export default function useBuildProgress(building: boolean) {
+  const qc = useQueryClient()
+
+  useEffect(() => {
+    if (!building) return
+    let retry = 1
+    let es: EventSource
+    const connect = () => {
+      es = new EventSource(API_BUILD_PROGRESS)
+      es.addEventListener('open', () => {
+        retry = 1
+      })
+      es.onmessage = (e) => {
+        try {
+          const data = JSON.parse(e.data) as Partial<AppInfo>
+          qc.setQueryData(['app'], (prev: AppInfo | undefined) =>
+            prev ? { ...prev, ...data } : undefined,
+          )
+        } catch {}
+      }
+      es.onerror = () => {
+        es.close()
+        setTimeout(connect, retry * 1000)
+        retry = Math.min(retry * 2, 30)
+      }
+    }
+    connect()
+    return () => {
+      es.close()
+    }
+  }, [building, qc])
+}

--- a/tests/appUrl.test.ts
+++ b/tests/appUrl.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { GET } from '../src/app/api/app/url/route'
+
+describe('api app url', () => {
+  it('returns url', async () => {
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data).toHaveProperty('url')
+  })
+})


### PR DESCRIPTION
## Summary
- compartimos la lógica SSE en un nuevo hook `useBuildProgress`
- agregamos endpoint `/api/app/url` y constante `API_APP_URL`
- actualizamos la página de App para usar el hook, la nueva ruta y Toast
- remplazamos la clase de fondo por `bg-accent-500`
- se muestra aviso "APK listo" al terminar la compilación

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865937c37308328bcc1b93a3d3eb226