### PR TITLE
0.2.248

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## 0.2.247
 - Ignoramos `AbortError` en consultas de App para evitar toasts falsos.
 
+## 0.2.248
+- Evitamos refetch manual en App utilizando `enabled` por sesión.
+- Cerramos la SSE de progreso al recibir 401.
+- Usamos `useRef` para detectar final de build sin render extra.
+- Forzamos `building: true` al iniciar el build.
+- Añadimos `rel="noopener"` al enlace de descarga.
+
 ## 0.2.245
 - Compartimos la lógica de progreso de build en `useBuildProgress`.
 - Cambiamos el enlace de descarga a `/api/app/url`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.2.247",
+  "version": "0.2.248",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/hooks/useBuildProgress.ts
+++ b/src/hooks/useBuildProgress.ts
@@ -22,9 +22,13 @@ export function startBuildProgress(
         onData(data)
       } catch {}
     }
-    es.onerror = () => {
+    es.onerror = async () => {
       es.close()
       attempts += 1
+      try {
+        const r = await fetch(API_BUILD_PROGRESS, { method: 'HEAD' })
+        if (r.status === 401) return
+      } catch {}
       if (attempts <= maxRetries) {
         setTimeout(connect, retry * 1000)
         retry = Math.min(retry * 2, 30)

--- a/tests/buildProgressReconnect.test.ts
+++ b/tests/buildProgressReconnect.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { startBuildProgress } from '../src/hooks/useBuildProgress'
 
 class MockES {
@@ -9,17 +9,41 @@ class MockES {
   close() {}
 }
 
+afterEach(() => {
+  vi.restoreAllMocks()
+  MockES.instances = []
+})
+
 describe('build progress reconnect', () => {
-  it('retries connection on error', () => {
+  it('retries connection on error', async () => {
     // @ts-ignore
     global.EventSource = MockES
     const onData = vi.fn()
     vi.useFakeTimers()
+    // @ts-ignore
+    global.fetch = vi.fn().mockResolvedValue(new Response('', { status: 200 }))
     const stop = startBuildProgress(onData)
     expect(MockES.instances.length).toBe(1)
     MockES.instances[0].onerror && MockES.instances[0].onerror()
+    await Promise.resolve()
     vi.advanceTimersByTime(1000)
     expect(MockES.instances.length).toBe(2)
+    stop()
+    vi.useRealTimers()
+  })
+
+  it('stops reconnecting when unauthorized', async () => {
+    // @ts-ignore
+    global.EventSource = MockES
+    // @ts-ignore
+    global.fetch = vi.fn().mockResolvedValue(new Response('', { status: 401 }))
+    vi.useFakeTimers()
+    const stop = startBuildProgress(() => {})
+    expect(MockES.instances.length).toBe(1)
+    MockES.instances[0].onerror && MockES.instances[0].onerror()
+    await Promise.resolve()
+    vi.advanceTimersByTime(1000)
+    expect(MockES.instances.length).toBe(1)
     stop()
     vi.useRealTimers()
   })


### PR DESCRIPTION
## Summary
- refine App query and mutation to avoid unnecessary refetch
- handle unauthorized SSE in `useBuildProgress`
- use `useRef` to detect APK readiness
- update download link security
- add tests for SSE cleanup

## Testing
- `npm test`
- `npm run build`


------
