### PR TITLE
0.2.257

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -6,6 +6,7 @@ const config: CapacitorConfig = {
   webDir: 'out',
   plugins: {
     Capgo: {
+      appId: 'honeylabs',
       liveUpdates: true,
       channel: 'prod',
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.2.256",
+  "version": "0.2.257",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,5 @@
+import { CapacitorUpdater as Updater } from '@capgo/capacitor-updater'
+
+Updater.addListener('downloadComplete', () => {
+  Updater.reload()
+})


### PR DESCRIPTION
## Summary
- configuramos Capgo con `appId: 'honeylabs'`
- añadimos `src/main.tsx` con el listener de descargas
- actualizamos versión a 0.2.257

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865e11586e48328a03e9c9f514fa9e4