### PR TITLE
0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 ## 0.2.270
 - Evitamos conectar a Prisma si DATABASE_URL no está definido durante el build.
 
+## 0.3.0
+- Mejoramos la tarjeta de almacén con acciones en menú y descarga de QR.
+- Selectores y textos actualizados.
+
 ## 0.2.265
 - Creamos tabla `HistorialUnidad` faltante para prevenir errores en migraciones.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.2.258
+0.3.0
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.2.270",
+  "version": "0.3.0",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/components/AlmacenesGrid.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenesGrid.tsx
@@ -1,31 +1,41 @@
 "use client";
-import Image from "next/image";
-import { Star } from "lucide-react";
-import { QRCodeSVG } from "qrcode.react";
-import dayjs from "dayjs";
-import { cn } from "@/lib/utils";
-import type { Almacen } from "@/hooks/useAlmacenes";
+import Image from 'next/image'
+import { Star } from 'lucide-react'
+import { QRCodeSVG } from 'qrcode.react'
+import dayjs from 'dayjs'
+import { cn } from '@/lib/utils'
+import { useRef, useState } from 'react'
+import type { Almacen } from '@/hooks/useAlmacenes'
 
 export default function AlmacenesGrid({
   almacenes,
   onOpen,
   favoritos,
   onToggleFavorito,
+  onEdit,
+  onDelete,
+  onDuplicate,
 }: {
-  almacenes: Almacen[];
-  onOpen: (id: number) => void;
-  favoritos: number[];
-  onToggleFavorito: (id: number) => void;
+  almacenes: Almacen[]
+  onOpen: (id: number) => void
+  favoritos: number[]
+  onToggleFavorito: (id: number) => void
+  onEdit?: (id: number) => void
+  onDelete?: (id: number) => void
+  onDuplicate?: (id: number) => void
 }) {
+  const [openMenu, setOpenMenu] = useState<number | null>(null)
+  const qrRefs = useRef<Record<number, QRCodeSVG | null>>({})
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4" data-oid="p2a3lo_">
       {almacenes.map((a) => (
         <div
           key={a.id}
-          className="flex gap-3 p-3 border rounded-lg cursor-pointer hover:bg-white/5"
+          className="grid grid-cols-[96px_1fr_auto] gap-3 p-3 border rounded-lg cursor-pointer hover:bg-white/5 transition"
+          style={{ boxShadow: 'var(--dashboard-widget-glow)' }}
           onClick={() => onOpen(a.id)}
         >
-          <div className="w-20 h-20 sm:w-24 sm:h-24 flex-shrink-0 bg-white/10 rounded-md overflow-hidden relative">
+          <div className="w-24 h-24 bg-white/10 rounded-md overflow-hidden relative">
             <Image
               src={a.imagenUrl || '/ilustracion-almacen-3d.svg'}
               alt={a.nombre}
@@ -33,24 +43,24 @@ export default function AlmacenesGrid({
               className="object-cover w-full h-full"
             />
           </div>
-          <div className="flex flex-col flex-1">
-            <div className="flex justify-between items-start gap-2">
-              <div>
-                <h3 className="font-semibold">{a.nombre}</h3>
-                <span className="text-xs text-[var(--dashboard-muted)]">ID: {a.id}</span>
-              </div>
-              {a.ultimaActualizacion && (
-                <span className="text-xs text-[var(--dashboard-muted)]">
-                  {dayjs(a.ultimaActualizacion).format('DD/MM/YYYY')}
-                </span>
-              )}
+          <div className="flex flex-col">
+            <div className="flex items-center gap-2">
+              <h3 className="font-semibold text-base">{a.nombre}</h3>
+              <span
+                className={cn(
+                  'px-2 py-0.5 rounded-full text-xs font-semibold',
+                  (a.inventario ?? 0) > 0 ? 'bg-yellow-400 text-black' : 'bg-gray-500 text-white',
+                )}
+              >
+                {a.inventario ?? 0}
+              </span>
               <button
                 onClick={(e) => {
                   e.stopPropagation();
                   onToggleFavorito(a.id);
                 }}
                 className={cn(
-                  'p-1 -mr-1 hover:text-yellow-400',
+                  'ml-auto p-1 hover:text-yellow-400',
                   favoritos.includes(a.id) ? 'text-yellow-300' : 'text-white/50',
                 )}
                 title="Favorito"
@@ -59,6 +69,12 @@ export default function AlmacenesGrid({
                 <Star className="w-4 h-4" fill={favoritos.includes(a.id) ? 'currentColor' : 'none'} />
               </button>
             </div>
+            {a.descripcion && <p className="text-[0.875rem] text-[var(--dashboard-muted)]">{a.descripcion}</p>}
+            {a.ultimaActualizacion && (
+              <p className="text-[0.75rem] text-[var(--dashboard-muted)]">
+                {dayjs(a.ultimaActualizacion).format('DD/MM/YYYY HH:mm')}
+              </p>
+            )}
             <div className="text-xs mt-1 flex gap-2 items-center">
               <span>📥 {a.entradas ?? 0}</span>
               <span>📤 {a.salidas ?? 0}</span>
@@ -89,8 +105,37 @@ export default function AlmacenesGrid({
               )}
             </div>
           </div>
-          <div className="hidden sm:block ml-auto">
-            <QRCodeSVG value={a.codigoUnico ?? ''} size={56} />
+          <div className="flex flex-col items-end gap-2 ml-auto relative">
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                setOpenMenu(openMenu === a.id ? null : a.id)
+              }}
+              className="p-1 text-white/70 hover:text-white"
+              aria-label="Opciones"
+            >
+              ⋮
+            </button>
+            {openMenu === a.id && (
+              <ul className="absolute right-0 top-6 bg-[var(--dashboard-card)] border border-[var(--dashboard-border)] rounded-md text-sm shadow-lg z-10">
+                <li>
+                  <button onClick={(e)=>{e.stopPropagation(); setOpenMenu(null); onEdit?.(a.id);}} className="block w-full text-left px-3 py-1 hover:bg-white/10">Editar</button>
+                </li>
+                <li>
+                  <button onClick={(e)=>{e.stopPropagation(); setOpenMenu(null); onDuplicate?.(a.id);}} className="block w-full text-left px-3 py-1 hover:bg-white/10">Duplicar</button>
+                </li>
+                <li>
+                  <button onClick={(e)=>{e.stopPropagation(); setOpenMenu(null); onDelete?.(a.id);}} className="block w-full text-left px-3 py-1 hover:bg-red-600/40">Eliminar</button>
+                </li>
+              </ul>
+            )}
+            <div className="flex items-center gap-1">
+              <QRCodeSVG ref={(el) => (qrRefs.current[a.id] = el)} value={a.codigoUnico ?? ''} size={56} />
+              <div className="flex flex-col gap-1">
+                <button onClick={(e)=>{e.stopPropagation(); navigator.clipboard.writeText(a.codigoUnico ?? '')}} className="text-xs hover:underline">Copiar</button>
+                <button onClick={(e)=>{e.stopPropagation(); const node=qrRefs.current[a.id]?.svgRef as SVGSVGElement|undefined;if(node){const data=new XMLSerializer().serializeToString(node);const url=URL.createObjectURL(new Blob([data],{type:'image/svg+xml'}));const link=document.createElement('a');link.href=url;link.download=`almacen-${a.id}.svg`;link.click();URL.revokeObjectURL(url);}}} className="text-xs hover:underline">Descargar</button>
+              </div>
+            </div>
           </div>
         </div>
       ))}

--- a/src/app/dashboard/almacenes/components/MaterialForm.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialForm.tsx
@@ -70,6 +70,10 @@ export default function MaterialForm({
         onChange(campo, Number(e.target.value));
         return;
       }
+      if (campo === 'unidad' || campo === 'estado') {
+        onChange(campo, e.target.value || null);
+        return;
+      }
       if (campo === 'miniatura') {
         onChange(campo, (e.target as HTMLInputElement).files?.[0] || null);
         return;
@@ -140,9 +144,9 @@ export default function MaterialForm({
         <label htmlFor="material-unidad" className="text-xs text-[var(--dashboard-muted)]">Unidad de medida base</label>
         <select
           id="material-unidad"
-          value={material.unidad ?? ""}
-          onChange={handle("unidad")}
-          className="dashboard-input w-full mt-1"
+          value={material.unidad ?? ''}
+          onChange={handle('unidad')}
+          className="dashboard-select w-full mt-1"
           disabled={readOnly}
         >
           <option value="">-</option>
@@ -199,7 +203,7 @@ export default function MaterialForm({
           id="material-estado"
           value={material.estado ?? ''}
           onChange={handle('estado')}
-          className="dashboard-input w-full mt-1"
+          className="dashboard-select w-full mt-1"
           disabled={readOnly}
         >
           <option value="">-</option>

--- a/src/app/dashboard/almacenes/components/MaterialList.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialList.tsx
@@ -64,7 +64,7 @@ export default function MaterialList({
         <select
           value={orden}
           onChange={(e) => setOrden(e.target.value as any)}
-          className="p-2 rounded-md bg-white/5"
+          className="dashboard-select"
         >
           <option value="nombre">Nombre</option>
           <option value="cantidad">Cantidad</option>
@@ -124,7 +124,7 @@ export default function MaterialList({
           onClick={onNuevo}
           className="flex-1 py-1 rounded-md bg-[var(--dashboard-accent)] text-black text-sm hover:bg-[var(--dashboard-accent-hover)]"
         >
-          Nuevo
+          Nuevo Material
         </button>
         <button
           onClick={onDuplicar}

--- a/src/app/dashboard/almacenes/components/UnidadForm.tsx
+++ b/src/app/dashboard/almacenes/components/UnidadForm.tsx
@@ -234,7 +234,7 @@ export default function UnidadForm({ unidad, onChange, onGuardar, onCancelar }: 
           id="unidad-estado"
           value={unidad.estado ?? ''}
           onChange={handle('estado')}
-          className="dashboard-input w-full mt-1"
+          className="dashboard-select w-full mt-1"
         >
           <option value="">-</option>
           <option value="pendiente">pendiente</option>

--- a/src/app/dashboard/almacenes/page.tsx
+++ b/src/app/dashboard/almacenes/page.tsx
@@ -25,6 +25,7 @@ export default function AlmacenesPage() {
     handleDragEnd,
     moveItem,
     eliminar,
+    duplicar,
     toggleFavorito,
   } = useAlmacenesLogic();
 
@@ -73,6 +74,12 @@ export default function AlmacenesPage() {
           almacenes={almacenes}
           favoritos={favoritos}
           onToggleFavorito={toggleFavorito}
+          onEdit={(id) => router.push(`/dashboard/almacenes/${id}/editar`)}
+          onDelete={eliminar}
+          onDuplicate={async (id) => {
+            const nuevo = await duplicar(id)
+            if (nuevo) router.push(`/dashboard/almacenes/${nuevo}`)
+          }}
           onOpen={(id) => router.push(`/dashboard/almacenes/${id}`)}
         />
       ) : (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -359,6 +359,20 @@ html, body {
   border-color: var(--dashboard-accent);
 }
 
+/* Selects con estilo HoneyLabs */
+.dashboard-select {
+  @apply rounded-md px-4 py-2 bg-white/5;
+  color: var(--dashboard-text);
+  border: 1.5px solid var(--dashboard-border);
+  font-size: 1rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+.dashboard-select:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--dashboard-accent);
+  border-color: var(--dashboard-accent);
+}
+
 /* --------- TARJETAS --------- */
 .dashboard-card {
   @apply p-4 rounded-md border transition shadow-sm hover:bg-white/5;

--- a/src/hooks/useAlmacenesLogic.ts
+++ b/src/hooks/useAlmacenesLogic.ts
@@ -149,6 +149,25 @@ export default function useAlmacenesLogic() {
     [almacenes],
   )
 
+  const duplicar = useCallback(
+    async (id: number) => {
+      try {
+        const res = await apiFetch(`/api/almacenes/${id}/duplicar`, { method: 'POST' })
+        const data = await jsonOrNull(res)
+        if (res.ok && data?.almacen) {
+          mutate()
+          toast.show('Almacén duplicado', 'success')
+          return data.almacen.id as number
+        }
+        toast.show(data?.error || 'Error al duplicar', 'error')
+      } catch {
+        toast.show('Error al duplicar', 'error')
+      }
+      return null
+    },
+    [mutate, toast],
+  )
+
   const toggleFavorito = useCallback((id: number) => {
     setFavoritos((prev) => {
       const exists = prev.includes(id)
@@ -175,6 +194,7 @@ export default function useAlmacenesLogic() {
     handleDragEnd,
     moveItem,
     eliminar,
+    duplicar,
     toggleFavorito,
   }
 }

--- a/src/lib/validators/material.ts
+++ b/src/lib/validators/material.ts
@@ -4,7 +4,8 @@ export const materialSchema = z.object({
   nombre: z.string().min(1),
   descripcion: z.string().optional(),
   cantidad: z.coerce.number().int().nonnegative(),
-  unidad: z.string().optional().nullable(),
+  unidad: z
+    .preprocess((v) => (v === '' ? null : v), z.string().optional().nullable()),
   lote: z.string().optional().nullable(),
   fechaCaducidad: z.coerce.date().optional().nullable(),
   ubicacion: z.string().optional().nullable(),


### PR DESCRIPTION
## Summary
- refine material validator to accept empty `unidad`
- tweak global select styles
- adjust select usage across forms
- show `Nuevo Material` button label
- improve `AlmacenesGrid` layout with menu actions and QR tools
- bump version to 0.3.0

## Testing
- `npm run build` *(fails: prisma not found)*
- `npm test` *(fails: vitest not found)*

------
