### PR TITLE
0.2.246

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,5 @@
+export class ApiError extends Error {
+  constructor(public code: string, message?: string) {
+    super(message ?? code)
+  }
+}


### PR DESCRIPTION
## Summary
- add ApiError class for typed errors
- clean `AppPage` queryFn using `ctx.signal`
- prevent login toast spam
- limit build progress SSE retries

## Testing
- `npm test --silent`
- `npm run build --silent`

------
