### PR TITLE
0.2.268

### DIFF
--- a/lib/buildStatus.ts
+++ b/lib/buildStatus.ts
@@ -1,0 +1,24 @@
+import fs from 'fs/promises'
+import path from 'path'
+
+export const buildStatusPath = path.join(process.cwd(), 'public', 'build-status.json')
+
+export type BuildStatus = {
+  building: boolean
+  progress: number
+  timestamp?: number
+  error?: string
+}
+
+export async function updateBuildStatus(data: BuildStatus) {
+  await fs.writeFile(buildStatusPath, JSON.stringify({ ...data, timestamp: Date.now() }))
+}
+
+export async function readBuildStatus(): Promise<BuildStatus> {
+  try {
+    const raw = await fs.readFile(buildStatusPath, 'utf8')
+    return JSON.parse(raw) as BuildStatus
+  } catch {
+    return { building: false, progress: 0 }
+  }
+}

--- a/scripts/update-status.js
+++ b/scripts/update-status.js
@@ -5,7 +5,7 @@ async function main() {
   const [runId, pct] = process.argv.slice(2)
   const progress = Math.max(0, Math.min(1, parseFloat(pct || '0')))
   const building = progress < 1
-  const file = path.join(process.cwd(), 'lib', 'build-status.json')
+  const file = path.join(process.cwd(), 'public', 'build-status.json')
   await fs.writeFile(file, JSON.stringify({ building, progress }))
 
   const token = process.env.GITHUB_TOKEN

--- a/src/app/api/app/url/route.ts
+++ b/src/app/api/app/url/route.ts
@@ -26,6 +26,9 @@ export async function HEAD() {
     const { url } = JSON.parse(raw) as { url: string }
     const res = await fetch(url, { method: 'HEAD' })
     if (res.ok) return new Response(null)
+    if (!res.ok && process.env.AWS_APK_URL) {
+      return NextResponse.json({ url: process.env.AWS_APK_URL })
+    }
     if (
       res.status === 403 &&
       process.env.AWS_S3_BUCKET &&
@@ -61,6 +64,9 @@ export async function HEAD() {
     }
     return new Response(null, { status: res.status })
   } catch {
+    if (process.env.AWS_APK_URL) {
+      return NextResponse.json({ url: process.env.AWS_APK_URL })
+    }
     return new Response(null, { status: 500 })
   }
 }

--- a/src/app/api/build-mobile/route.ts
+++ b/src/app/api/build-mobile/route.ts
@@ -4,14 +4,17 @@ import { NextRequest, NextResponse } from 'next/server'
 import fs from 'fs/promises'
 import path from 'path'
 import { env } from 'process'
+if (process.env.NODE_ENV !== 'production') {
+  await import('dotenv/config')
+}
 import { getUsuarioFromSession } from '@lib/auth'
 import { isAdminUser } from '@lib/permisos'
 import { detectNativeChanges } from '@lib/mobile'
 import * as logger from '@lib/logger'
+import { updateBuildStatus, readBuildStatus } from '@lib/buildStatus'
+import { z } from 'zod'
 
 let lastRun = 0
-
-const buildStatusPath = path.join(process.cwd(), 'lib', 'build-status.json')
 
 export async function POST(req: NextRequest) {
   const usuario = await getUsuarioFromSession(req)
@@ -29,42 +32,69 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'rate_limited' }, { status: 429 })
   }
   try {
-    const prevRaw = await fs.readFile(buildStatusPath, 'utf8').catch(() => '{"building":false}')
-    const prev = JSON.parse(prevRaw) as { building: boolean }
+    const prev = await readBuildStatus()
     if (prev.building) {
       return NextResponse.json({ error: 'busy' }, { status: 429 })
     }
   } catch {}
