### PR TITLE
0.2.268

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -25,6 +25,12 @@ jobs:
       - run: pnpm i
       - name: Setup environment
         run: echo "${{ secrets.ENV_FILE }}" > .env
+      - name: Validate DATABASE_URL
+        run: |
+          if ! grep -q '^DATABASE_URL=prisma' .env; then
+            echo 'DATABASE_URL debe iniciar con prisma://' >&2
+            exit 1
+          fi
       - run: pnpm build
       - run: nx affected -t build --prod
       - run: next build && next export -o dist

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -21,6 +21,12 @@ jobs:
       - run: pnpm i
       - name: Setup environment
         run: echo "${{ secrets.ENV_FILE }}" > .env
+      - name: Validate DATABASE_URL
+        run: |
+          if ! grep -q '^DATABASE_URL=prisma' .env; then
+            echo 'DATABASE_URL debe iniciar con prisma://' >&2
+            exit 1
+          fi
       - run: pnpm build
       - name: progress 20%
         run: gh api -X PATCH /repos/$GITHUB_REPOSITORY/check-runs/${{ steps.check.outputs.id }} -f output='{"summary":"progress:0.2"}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.268
+- Validamos DATABASE_URL en workflows antes del build.
+
 ## 0.2.265
 - Creamos tabla `HistorialUnidad` faltante para prevenir errores en migraciones.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.2.267",
+  "version": "0.2.268",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- validamos `DATABASE_URL` antes del build en workflows móviles
- actualizamos versión a 0.2.268

## Testing
- `npm run build` *(falló: InvalidDatasourceError por variables faltantes)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68672f1b9ef8832892658e29e33a04b7