### PR TITLE
0.2.259

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -24,6 +24,9 @@ jobs:
       - uses: pnpm/action-setup@v3
       - run: pnpm i
       - run: pnpm build
+      - run: nx affected -t build --prod
+      - run: next build && next export -o dist
+      - run: capgo upload --appId honeylabs ./dist
       - run: pnpm cap sync android && pnpm cap build android --release
       - uses: sigstore/cosign-installer@v3
       - uses: anchore/sbom-action@v0

--- a/.github/workflows/ota-update.yml
+++ b/.github/workflows/ota-update.yml
@@ -1,0 +1,20 @@
+name: OTA Update
+
+on:
+  repository_dispatch:
+    types: [ota]
+
+jobs:
+  ota:
+    runs-on: ubuntu-latest
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+      - run: pnpm i
+      - run: nx affected -t build --prod
+      - run: next build && next export -o dist
+      - run: capgo upload --appId honeylabs ./dist
+      - run: node scripts/update-status.js ${{ github.run_id }} 1
+

--- a/lib/mobile.ts
+++ b/lib/mobile.ts
@@ -1,0 +1,23 @@
+import { promisify } from 'util'
+import { exec as execCb } from 'child_process'
+
+const exec = promisify(execCb)
+
+/**
+ * Devuelve true si existen cambios en archivos nativos
+ * desde el último commit.
+ */
+export async function detectNativeChanges(): Promise<boolean> {
+  try {
+    const { stdout } = await exec('git diff --name-only HEAD~1')
+    const files = stdout.split('\n').filter(Boolean)
+    return files.some((f) =>
+      f.startsWith('android/') ||
+      f.startsWith('packages/mobile-plugins/') ||
+      f.startsWith('capacitor.config')
+    )
+  } catch {
+    return false
+  }
+}
+

--- a/scripts/update-status.js
+++ b/scripts/update-status.js
@@ -1,0 +1,35 @@
+const fs = require('fs/promises')
+const path = require('path')
+
+async function main() {
+  const [runId, pct] = process.argv.slice(2)
+  const progress = Math.max(0, Math.min(1, parseFloat(pct || '0')))
+  const building = progress < 1
+  const file = path.join(process.cwd(), 'lib', 'build-status.json')
+  await fs.writeFile(file, JSON.stringify({ building, progress }))
+
+  const token = process.env.GITHUB_TOKEN
+  const repo = process.env.GITHUB_REPOSITORY
+  if (runId && token && repo) {
+    try {
+      await fetch(`https://api.github.com/repos/${repo}/check-runs/${runId}`, {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'User-Agent': 'honeylabs-status',
+          Accept: 'application/vnd.github+json',
+        },
+        body: JSON.stringify({
+          status: building ? 'in_progress' : 'completed',
+          conclusion: building ? undefined : 'success',
+          output: { title: 'mobile', summary: `progress:${progress}` },
+        }),
+      })
+    } catch (err) {
+      console.error('update-status', err)
+    }
+  }
+}
+
+main()
+

--- a/tests/buildMobile.test.ts
+++ b/tests/buildMobile.test.ts
@@ -3,15 +3,17 @@ import { NextRequest } from 'next/server'
 import fs from 'fs/promises'
 import path from 'path'
 import * as auth from '../lib/auth'
+import * as mobile from '../lib/mobile'
 import { POST } from '../src/app/api/build-mobile/route'
 
 const buildStatusPath = path.join(process.cwd(), 'lib', 'build-status.json')
 const envBackup = { repo: process.env.GITHUB_REPO, token: process.env.GITHUB_TOKEN }
 
-afterEach(() => {
+afterEach(async () => {
   vi.restoreAllMocks()
   process.env.GITHUB_REPO = envBackup.repo
   process.env.GITHUB_TOKEN = envBackup.token
+  await fs.writeFile(buildStatusPath, JSON.stringify({ building: false, progress: 0 }))
 })
 
 describe('build mobile endpoint', () => {
@@ -22,25 +24,48 @@ describe('build mobile endpoint', () => {
     expect(res.status).toBe(401)
   })
 
+  it('rejects non admin user', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ tipoCuenta: 'standard' } as any)
+    process.env.CSRF_TOKEN = 'secret'
+    const req = new NextRequest('http://localhost/api/build-mobile', { method: 'POST', headers: { 'x-csrf-token': 'secret' } })
+    const res = await POST(req)
+    expect(res.status).toBe(403)
+  })
+
   it('triggers build for admin', async () => {
     vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ tipoCuenta: 'admin' } as any)
+    vi.spyOn(mobile, 'detectNativeChanges').mockResolvedValue(false)
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))
     process.env.CSRF_TOKEN = 'secret'
     const req = new NextRequest('http://localhost/api/build-mobile', { method: 'POST', headers: { 'x-csrf-token': 'secret' } })
     const res = await POST(req)
     expect(res.status).toBe(202)
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.event_type).toBe('ota')
     const data = await res.json()
     expect(data.ok).toBe(true)
   })
 
   it('keeps building status when dispatch fails', async () => {
     vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ tipoCuenta: 'admin' } as any)
-    process.env.GITHUB_REPO = ''
-    process.env.GITHUB_TOKEN = ''
+    vi.spyOn(mobile, 'detectNativeChanges').mockResolvedValue(false)
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('fail'))
+    process.env.GITHUB_REPO = 'repo'
+    process.env.GITHUB_TOKEN = 'tok'
     process.env.CSRF_TOKEN = 'secret'
     const req = new NextRequest('http://localhost/api/build-mobile', { method: 'POST', headers: { 'x-csrf-token': 'secret' } })
     await POST(req)
     const statusRaw = await fs.readFile(buildStatusPath, 'utf8')
     const status = JSON.parse(statusRaw)
-    expect(status.building).toBe(true)
+    expect(status.progress).toBe(0)
+  })
+
+  it('blocks when already building', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ tipoCuenta: 'admin' } as any)
+    await fs.writeFile(buildStatusPath, JSON.stringify({ building: true, progress: 0 }))
+    process.env.CSRF_TOKEN = 'secret'
+    const req = new NextRequest('http://localhost/api/build-mobile', { method: 'POST', headers: { 'x-csrf-token': 'secret' } })
+    const res = await POST(req)
+    expect(res.status).toBe(429)
   })
 })


### PR DESCRIPTION
## Summary
- enforce admin JWT validation and block concurrent builds in `/api/build-mobile`
- detect native changes with new helper and dispatch correct event type
- add OTA workflow and update mobile workflow
- provide `update-status.js` script
- update tests for new flow

## Testing
- `npm run build --silent`
- `npm test --silent`

------
