### PR TITLE
0.2.271

### DIFF
--- a/src/app/api/almacenes/[id]/route.ts
+++ b/src/app/api/almacenes/[id]/route.ts
@@ -175,7 +175,7 @@ export async function DELETE(req: NextRequest) {
   if (!pertenece && !hasManagePerms(usuario)) {
       return NextResponse.json({ error: 'Sin permisos' }, { status: 403 });
     }
-    await prisma.$transaction(async tx => {
+  await prisma.$transaction(async tx => {
       await snapshot(tx, id, usuario.id, 'Eliminación')
       await tx.usuarioAlmacen.deleteMany({ where: { almacenId: id } })
       await tx.codigoAlmacen.deleteMany({ where: { almacenId: id } })
@@ -190,7 +190,9 @@ export async function DELETE(req: NextRequest) {
       await tx.archivoMaterial.deleteMany({ where: { material: { almacenId: id } } })
       await tx.material.deleteMany({ where: { almacenId: id } })
       await tx.almacen.delete({ where: { id } })
-    })
+  })
+
+    await logAudit(usuario.id, 'eliminacion', 'almacen', { almacenId: id })
     return NextResponse.json({ success: true });
   } catch (err) {
     logger.error('DELETE /api/almacenes/[id]', err);
@@ -269,6 +271,8 @@ export async function PUT(req: NextRequest) {
       await snapshot(tx, id, usuario.id, 'Modificación')
       return upd
   })
+
+  await logAudit(usuario.id, 'modificacion', 'almacen', { almacenId: id })
 
   const resp = {
     ...almacen,

--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -8,6 +8,7 @@ import crypto from "node:crypto";
 import { getUsuarioFromSession } from "@lib/auth";
 import { hasManagePerms, normalizeTipoCuenta } from "@lib/permisos";
 import * as logger from '@lib/logger'
+import { logAudit } from '@/lib/audit'
 
 const MAX_IMAGE_MB = 5;
 const MAX_IMAGE_BYTES = MAX_IMAGE_MB * 1024 * 1024;
@@ -260,6 +261,8 @@ export async function POST(req: NextRequest) {
       await snapshot(tx, creado.id, usuario.id, 'Creación')
       return creado
   })
+
+  await logAudit(usuario.id, 'creacion', 'almacen', { almacenId: almacen.id })
 
   const resp = {
     ...almacen,

--- a/src/app/api/materiales/[id]/route.ts
+++ b/src/app/api/materiales/[id]/route.ts
@@ -8,6 +8,7 @@ import { hasManagePerms } from '@lib/permisos'
 import { materialSchema } from '@/lib/validators/material'
 import crypto from 'node:crypto'
 import * as logger from '@lib/logger'
+import { logAudit } from '@/lib/audit'
 
 async function snapshot(
   db: Prisma.TransactionClient | typeof prisma,
@@ -162,6 +163,8 @@ export async function PUT(req: NextRequest) {
       await snapshot(tx, id, usuario.id, 'Modificación')
       return upd
     })
+
+    await logAudit(usuario.id, 'modificacion_material', 'material', { materialId: id })
     return NextResponse.json({ material: actualizado })
   } catch (err) {
     logger.error('PUT /api/materiales/[id]', err)
@@ -193,6 +196,7 @@ export async function DELETE(req: NextRequest) {
       await tx.archivoMaterial.deleteMany({ where: { materialId: id } })
       await tx.material.delete({ where: { id } })
     })
+    await logAudit(usuario.id, 'eliminacion_material', 'material', { materialId: id })
     return NextResponse.json({ success: true })
   } catch (err) {
     logger.error('DELETE /api/materiales/[id]', err)

--- a/src/app/api/materiales/[id]/unidades/route.ts
+++ b/src/app/api/materiales/[id]/unidades/route.ts
@@ -6,6 +6,7 @@ import { Prisma } from '@prisma/client'
 import { getUsuarioFromSession } from '@lib/auth'
 import { hasManagePerms } from '@lib/permisos'
 import * as logger from '@lib/logger'
+import { logAudit } from '@/lib/audit'
 
 async function snapshot(unidadId: number, usuarioId: number, descripcion: string) {
   const unidad = await prisma.materialUnidad.findUnique({
@@ -145,6 +146,7 @@ export async function POST(req: NextRequest) {
         select: { id: true, nombre: true, codigoQR: true },
       })
       await snapshot(creado.id, usuario.id, 'Creación')
+      await logAudit(usuario.id, 'creacion_unidad', 'material', { materialId, unidadId: creado.id })
       return NextResponse.json({ unidad: creado })
     } catch (e) {
       if (


### PR DESCRIPTION
## Summary
- registramos auditorías en las operaciones de almacenes, materiales y unidades
- usamos `logAudit` para anotar creaciones, modificaciones y eliminaciones

## Testing
- `npm run build` *(fails: prisma not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713ea825d083289cc8124ca62ee0c5