### PR TITLE
0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
 ## 0.4.7
 - Abrimos automáticamente las tarjetas de Unidades y formulario al seleccionar un material.
 
+## 0.4.8
+- Añadimos modelo `HistorialUnidad` en Prisma y campo `estado` a `HistorialLote`.
+- Removimos el reordenamiento automático de pestañas al agregar nuevas.
+
 ## 0.2.265
 - Creamos tabla `HistorialUnidad` faltante para prevenir errores en migraciones.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -345,9 +345,21 @@ model HistorialLote {
   descripcion String?
   ubicacion   String?
   cantidad    Float?
+  estado      Json?
   fecha       DateTime @default(now())
   usuarioId   Int?
   material    Material @relation(fields: [materialId], references: [id])
+  usuario     Usuario? @relation(fields: [usuarioId], references: [id])
+}
+
+model HistorialUnidad {
+  id          Int      @id @default(autoincrement())
+  unidadId    Int
+  descripcion String?
+  estado      Json?
+  fecha       DateTime @default(now())
+  usuarioId   Int?
+  unidad      MaterialUnidad @relation(fields: [unidadId], references: [id], onDelete: Cascade)
   usuario     Usuario? @relation(fields: [usuarioId], references: [id])
 }
 
@@ -387,6 +399,7 @@ model MaterialUnidad {
   observaciones      String?
   imagen             Bytes?
   imagenNombre       String?
+  historial         HistorialUnidad[]
   archivos           ArchivoUnidad[]
   material           Material        @relation(fields: [materialId], references: [id])
 

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -60,7 +60,6 @@ export const useTabStore = create<TabState>()(
           const pos = idx >= 0 ? idx + 1 : state.tabs.length;
           const arr = state.tabs.slice();
           arr.splice(pos, 0, tab);
-          arr.sort((a, b) => Number(b.pinned) - Number(a.pinned));
           return { tabs: arr, activeId: tab.id };
         }),
       closeOthers: (id) =>


### PR DESCRIPTION
## Summary
- añadimos modelo `HistorialUnidad` y campo `estado` a `HistorialLote`
- evitamos reordenamiento automático de pestañas al insertar
- actualizamos la versión a 0.4.8

## Testing
- `npm run build` *(fails: prisma not found)*
- `npm test` *(fails: vitest not found)*

------
