### PR TITLE
0.2.247

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.247
+- Ignoramos `AbortError` en consultas de App para evitar toasts falsos.
+
 ## 0.2.245
 - Compartimos la lógica de progreso de build en `useBuildProgress`.
 - Cambiamos el enlace de descarga a `/api/app/url`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.2.245",
+  "version": "0.2.247",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/dashboard/app/page.tsx
+++ b/src/app/dashboard/app/page.tsx
@@ -35,8 +35,10 @@ export default function AppPage() {
       return data ? appInfoSchema.parse(data) : undefined;
     },
     refetchInterval: 60_000,
-    onError: (err: ApiError) => {
-      const msg = err?.code === "fetch_error" ? "No se pudo obtener la información de la app" : "Error desconocido";
+    onError: (err: ApiError | Error) => {
+      if ((err as Error).name === 'AbortError') return;
+      const msg = err instanceof ApiError && err.code === "fetch_error" ?
+        "No se pudo obtener la información de la app" : "Error desconocido";
       toast.show(msg, "error");
     },
   });
@@ -46,8 +48,10 @@ export default function AppPage() {
     onSuccess: () => {
       refetch();
     },
-    onError: (err: ApiError) => {
-      const msg = err?.code === "start_failed" ? "No se pudo iniciar el build" : "Error desconocido";
+    onError: (err: ApiError | Error) => {
+      if ((err as Error).name === 'AbortError') return;
+      const msg = err instanceof ApiError && err.code === "start_failed" ?
+        "No se pudo iniciar el build" : "Error desconocido";
       toast.show(msg, "error");
     },
   });


### PR DESCRIPTION
## Summary
- avoid toast on aborted fetch in App
- bump patch version

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68659ea0d5b48328a620c16547f0a134