### PR TITLE
0.4.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/[id]/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import QuickInventoryModal from "./QuickInventoryModal";
+import { jsonOrNull } from "@lib/http";
+
+export default function AlmacenPage() {
+  const { id } = useParams();
+  const [inv, setInv] = useState<{ entradas: number; salidas: number; inventario: number } | null>(null);
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const handler = () => {
+      fetch(`/api/almacenes/${id}`)
+        .then(jsonOrNull)
+        .then((d) => {
+          if (d?.almacen) {
+            setInv({
+              entradas: d.almacen.entradas ?? 0,
+              salidas: d.almacen.salidas ?? 0,
+              inventario: d.almacen.inventario ?? 0,
+            });
+            setShow(true);
+          }
+        })
+        .catch(() => {});
+    };
+    window.addEventListener("quick-inventory", handler);
+    return () => window.removeEventListener("quick-inventory", handler);
+  }, [id]);
+
+  return show && inv ? <QuickInventoryModal data={inv} onClose={() => setShow(false)} /> : null;
+}


### PR DESCRIPTION
## Summary
- añadimos página principal para almacenes
- actualizamos versión a 0.4.19

## Testing
- `pnpm install --frozen-lockfile`
- `npm run build` *(failed: JWT_SECRET no definido)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873f6a351688328a39d02adfc0593d6