### PR TITLE
0.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@
 - Permitimos crear y borrar materiales desde la nueva tarjeta.
 - Solicitamos confirmación al eliminar materiales o unidades.
 
+## 0.4.12
+- Creamos tabla `AuditLog` y ajustamos inserción con Prisma.
+
 ## 0.2.265
 - Creamos tabla `HistorialUnidad` faltante para prevenir errores en migraciones.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/prisma/migrations/20250712000000_audit_log/migration.sql
+++ b/prisma/migrations/20250712000000_audit_log/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" SERIAL NOT NULL,
+    "usuarioId" INTEGER,
+    "accion" TEXT NOT NULL,
+    "entidad" TEXT NOT NULL,
+    "payload" JSONB,
+    "fecha" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_usuarioId_fkey" FOREIGN KEY ("usuarioId") REFERENCES "Usuario"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,6 +100,7 @@ model Usuario {
   plan                 Plan?                  @relation(fields: [planId], references: [id])
   almacenes            UsuarioAlmacen[]
   roles                Rol[]                  @relation("RolToUsuario")
+  auditLogs            AuditLog[]
 }
 
 model BitacoraCambioPerfil {
@@ -518,4 +519,14 @@ enum PrioridadAlerta {
   ALTA
   MEDIA
   BAJA
+}
+
+model AuditLog {
+  id        Int      @id @default(autoincrement())
+  usuarioId Int?
+  accion    String
+  entidad   String
+  payload   Json?
+  fecha     DateTime @default(now())
+  usuario   Usuario? @relation(fields: [usuarioId], references: [id])
 }

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -7,7 +7,7 @@ export async function logAudit(
   try {
     const prisma = (await import('@lib/prisma')).default
     await prisma.$executeRawUnsafe(
-      `INSERT INTO audit_log (usuario_id, accion, entidad, payload, fecha)
+      `INSERT INTO "AuditLog" ("usuarioId", accion, entidad, payload, fecha)
        VALUES ($1,$2,$3,$4,NOW())`,
       usuarioId,
       accion,

--- a/tests/auditLog.test.ts
+++ b/tests/auditLog.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest'
+
+describe('logAudit', () => {
+  it('ejecuta inserción en AuditLog', async () => {
+    const spy = vi.fn()
+    vi.doMock('../lib/prisma', () => ({ default: { $executeRawUnsafe: spy } }))
+    const { logAudit } = await import('../src/lib/audit')
+    await logAudit(1, 'creacion', 'almacen', { foo: 'bar' })
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO "AuditLog"'),
+      1,
+      'creacion',
+      'almacen',
+      JSON.stringify({ foo: 'bar' })
+    )
+    vi.unmock('../lib/prisma')
+  })
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -16,6 +16,11 @@ class PrismaClient {
   usuarioAlmacen = {
     findFirst: () => Promise.resolve(),
   }
+  material = {
+    findMany: () => Promise.resolve(),
+  }
+  $transaction = (cb: any) => cb(this)
+  $executeRawUnsafe = () => Promise.resolve()
   $use() {}
   $connect() {}
 }


### PR DESCRIPTION
## Summary
- añadimos el modelo `AuditLog` a Prisma
- registramos nueva migración
- actualizamos `logAudit` para usar la nueva tabla
- ajustamos el mock global de Prisma en tests y agregamos prueba para `logAudit`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872f5b49b708328a5074d91ffa41981