### PR TITLE
0.4.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@
 ## 0.4.16
 - Corregimos el orden de hooks en `MaterialForm` para evitar errores de renderizado.
 
+## 0.4.17
+- No renderizamos la tarjeta de material sin una selección válida.
+- Validamos el identificador al abrir nuevas tarjetas.
+
 ## 0.2.265
 - Creamos tabla `HistorialUnidad` faltante para prevenir errores en migraciones.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "honeylabs",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "honeylabs",
-      "version": "0.4.16",
+      "version": "0.4.17",
       "hasInstallScript": true,
       "dependencies": {
         "@capacitor/core": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/components/DraggableCard.tsx
+++ b/src/app/dashboard/almacenes/components/DraggableCard.tsx
@@ -19,7 +19,8 @@ function CardContent({ tab }: { tab: Tab }) {
     useBoard();
   const toast = useToast();
   const { addAfterActive, tabs, setActive } = useTabStore();
-  const openMaterial = (id: string) => {
+  const openMaterial = (id: string | null) => {
+    if (!id) return;
     setSelectedId(id);
     const ensure = (type: Tab["type"], title: string, side: "left" | "right") => {
       const existing = tabs.find((t) => t.type === type);
@@ -68,6 +69,7 @@ function CardContent({ tab }: { tab: Tab }) {
         />
       );
     case "form-material":
+      if (!selected) return null;
       return (
         <MaterialForm
           material={selected}

--- a/src/app/dashboard/almacenes/components/MaterialForm.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialForm.tsx
@@ -31,10 +31,7 @@ export default function MaterialForm({
   readOnly = false,
   historialInfo,
 }: Props) {
-  if (!material)
-    return (
-      <p className="text-sm text-[var(--dashboard-muted)]">Selecciona o crea un material.</p>
-    );
+  if (!material) return null;
 
   const toast = useToast();
   const [preview, setPreview] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- no renderizamos `MaterialForm` si no hay material seleccionado
- validamos el id antes de abrir la tarjeta de material
- actualizamos versiones a 0.4.17

## Testing
- `npm test`
- `npm run build` *(falló: JWT_SECRET no definido)*

------
