### PR TITLE
0.4.12

### DIFF
--- a/src/app/dashboard/almacenes/components/MaterialForm.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialForm.tsx
@@ -33,17 +33,16 @@ export default function MaterialForm({
 }: Props) {
   const toast = useToast();
   const [preview, setPreview] = useState<string | null>(null);
-  if (!material)
-    return (
-      <p className="text-sm text-[var(--dashboard-muted)]">Selecciona o crea un material.</p>
-    );
-
-  const { unidades } = useUnidades(material.dbId);
+  const { unidades } = useUnidades(material?.dbId);
   const {
     archivos: archivosPreviosHook,
     eliminar,
     mutate,
-  } = useArchivosMaterial(material.dbId);
+  } = useArchivosMaterial(material?.dbId);
+  if (!material)
+    return (
+      <p className="text-sm text-[var(--dashboard-muted)]">Selecciona o crea un material.</p>
+    );
   const archivosPrevios = readOnly && Array.isArray(material.archivos)
     ? (material.archivos as any[]).map((a, i) => ({ ...a, id: i }))
     : archivosPreviosHook;


### PR DESCRIPTION
## Cambios
- Invocamos `useUnidades` y `useArchivosMaterial` incluso cuando no hay material seleccionado para mantener el orden de hooks

## Notas
- `npm run build` finalizó correctamente
- Algunos tests fallaron por errores en `materialsOrderRelation.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6871db125d80832888b598b00fa05aea