### PR TITLE
Fix Prisma proxy URL handling

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -6,9 +6,7 @@ export function resolveDatabaseUrl() {
   let url = process.env.DATABASE_URL
   if (!url) return undefined
 
-  if (url.startsWith('prisma+postgres://')) {
-    url = url.replace('prisma+postgres://', 'prisma+postgresql://')
-  } else if (url.startsWith('postgres://')) {
+  if (url.startsWith('postgres://')) {
     url = url.replace('postgres://', 'postgresql://')
   }
 

--- a/tests/resolveDatabaseUrl.test.ts
+++ b/tests/resolveDatabaseUrl.test.ts
@@ -11,7 +11,7 @@ describe('resolveDatabaseUrl', () => {
 
   it('corrige prefijo prisma+postgres', () => {
     process.env.DATABASE_URL = 'prisma+postgres://example'
-    expect(resolveDatabaseUrl()).toBe('prisma+postgresql://example')
+    expect(resolveDatabaseUrl()).toBe('prisma+postgres://example')
   })
 
   it('agrega prisma+ con data proxy', () => {


### PR DESCRIPTION
## Summary
- maintain `prisma+postgres://` URLs in resolveDatabaseUrl
- update unit test to reflect new behaviour

## Testing
- `pnpm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68660d829f348328bdeca527f8c52658