### PR TITLE
0.2.264

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -2,15 +2,23 @@ import { PrismaClient } from '@prisma/client'
 
 const globalForPrisma = global as unknown as { prisma: PrismaClient }
 
-function resolveDatabaseUrl() {
+export function resolveDatabaseUrl() {
   let url = process.env.DATABASE_URL
   if (!url) return undefined
+
+  if (url.startsWith('prisma+postgres://')) {
+    url = url.replace('prisma+postgres://', 'prisma+postgresql://')
+  } else if (url.startsWith('postgres://')) {
+    url = url.replace('postgres://', 'postgresql://')
+  }
+
   const useProxy = process.env.PRISMA_DATA_PROXY?.toLowerCase() === 'true'
   if (useProxy && !url.startsWith('prisma://') && !url.startsWith('prisma+')) {
-    if (url.startsWith('postgres://') || url.startsWith('postgresql://')) {
+    if (url.startsWith('postgresql://')) {
       url = `prisma+${url}`
     }
   }
+
   return url
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.2.263",
+  "version": "0.2.264",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/tests/resolveDatabaseUrl.test.ts
+++ b/tests/resolveDatabaseUrl.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { resolveDatabaseUrl } from '../lib/prisma'
+
+const clean = () => {
+  delete process.env.PRISMA_DATA_PROXY
+  delete process.env.DATABASE_URL
+}
+
+describe('resolveDatabaseUrl', () => {
+  afterEach(clean)
+
+  it('corrige prefijo prisma+postgres', () => {
+    process.env.DATABASE_URL = 'prisma+postgres://example'
+    expect(resolveDatabaseUrl()).toBe('prisma+postgresql://example')
+  })
+
+  it('agrega prisma+ con data proxy', () => {
+    process.env.DATABASE_URL = 'postgresql://db'
+    process.env.PRISMA_DATA_PROXY = 'true'
+    expect(resolveDatabaseUrl()).toBe('prisma+postgresql://db')
+  })
+})
+


### PR DESCRIPTION
## Summary
- normalize Prisma URLs to support deprecated `prisma+postgres://` prefix
- export `resolveDatabaseUrl` for testing and add unit tests
- bump version to 0.2.264

## Testing
- `pnpm install`
- `npm run build`
- `npm test`


------
