### PR TITLE
0.4.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/components/DraggableCard.tsx
+++ b/src/app/dashboard/almacenes/components/DraggableCard.tsx
@@ -33,8 +33,13 @@ function CardBody({ tab }: { tab: Tab }) {
 
 
 export default function DraggableCard({ tab }: { tab: Tab }) {
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: tab.id });
-  const style = { transform: CSS.Transform.toString(transform), transition } as React.CSSProperties;
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: tab.id });
+  const style = {
+    transform: `${CSS.Transform.toString(transform)}${isDragging ? ' scale(1.05)' : ''}`,
+    transition,
+    zIndex: isDragging ? 50 : undefined,
+    boxShadow: isDragging ? '0 10px 15px rgba(0,0,0,0.3)' : undefined,
+  } as React.CSSProperties;
 
   const { update, close, rename } = useTabStore();
   const prompt = usePrompt();

--- a/src/app/dashboard/almacenes/components/MaterialList.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialList.tsx
@@ -2,6 +2,7 @@
 import { useMemo, useState } from "react";
 import { useToast } from "@/components/Toast";
 import ImageModal from "@/components/ImageModal";
+import useObjectUrl from "@/hooks/useObjectUrl";
 import type { Material } from "./MaterialRow";
 
 interface Props {
@@ -53,6 +54,23 @@ export default function MaterialList({
 
   const [preview, setPreview] = useState<string | null>(null);
 
+  function Miniatura({ m }: { m: Material }) {
+    const url = useObjectUrl(m.miniatura instanceof File ? m.miniatura : undefined);
+    const src = m.miniatura instanceof File ? url : (typeof m.miniatura === 'string' ? m.miniatura : m.miniaturaUrl as string | null);
+    if (!src) return null;
+    return (
+      <img
+        src={src}
+        className="w-32 h-32 object-cover rounded cursor-pointer"
+        alt="miniatura"
+        onClick={(e) => {
+          e.stopPropagation();
+          setPreview(src);
+        }}
+      />
+    );
+  }
+
   return (
     <div className="space-y-4">
       <div className="flex gap-2">
@@ -88,25 +106,7 @@ export default function MaterialList({
               onClick={() => onSeleccion(m.id)}
               className={`dashboard-card w-full text-left flex items-center gap-4 ${m.id === selectedId ? 'border-[var(--dashboard-accent)]' : 'hover:border-[var(--dashboard-accent)]'}`}
             >
-              {(m.miniatura || m.miniaturaUrl) && (
-                <img
-                  src={
-                    m.miniatura
-                      ? URL.createObjectURL(m.miniatura)
-                      : (m.miniaturaUrl as string)
-                  }
-                  className="w-32 h-32 object-cover rounded cursor-pointer"
-                  alt="miniatura"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setPreview(
-                      m.miniatura
-                        ? URL.createObjectURL(m.miniatura)
-                        : (m.miniaturaUrl as string)
-                    );
-                  }}
-                />
-              )}
+              {(m.miniatura || m.miniaturaUrl) && <Miniatura m={m} />}
               <div className="flex flex-col flex-1">
                 <span className="font-semibold">{m.nombre}</span>
                 <span className="text-xs">

--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -10,6 +10,14 @@ export default function ImageModal({ src, alt, onClose }: { src: string; alt?: s
     return () => window.removeEventListener("keydown", handler);
   }, [onClose]);
 
+  useEffect(() => {
+    return () => {
+      if (src.startsWith('blob:')) {
+        URL.revokeObjectURL(src);
+      }
+    };
+  }, [src]);
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"

--- a/src/hooks/useObjectUrl.ts
+++ b/src/hooks/useObjectUrl.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+export default function useObjectUrl(file?: File | null) {
+  const [url, setUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!file) {
+      setUrl(null)
+      return
+    }
+    const objectUrl = URL.createObjectURL(file)
+    setUrl(objectUrl)
+    return () => {
+      URL.revokeObjectURL(objectUrl)
+    }
+  }, [file])
+
+  return url
+}


### PR DESCRIPTION
## Summary
- fix MaterialFormTab to allow editing and saving materials
- add object URL cleanup helper and use it in image components
- enhance card dragging with levitation effect
- guard image modals against memory leaks

## Testing
- `npm run build`
- `npm test`


------
