### PR TITLE
0.4.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@
 ## 0.4.15
 - Limpiamos el filtro de búsqueda al crear un material nuevo en la vista de almacén.
 
+## 0.4.16
+- Corregimos el orden de hooks en `MaterialForm` para evitar errores de renderizado.
+
 ## 0.2.265
 - Creamos tabla `HistorialUnidad` faltante para prevenir errores en migraciones.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "honeylabs",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "honeylabs",
-      "version": "0.4.15",
+      "version": "0.4.16",
       "hasInstallScript": true,
       "dependencies": {
         "@capacitor/core": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/components/MaterialForm.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialForm.tsx
@@ -31,18 +31,19 @@ export default function MaterialForm({
   readOnly = false,
   historialInfo,
 }: Props) {
-  const toast = useToast();
-  const [preview, setPreview] = useState<string | null>(null);
-  const { unidades } = useUnidades(material?.dbId);
-  const {
-    archivos: archivosPreviosHook,
-    eliminar,
-    mutate,
-  } = useArchivosMaterial(material?.dbId);
   if (!material)
     return (
       <p className="text-sm text-[var(--dashboard-muted)]">Selecciona o crea un material.</p>
     );
+
+  const toast = useToast();
+  const [preview, setPreview] = useState<string | null>(null);
+  const { unidades } = useUnidades(material.dbId);
+  const {
+    archivos: archivosPreviosHook,
+    eliminar,
+    mutate,
+  } = useArchivosMaterial(material.dbId);
   const archivosPrevios = readOnly && Array.isArray(material.archivos)
     ? (material.archivos as any[]).map((a, i) => ({ ...a, id: i }))
     : archivosPreviosHook;


### PR DESCRIPTION
## Summary
- prevenimos el error de hooks moviendo la verificación de `material` antes de llamar hooks en `MaterialForm`
- actualizamos versión a **0.4.16**
- documentamos la corrección en el CHANGELOG

## Testing
- `npm test`
- `npm run build`

------
