### PR TITLE
0.2.262

### DIFF
--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,27 @@
+name: rollback
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+      - run: pnpm i
+      - id: sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: honeylabs
+          SENTRY_PROJECT: honeylabs
+        run: |
+          rate=$(npx sentry-cli stats --json | node -e "const d=require('fs').readFileSync(0,'utf8');console.log(JSON.parse(d).error_rate||0)")
+          echo "error_rate=$rate" >> $GITHUB_OUTPUT
+      - name: rollback if needed
+        if: ${{ steps.sentry.outputs.error_rate >= 0.5 }}
+        run: |
+          capgo promote --channel prev-stable
+          node scripts/update-app-info.js $(jq -r '.sha256' lib/app-info.json) $(jq -r '.version' lib/app-info.json)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - Configuramos `android/app/build.gradle` para firmar en modo release.
 - Progreso SSE ahora se actualiza cada 2 s desde GitHub Checks.
 
+## 0.2.262
+- Verificamos descargas antes de mostrar el botón.
+- Ejecutamos `Updater.check()` al iniciar la app.
+- Añadimos workflow `rollback.yml` para revertir versiones con Sentry.
+
 ## 0.2.258
 - Ocultamos el botón de generación salvo para administradores.
 - Enviamos `commit` y `type` al iniciar la compilación.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.2.260",
+  "version": "0.2.262",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/dashboard/app/page.tsx
+++ b/src/app/dashboard/app/page.tsx
@@ -50,6 +50,16 @@ export default function AppPage() {
     },
   });
 
+  const { data: canDownload } = useQuery({
+    queryKey: ['app-url-valid', info?.version],
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch(API_APP_URL, { method: 'HEAD', signal })
+      return res.ok
+    },
+    enabled: !!info,
+    refetchInterval: 60_000,
+  })
+
   const buildMutation = useMutation({
     mutationFn: startBuild,
     onMutate: () => {
@@ -137,15 +147,17 @@ export default function AppPage() {
         Versión actual: <span className="font-mono">{info.version}</span>
       </p>
       <p className="break-all font-mono text-sm">SHA-256: {info.sha256}</p>
-      <a
-        href={info.url}
-        download
-        rel="noopener"
-        onClick={handleDownload}
-        className="inline-block px-4 py-2 bg-accent-500 text-black rounded"
-      >
-        Descargar
-      </a>
+      {canDownload && (
+        <a
+          href={info.url}
+          download
+          rel="noopener"
+          onClick={handleDownload}
+          className="inline-block px-4 py-2 bg-accent-500 text-black rounded"
+        >
+          Descargar
+        </a>
+      )}
       {isAdminUser(usuario) && (
         <button
           type="button"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,3 +3,6 @@ import { CapacitorUpdater as Updater } from '@capgo/capacitor-updater'
 Updater.addListener('downloadComplete', () => {
   Updater.reload()
 })
+
+// Verificamos actualizaciones OTA al iniciar la app
+Updater.check().catch(() => {})


### PR DESCRIPTION
## Summary
- verificamos el enlace de descarga antes de mostrarlo
- ejecutamos `Updater.check()` al arrancar la app
- añadimos workflow `rollback.yml` para revertir cuando Sentry detecta errores
- bump a 0.2.262

## Testing
- `npm test`
- `npm run build`


------
