### PR TITLE
0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 ## 0.4.0
 - Incluimos menú de tarjetas en el navbar de almacenes para añadir nuevas pestañas.
 
+## 0.4.2
+- Movimos el handle de arrastre a la cabecera de cada tarjeta.
+- Permitimos cambiar de columna arrastrando la tarjeta.
+- Los formularios ahora aparecen en la columna derecha de forma predeterminada.
+
 ## 0.2.265
 - Creamos tabla `HistorialUnidad` faltante para prevenir errores en migraciones.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/[id]/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/page.tsx
@@ -63,7 +63,7 @@ export default function AlmacenPage() {
   const { add } = useTabStore();
   useEffect(() => {
     if (!id) return;
-    add({ id: `almacen-${id}-materiales`, title: `Almacén ${id}`, type: 'materiales' });
+    add({ id: `almacen-${id}-materiales`, title: `Almacén ${id}`, type: 'materiales', side: 'left' });
   }, [id, add]);
 
   const routerNav = useNextRouter();

--- a/src/app/dashboard/almacenes/components/CardBoard.tsx
+++ b/src/app/dashboard/almacenes/components/CardBoard.tsx
@@ -15,12 +15,12 @@ import DraggableCard from "./DraggableCard";
 import { useDetalleUI } from "../DetalleUI";
 
 export default function CardBoard() {
-  const { tabs, move, add } = useTabStore();
+  const { tabs, move, add, update } = useTabStore();
   const { collapsed } = useDetalleUI();
 
   useEffect(() => {
     if (tabs.length === 0) {
-      add({ id: generarUUID(), title: "Nuevo", type: "blank" });
+      add({ id: generarUUID(), title: "Nuevo", type: "blank", side: "left" });
     }
   }, [tabs.length, add]);
 
@@ -28,16 +28,19 @@ export default function CardBoard() {
 
   const handleDragEnd = (ev: DragEndEvent) => {
     const { active, over } = ev;
-    if (over && active.id !== over.id) {
-      const oldIndex = tabs.findIndex((t) => t.id === active.id);
-      const newIndex = tabs.findIndex((t) => t.id === over.id);
-      if (oldIndex >= 0 && newIndex >= 0) move(oldIndex, newIndex);
+    if (!over || active.id === over.id) return;
+    const oldIndex = tabs.findIndex((t) => t.id === active.id);
+    const newIndex = tabs.findIndex((t) => t.id === over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+    const overSide = tabs[newIndex].side ?? "left";
+    move(oldIndex, newIndex);
+    if ((tabs[oldIndex].side ?? "left") !== overSide) {
+      update(active.id, { side: overSide });
     }
   };
 
-  const formTypes = ["form-material", "form-unidad"];
-  const left = tabs.filter((t) => formTypes.includes(t.type));
-  const right = tabs.filter((t) => !formTypes.includes(t.type));
+  const left = tabs.filter((t) => (t.side ?? "left") === "left");
+  const right = tabs.filter((t) => (t.side ?? "left") === "right");
 
   return (
     <div className={`flex gap-4 transition-all duration-300 ${collapsed ? 'pt-0' : 'pt-2'}`}>\

--- a/src/app/dashboard/almacenes/components/DraggableCard.tsx
+++ b/src/app/dashboard/almacenes/components/DraggableCard.tsx
@@ -63,8 +63,8 @@ export default function DraggableCard({ tab }: { tab: Tab }) {
   };
 
   return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners} className="dashboard-card cursor-move">
-      <div className="flex items-center justify-between mb-2">
+    <div ref={setNodeRef} style={style} {...attributes} className="dashboard-card resize overflow-auto">
+      <div className="flex items-center justify-between mb-2 cursor-move" {...listeners}>
         <span className="font-semibold" onDoubleClick={toggle}>{tab.title}</span>
         <div className="flex items-center gap-1">
           <button onClick={onRename} className="p-1 hover:bg-white/10 rounded" title="Renombrar">

--- a/src/app/dashboard/almacenes/components/TabsMenu.tsx
+++ b/src/app/dashboard/almacenes/components/TabsMenu.tsx
@@ -25,8 +25,10 @@ export default function TabsMenu() {
     return () => document.removeEventListener("mousedown", handler);
   }, []);
 
+  const formTypes = ["form-material", "form-unidad"];
   const create = (type: TabType, label: string) => {
-    addAfterActive({ id: generarUUID(), title: label, type });
+    const side = formTypes.includes(type) ? "right" : "left";
+    addAfterActive({ id: generarUUID(), title: label, type, side });
     setOpen(false);
   };
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -379,6 +379,8 @@ html, body {
   background: var(--dashboard-card);
   border-color: var(--dashboard-border);
   box-shadow: var(--dashboard-shadow);
+  resize: both;
+  overflow: auto;
 }
 .dashboard-card:hover {
   border-color: var(--dashboard-accent);

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -14,6 +14,7 @@ export interface Tab {
   id: string;
   title: string;
   type: TabType;
+  side?: "left" | "right";
   pinned?: boolean;
   collapsed?: boolean;
   minimized?: boolean;


### PR DESCRIPTION
## Summary
- añadimos propiedad `side` a las pestañas
- movimos el handle de arrastre de tarjetas a su cabecera y permitimos redimensionarlas
- formulamos `CardBoard` para soportar columnas y arrastre entre ellas
- definimos la columna por defecto según tipo de formulario
- actualizamos versión del paquete a 0.4.2

## Testing
- `npm run build` *(fails: prisma not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871949445588328af699f503b53dffc