### PR TITLE
0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Mejoramos la tarjeta de almacén con acciones en menú y descarga de QR.
 - Selectores y textos actualizados.
 
+## 0.3.1
+- Integramos sistema de pestañas persistentes con Zustand.
+
 ## 0.2.265
 - Creamos tabla `HistorialUnidad` faltante para prevenir errores en migraciones.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.3.0
+0.3.1
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/[id]/layout.tsx
+++ b/src/app/dashboard/almacenes/[id]/layout.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import AlmacenDetailNavbar from "../components/AlmacenDetailNavbar";
 import Spinner from "@/components/Spinner";
 import useSession from "@/hooks/useSession";
+import TabBoard from "../components/TabBoard";
 
 function ProtectedAlmacen({ children }: { children: React.ReactNode }) {
   const { fullscreen, setFullscreen } = useDashboardUI();
@@ -51,10 +52,10 @@ function ProtectedAlmacen({ children }: { children: React.ReactNode }) {
       >
         <AlmacenDetailNavbar />
         <section
-          className="flex-1 p-4 overflow-y-auto bg-[var(--dashboard-bg)] text-[var(--dashboard-text)]"
+          className="flex-1 overflow-y-auto bg-[var(--dashboard-bg)] text-[var(--dashboard-text)]"
           data-oid="fuuwox1"
         >
-          {children}
+          <TabBoard />
         </section>
       </main>
     </div>

--- a/src/app/dashboard/almacenes/[id]/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/page.tsx
@@ -17,6 +17,7 @@ import { generarUUID } from "@/lib/uuid";
 import type { UnidadDetalle } from "@/types/unidad-detalle";
 import useUnidades from "@/hooks/useUnidades";
 import QuickInventoryModal from "./QuickInventoryModal";
+import { useTabStore } from "@/hooks/useTabs";
 
 interface Almacen {
   id: number;
@@ -59,6 +60,11 @@ export default function AlmacenPage() {
   const [unidadSel, setUnidadSel] = useState<UnidadDetalle | null>(null);
   const [historialBackup, setHistorialBackup] = useState<any | null>(null);
   const [showQuick, setShowQuick] = useState(false);
+  const { add } = useTabStore();
+  useEffect(() => {
+    if (!id) return;
+    add({ id: `almacen-${id}-materiales`, title: `Almacén ${id}`, type: 'materiales' });
+  }, [id, add]);
 
   const routerNav = useNextRouter();
   const selectedMaterial = historialBackup

--- a/src/app/dashboard/almacenes/components/DraggableTab.tsx
+++ b/src/app/dashboard/almacenes/components/DraggableTab.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { useRef } from "react";
+import { useTabStore, Tab } from "@/hooks/useTabs";
+
+export default function DraggableTab({ tab, index }: { tab: Tab; index: number }) {
+  const { activeId, setActive, move, update, close } = useTabStore();
+  const ref = useRef<HTMLDivElement>(null);
+
+  const onDragStart = (e: React.DragEvent) => {
+    e.dataTransfer.setData("tab-index", String(index));
+  };
+  const onDrop = (e: React.DragEvent) => {
+    const from = Number(e.dataTransfer.getData("tab-index"));
+    move(from, index);
+  };
+
+  const pin = () => update(tab.id, { pinned: !tab.pinned });
+  const toggle = () => update(tab.id, { collapsed: !tab.collapsed });
+  const minimize = () => update(tab.id, { minimized: true });
+  const popout = (e: React.MouseEvent) => {
+    e.preventDefault();
+    update(tab.id, { popout: true });
+  };
+
+  return (
+    <div
+      ref={ref}
+      draggable
+      onDragStart={onDragStart}
+      onDrop={onDrop}
+      onDragOver={(e) => e.preventDefault()}
+      onClick={() => setActive(tab.id)}
+      onDoubleClick={toggle}
+      onContextMenu={popout}
+      className={`px-3 py-1 rounded cursor-pointer select-none flex items-center gap-1 text-sm whitespace-nowrap ${
+        activeId === tab.id ? "bg-[var(--dashboard-accent)] text-black" : "bg-[var(--dashboard-sidebar)] text-white"
+      }`}
+    >
+      <span>{tab.title}</span>
+      <button onClick={pin} className="text-xs">📌</button>
+      {!tab.pinned && (
+        <button onClick={() => close(tab.id)} className="text-xs">×</button>
+      )}
+      <button onClick={minimize} className="text-xs">_</button>
+    </div>
+  );
+}

--- a/src/app/dashboard/almacenes/components/TabBoard.tsx
+++ b/src/app/dashboard/almacenes/components/TabBoard.tsx
@@ -1,0 +1,62 @@
+"use client";
+import { useTabStore, Tab } from "@/hooks/useTabs";
+import DraggableTab from "./DraggableTab";
+import MaterialList from "./MaterialList";
+import MaterialForm from "./MaterialForm";
+import UnidadesPanel from "../[id]/UnidadesPanel";
+import AuditoriasPanel from "../[id]/AuditoriasPanel";
+
+function TabContent({ tab }: { tab: Tab }) {
+  switch (tab.type) {
+    case "materiales":
+      return <MaterialList materiales={[]} selectedId={null} onSeleccion={() => {}} busqueda="" setBusqueda={() => {}} orden="nombre" setOrden={() => {}} onNuevo={() => {}} onDuplicar={() => {}} />;
+    case "form-material":
+      return <MaterialForm material={null} onChange={() => {}} onGuardar={() => {}} onCancelar={() => {}} onDuplicar={() => {}} onEliminar={() => {}} />;
+    case "unidades":
+      return <UnidadesPanel material={null} onChange={() => {}} onSelect={() => {}} />;
+    case "auditorias":
+      return <AuditoriasPanel material={null} almacenId={0} onSelectHistorial={() => {}} />;
+    default:
+      return null;
+  }
+}
+
+export default function TabBoard() {
+  const { tabs, activeId, update } = useTabStore();
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex gap-2 overflow-x-auto border-b border-[var(--dashboard-border)] py-1">
+        {tabs.map((tab, i) => (
+          <DraggableTab key={tab.id} tab={tab} index={i} />
+        ))}
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {tabs.map(
+          (tab) =>
+            tab.id === activeId && !tab.minimized && (
+              <div key={tab.id} className={tab.collapsed ? "hidden" : "block"}>
+                <TabContent tab={tab} />
+              </div>
+            ),
+        )}
+      </div>
+      {tabs.map(
+        (tab) =>
+          tab.popout && (
+            <div
+              key={"pop-" + tab.id}
+              className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center"
+              onClick={() => update(tab.id, { popout: false })}
+            >
+              <div
+                className="bg-[var(--dashboard-bg)] p-4 rounded max-w-5xl w-full max-h-full overflow-y-auto"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <TabContent tab={tab} />
+              </div>
+            </div>
+          ),
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -1,0 +1,64 @@
+"use client";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type TabType =
+  | "materiales"
+  | "unidades"
+  | "auditorias"
+  | "form-material"
+  | "form-unidad";
+
+export interface Tab {
+  id: string;
+  title: string;
+  type: TabType;
+  pinned?: boolean;
+  collapsed?: boolean;
+  minimized?: boolean;
+  popout?: boolean;
+}
+
+interface TabState {
+  tabs: Tab[];
+  activeId: string | null;
+  add: (tab: Tab) => void;
+  close: (id: string) => void;
+  move: (from: number, to: number) => void;
+  setActive: (id: string) => void;
+  update: (id: string, data: Partial<Tab>) => void;
+}
+
+function arrayMove<T>(arr: T[], from: number, to: number) {
+  const copy = arr.slice();
+  const [item] = copy.splice(from, 1);
+  copy.splice(to, 0, item);
+  return copy;
+}
+
+export const useTabStore = create<TabState>()(
+  persist(
+    (set, get) => ({
+      tabs: [],
+      activeId: null,
+      add: (tab) =>
+        set((state) => ({ tabs: [...state.tabs, tab], activeId: tab.id })),
+      close: (id) =>
+        set((state) => ({
+          tabs: state.tabs.filter((t) => t.id !== id),
+          activeId: state.activeId === id ? null : state.activeId,
+        })),
+      move: (from, to) =>
+        set((state) => ({ tabs: arrayMove(state.tabs, from, to) })),
+      setActive: (id) => set({ activeId: id }),
+      update: (id, data) =>
+        set((state) => ({
+          tabs: state.tabs.map((t) => (t.id === id ? { ...t, ...data } : t)),
+        })),
+    }),
+    {
+      name: "honey-tabs",
+      skipHydration: true,
+    },
+  ),
+);

--- a/tests/tabStore.test.ts
+++ b/tests/tabStore.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useTabStore } from '../src/hooks/useTabs'
+
+beforeEach(() => {
+  const storage = {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+  }
+  Object.defineProperty(globalThis, 'localStorage', { value: storage, configurable: true })
+  useTabStore.setState({ tabs: [], activeId: null })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useTabStore', () => {
+  it('adds and activates tabs', () => {
+    useTabStore.getState().add({ id: '1', title: 't1', type: 'materiales' })
+    const state = useTabStore.getState()
+    expect(state.tabs.length).toBe(1)
+    expect(state.activeId).toBe('1')
+  })
+
+  it('moves tabs', () => {
+    const store = useTabStore.getState()
+    store.add({ id: 'a', title: 'A', type: 'materiales' })
+    store.add({ id: 'b', title: 'B', type: 'unidades' })
+    store.move(1, 0)
+    expect(useTabStore.getState().tabs[0].id).toBe('b')
+  })
+})


### PR DESCRIPTION
## Summary
- integrate a basic tabs system using zustand
- create TabBoard and DraggableTab components
- plug TabBoard into almacen layout
- auto create Materials tab on almacen page
- bump version to 0.3.1

## Testing
- `npm run build` *(fails: prisma not found)*
- `npm test` *(fails: vitest not found)*

------
