### PR TITLE
Implement menu for warehouse tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 ## 0.3.1
 - Integramos sistema de pestañas persistentes con Zustand.
 
+## 0.4.0
+- Incluimos menú de tarjetas en el navbar de almacenes para añadir nuevas pestañas.
+
 ## 0.2.265
 - Creamos tabla `HistorialUnidad` faltante para prevenir errores en migraciones.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.3.1
+0.4.0
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/components/AlmacenDetailNavbar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenDetailNavbar.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import useSession from "@/hooks/useSession";
 import UserMenu from "@/components/UserMenu";
 import AlmacenTools from "./AlmacenTools";
+import TabsMenu from "./TabsMenu";
 import { jsonOrNull } from "@lib/http";
 import { useDashboardUI } from "../../ui";
 import { NAVBAR_HEIGHT } from "../../constants";
@@ -140,6 +141,7 @@ export default function AlmacenDetailNavbar() {
             <ArrowLeft className="w-5 h-5" />
           </button>
         )}
+        <TabsMenu />
         <AlmacenTools id={id as string} />
         <button
           onClick={guardar}

--- a/src/app/dashboard/almacenes/components/TabsMenu.tsx
+++ b/src/app/dashboard/almacenes/components/TabsMenu.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { useState, useRef, useEffect } from "react";
+import { Plus } from "lucide-react";
+import { useTabStore, type TabType } from "@/hooks/useTabs";
+import { generarUUID } from "@/lib/uuid";
+
+const options: Array<{ type: TabType; label: string }> = [
+  { type: "materiales", label: "Materiales" },
+  { type: "form-material", label: "Formulario Material" },
+  { type: "unidades", label: "Unidades" },
+  { type: "form-unidad", label: "Formulario Unidad" },
+  { type: "auditorias", label: "Auditorías" },
+];
+
+export default function TabsMenu() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const { add } = useTabStore();
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const create = (type: TabType, label: string) => {
+    add({ id: generarUUID(), title: label, type });
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="p-2 hover:bg-white/10 rounded-lg"
+        title="Agregar tarjeta"
+      >
+        <Plus className="w-5 h-5" />
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-48 rounded-md bg-[var(--dashboard-sidebar)] border border-[var(--dashboard-border)] shadow-lg z-50 text-sm">
+          {options.map(opt => (
+            <button
+              key={opt.type}
+              onClick={() => create(opt.type, opt.label)}
+              className="block w-full text-left px-3 py-2 hover:bg-white/5"
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add **TabsMenu** component with options to insert Materiales, Formularios, Unidades y Auditorías
- integrate TabsMenu into `AlmacenDetailNavbar`
- document feature in CHANGELOG and bump to 0.4.0

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687178704f0883289e353508a0e71ac0