### PR TITLE
0.4.18

### DIFF
--- a/src/app/dashboard/almacenes/board/BoardProvider.tsx
+++ b/src/app/dashboard/almacenes/board/BoardProvider.tsx
@@ -2,12 +2,17 @@
 import { createContext, useContext, useState } from "react";
 import { useParams } from "next/navigation";
 import type { Material } from "../components/MaterialRow";
+import type { UnidadDetalle } from "@/types/unidad-detalle";
 import useMateriales from "@/hooks/useMateriales";
 
 interface BoardState {
   materiales: Material[];
   selectedId: string | null;
   setSelectedId: (id: string | null) => void;
+  unidadSel: UnidadDetalle | null;
+  setUnidadSel: (u: UnidadDetalle | null) => void;
+  auditoriaSel: number | null;
+  setAuditoriaSel: (id: number | null) => void;
   crear: (m: Material) => Promise<any>;
   actualizar: (m: Material) => Promise<any>;
   eliminar: (id: number) => Promise<any>;
@@ -18,6 +23,10 @@ const Context = createContext<BoardState>({
   materiales: [],
   selectedId: null,
   setSelectedId: () => {},
+  unidadSel: null,
+  setUnidadSel: () => {},
+  auditoriaSel: null,
+  setAuditoriaSel: () => {},
   crear: async () => ({}),
   actualizar: async () => ({}),
   eliminar: async () => ({}),
@@ -28,12 +37,18 @@ export function BoardProvider({ children }: { children: React.ReactNode }) {
   const { id } = useParams();
   const { materiales, crear, actualizar, eliminar, mutate } = useMateriales(id as string);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [unidadSel, setUnidadSel] = useState<UnidadDetalle | null>(null);
+  const [auditoriaSel, setAuditoriaSel] = useState<number | null>(null);
   return (
     <Context.Provider
       value={{
         materiales,
         selectedId,
         setSelectedId,
+        unidadSel,
+        setUnidadSel,
+        auditoriaSel,
+        setAuditoriaSel,
         crear,
         actualizar,
         eliminar,

--- a/src/app/dashboard/almacenes/components/AuditoriaForm.tsx
+++ b/src/app/dashboard/almacenes/components/AuditoriaForm.tsx
@@ -1,0 +1,33 @@
+"use client";
+import useSWR from "swr";
+import fetcher from "@lib/swrFetcher";
+
+interface Props {
+  auditoriaId: number | null;
+  onClose: () => void;
+}
+
+export default function AuditoriaForm({ auditoriaId, onClose }: Props) {
+  const { data } = useSWR(auditoriaId ? `/api/auditorias/${auditoriaId}` : null, fetcher);
+  const auditoria = data?.auditoria;
+
+  if (!auditoriaId) return <p className="text-sm p-2">Selecciona una auditoría.</p>;
+  if (!auditoria) return <p className="text-sm p-2">Cargando...</p>;
+
+  return (
+    <div className="space-y-2 text-sm p-2 overflow-y-auto max-h-[calc(100vh-8rem)]">
+      <div>Tipo: {auditoria.tipo}</div>
+      {auditoria.categoria && <div>Categoría: {auditoria.categoria}</div>}
+      {auditoria.almacen?.nombre && <div>Almacén: {auditoria.almacen.nombre}</div>}
+      {auditoria.material?.nombre && <div>Material: {auditoria.material.nombre}</div>}
+      {auditoria.unidad?.nombre && <div>Unidad: {auditoria.unidad.nombre}</div>}
+      {auditoria.observaciones && <div>{auditoria.observaciones}</div>}
+      {auditoria.usuario?.nombre && <div>Usuario: {auditoria.usuario.nombre}</div>}
+      <div>{new Date(auditoria.fecha).toLocaleString()}</div>
+      <button onClick={onClose} className="px-2 py-1 rounded bg-white/10 text-xs">
+        Cerrar
+      </button>
+    </div>
+  );
+}
+

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -8,6 +8,7 @@ export type TabType =
   | "auditorias"
   | "form-material"
   | "form-unidad"
+  | "form-auditoria"
   | "blank";
 
 export interface Tab {


### PR DESCRIPTION
## Summary
- abrimos formulario de unidad y de auditoría en nuevas pestañas
- extendemos `useTabs` con el tipo `form-auditoria`
- almacenamos en `BoardProvider` la unidad y auditoría seleccionadas
- implementamos `AuditoriaForm` con carga de datos vía API

## Testing
- `npm run build` *(fails: JWT_SECRET no definido)*
- `npm test`

------