-  lastRun = Date.now()
+
+  const schema = z.object({
+    type: z.enum(['auto', 'manual']).optional(),
+    commit: z.string().length(64).optional(),
+  })
+
+  let body: any = {}
   try {
-    await fs.writeFile(buildStatusPath, JSON.stringify({ building: true, progress: 0 }))
-    const repo = env.GITHUB_REPO
-    const token = env.GITHUB_TOKEN
-    if (repo && token) {
-      const native = await detectNativeChanges()
-      const eventType = native ? 'native' : 'ota'
-      fetch(`https://api.github.com/repos/${repo}/dispatches`, {
-        method: 'POST',
-        headers: {
-          Authorization: `token ${token}`,
-          'User-Agent': 'honeylabs-build',
-          Accept: 'application/vnd.github+json',
-        },
-        body: JSON.stringify({ event_type: eventType }),
-      }).catch((err) => logger.error('[BUILD_MOBILE] dispatch error', err))
+    const raw = await req.text()
+    if (raw) body = schema.parse(JSON.parse(raw))
+  } catch {
+    return NextResponse.json({ error: 'invalid_body' }, { status: 400 })
+  }
+
+  const { GITHUB_REPO, GITHUB_TOKEN, GITHUB_BRANCH } = process.env
+  if (!GITHUB_REPO || !GITHUB_TOKEN) {
+    await updateBuildStatus({ building: false, progress: 0 })
+    return NextResponse.json({ error: 'missing_env' }, { status: 500 })
+  }
+  const workflow = path.join(process.cwd(), '.github', 'workflows', 'build.yml')
+  try {
+    await fs.access(workflow)
+  } catch {
+    await updateBuildStatus({ building: false, progress: 0 })
+    return NextResponse.json({ error: 'workflow_missing' }, { status: 500 })
+  }
+
+  await updateBuildStatus({ building: true, progress: 0 })
+  lastRun = Date.now()
+
+  try {
+    const native = await detectNativeChanges()
+    const ref = body.commit || GITHUB_BRANCH || 'main'
+    const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/actions/workflows/build.yml/dispatches`, {
+      method: 'POST',
+      headers: {
+        Authorization: `token ${GITHUB_TOKEN}`,
+        'User-Agent': 'honeylabs-build',
+        Accept: 'application/vnd.github+json',
+      },
+      body: JSON.stringify({ ref, inputs: { event: native ? 'native' : 'ota', type: body.type || 'auto' } }),
+    })
+    if (!res.ok) {
+      const error = await res.text()
+      await updateBuildStatus({ building: false, progress: 0, error })
+      return NextResponse.json({ error: 'workflow_dispatch_failed', details: error }, { status: 500 })
     }
     return NextResponse.json({ ok: true }, { status: 202 })
-  } catch (err) {
-    logger.error('[BUILD_MOBILE]', err)
-    await fs.writeFile(buildStatusPath, JSON.stringify({ building: false, progress: 0 }))
-    return NextResponse.json({ error: 'failed' }, { status: 500 })
+  } catch (err: any) {
+    logger.error('[BUILD_MOBILE] Error:', err.message)
+    await updateBuildStatus({ building: false, progress: 0, error: err.message })
+    return NextResponse.json({ error: 'dispatch_error', message: err.message }, { status: 500 })
   }
 }
 
 export async function GET() {
   try {
-    const statusRaw = await fs.readFile(buildStatusPath, 'utf8')
-    const status = JSON.parse(statusRaw) as { building: boolean; progress: number }
+    const status = await readBuildStatus()
     return NextResponse.json(status)
   } catch {
     return NextResponse.json({ building: false, progress: 0 })

--- a/src/app/api/build-mobile/status/route.ts
+++ b/src/app/api/build-mobile/status/route.ts
@@ -1,0 +1,13 @@
+export const runtime = 'nodejs'
+
+import { NextResponse } from 'next/server'
+import { readBuildStatus } from '@lib/buildStatus'
+
+export async function GET() {
+  try {
+    const status = await readBuildStatus()
+    return NextResponse.json(status)
+  } catch {
+    return NextResponse.json({ building: false, progress: 0 })
+  }
+}

--- a/src/app/api/build-mobile/update/route.ts
+++ b/src/app/api/build-mobile/update/route.ts
@@ -3,9 +3,9 @@ export const runtime = 'nodejs'
 import { NextRequest, NextResponse } from 'next/server'
 import fs from 'fs/promises'
 import path from 'path'
+import { updateBuildStatus } from '@lib/buildStatus'
 
 const appInfoPath = path.join(process.cwd(), 'lib', 'app-info.json')
-const buildStatusPath = path.join(process.cwd(), 'lib', 'build-status.json')
 
 export async function POST(req: NextRequest) {
   let body: any
@@ -23,6 +23,6 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'invalid' }, { status: 400 })
   }
   await fs.writeFile(appInfoPath, JSON.stringify({ version, url, sha256 }, null, 2))
-  await fs.writeFile(buildStatusPath, JSON.stringify({ building: false, progress: 1 }))
+  await updateBuildStatus({ building: false, progress: 1 })
   return NextResponse.json({ success: true })
 }

--- a/tests/buildMobile.test.ts
+++ b/tests/buildMobile.test.ts
@@ -6,7 +6,7 @@ import * as auth from '../lib/auth'
 import * as mobile from '../lib/mobile'
 import { POST } from '../src/app/api/build-mobile/route'
 
-const buildStatusPath = path.join(process.cwd(), 'lib', 'build-status.json')
+const buildStatusPath = path.join(process.cwd(), 'public', 'build-status.json')
 const envBackup = { repo: process.env.GITHUB_REPO, token: process.env.GITHUB_TOKEN }
 
 afterEach(async () => {
@@ -14,12 +14,17 @@ afterEach(async () => {
   process.env.GITHUB_REPO = envBackup.repo
   process.env.GITHUB_TOKEN = envBackup.token
   await fs.writeFile(buildStatusPath, JSON.stringify({ building: false, progress: 0 }))
+  await fs.rm(path.join(process.cwd(), '.github', 'workflows', 'build.yml')).catch(() => {})
 })
 
 describe('build mobile endpoint', () => {
   it('rejects unauthorized user', async () => {
     vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue(null as any)
-    const req = new NextRequest('http://localhost/api/build-mobile', { method: 'POST', headers: { 'x-csrf-token': 'secret' } })
+    const req = new NextRequest('http://localhost/api/build-mobile', {
+      method: 'POST',
+      headers: { 'x-csrf-token': 'secret' },
+      body: JSON.stringify({ commit: 'a'.repeat(64) }),
+    })
     const res = await POST(req)
     expect(res.status).toBe(401)
   })
@@ -32,16 +37,36 @@ describe('build mobile endpoint', () => {
     expect(res.status).toBe(403)
   })
 
+  it('returns 500 when env missing', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ tipoCuenta: 'admin' } as any)
+    process.env.CSRF_TOKEN = 'secret'
+    const req = new NextRequest('http://localhost/api/build-mobile', {
+      method: 'POST',
+      headers: { 'x-csrf-token': 'secret' },
+      body: JSON.stringify({ commit: 'a'.repeat(64) }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(500)
+  })
+
   it('triggers build for admin', async () => {
     vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ tipoCuenta: 'admin' } as any)
     vi.spyOn(mobile, 'detectNativeChanges').mockResolvedValue(false)
     const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))
+    process.env.GITHUB_REPO = 'repo'
+    process.env.GITHUB_TOKEN = 'tok'
+    await fs.writeFile(path.join(process.cwd(), '.github', 'workflows', 'build.yml'), '')
     process.env.CSRF_TOKEN = 'secret'
-    const req = new NextRequest('http://localhost/api/build-mobile', { method: 'POST', headers: { 'x-csrf-token': 'secret' } })
+    const req = new NextRequest('http://localhost/api/build-mobile', {
+      method: 'POST',
+      headers: { 'x-csrf-token': 'secret' },
+      body: JSON.stringify({ commit: 'a'.repeat(64) }),
+    })
     const res = await POST(req)
     expect(res.status).toBe(202)
     const body = JSON.parse(fetchMock.mock.calls[0][1].body)
-    expect(body.event_type).toBe('ota')
+    expect(body.ref).toBe('a'.repeat(64))
+    expect(body.inputs.event).toBe('ota')
     const data = await res.json()
     expect(data.ok).toBe(true)
   })
@@ -53,7 +78,11 @@ describe('build mobile endpoint', () => {
     process.env.GITHUB_REPO = 'repo'
     process.env.GITHUB_TOKEN = 'tok'
     process.env.CSRF_TOKEN = 'secret'
-    const req = new NextRequest('http://localhost/api/build-mobile', { method: 'POST', headers: { 'x-csrf-token': 'secret' } })
+    const req = new NextRequest('http://localhost/api/build-mobile', {
+      method: 'POST',
+      headers: { 'x-csrf-token': 'secret' },
+      body: JSON.stringify({ commit: 'a'.repeat(64) }),
+    })
     await POST(req)
     const statusRaw = await fs.readFile(buildStatusPath, 'utf8')
     const status = JSON.parse(statusRaw)
@@ -64,7 +93,11 @@ describe('build mobile endpoint', () => {
     vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ tipoCuenta: 'admin' } as any)
     await fs.writeFile(buildStatusPath, JSON.stringify({ building: true, progress: 0 }))
     process.env.CSRF_TOKEN = 'secret'
-    const req = new NextRequest('http://localhost/api/build-mobile', { method: 'POST', headers: { 'x-csrf-token': 'secret' } })
+    const req = new NextRequest('http://localhost/api/build-mobile', {
+      method: 'POST',
+      headers: { 'x-csrf-token': 'secret' },
+      body: JSON.stringify({ commit: 'a'.repeat(64) }),
+    })
     const res = await POST(req)
     expect(res.status).toBe(429)
   })

--- a/tests/buildMobileUpdate.test.ts
+++ b/tests/buildMobileUpdate.test.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import { POST } from '../src/app/api/build-mobile/update/route'
 
 const appInfoPath = path.join(process.cwd(), 'lib', 'app-info.json')
-const buildStatusPath = path.join(process.cwd(), 'lib', 'build-status.json')
+const buildStatusPath = path.join(process.cwd(), 'public', 'build-status.json')
 
 let infoBackup: string | null = null
 let statusBackup: string | null = null


### PR DESCRIPTION
## Summary
- handle `missing_env` and dispatch errors in build endpoint
- track build status in `public/build-status.json`
- add health check endpoint and workflow dispatch validation
- adjust build mobile tests
- allow APK fallback URL

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/