### PR TITLE
0.4.23

### DIFF
--- a/src/app/dashboard/almacenes/[id]/AuditoriasPanel.tsx
+++ b/src/app/dashboard/almacenes/[id]/AuditoriasPanel.tsx
@@ -6,6 +6,7 @@ import useMovimientos from "@/hooks/useMovimientos";
 import useHistorialAlmacen from "@/hooks/useHistorialAlmacen";
 import useHistorialUnidad from "@/hooks/useHistorialUnidad";
 import { useState, useMemo } from "react";
+import { apiFetch } from "@lib/api";
 import Link from "next/link";
 import {
   PlusIcon,
@@ -125,7 +126,7 @@ export default function HistorialMovimientosPanel({ material, almacenId, unidadI
     const [pref, real] = id.split('-');
     if (pref === 'h') {
       try {
-        const res = await fetch(`/api/historial/material/${real}`);
+        const res = await apiFetch(`/api/historial/material/${real}`);
         const data = await res.json();
         if (data.entry?.estado) {
           setDetalle({ ...data.entry, id });
@@ -150,7 +151,7 @@ export default function HistorialMovimientosPanel({ material, almacenId, unidadI
       }
     } else if (pref === 'hu') {
       try {
-        const res = await fetch(`/api/historial/unidad/${real}`);
+        const res = await apiFetch(`/api/historial/unidad/${real}`);
         const data = await res.json();
         if (data.entry?.estado) {
           setDetalle({ ...data.entry, id });

--- a/src/app/dashboard/almacenes/[id]/editar/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/editar/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import { useParams, useRouter } from "next/navigation";
 import { useToast } from "@/components/Toast";
 import Spinner from "@/components/Spinner";
@@ -16,7 +17,7 @@ export default function EditarAlmacenPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch(`/api/almacenes/${id}`)
+    apiFetch(`/api/almacenes/${id}`)
       .then(jsonOrNull)
       .then((d) => {
         if (d.almacen) {
@@ -44,7 +45,7 @@ export default function EditarAlmacenPage() {
         body = JSON.stringify({ nombre, descripcion, imagenUrl });
         headers = { 'Content-Type': 'application/json' };
       }
-      const res = await fetch(`/api/almacenes/${id}`, {
+      const res = await apiFetch(`/api/almacenes/${id}`, {
         method: 'PUT',
         body,
         headers,

--- a/src/app/dashboard/almacenes/[id]/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import QuickInventoryModal from "./QuickInventoryModal";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import { QUICK_INVENTORY_EVENT } from "@/lib/ui-events";
 
 interface Inventory {
@@ -18,7 +19,7 @@ export default function AlmacenPage() {
   useEffect(() => {
     const ctrl = new AbortController();
     const fetchInv = () =>
-      fetch(`/api/almacenes/${id}`, { signal: ctrl.signal })
+      apiFetch(`/api/almacenes/${id}`, { signal: ctrl.signal })
         .then(jsonOrNull)
         .then((d) => {
           if (d?.almacen) {

--- a/src/app/dashboard/almacenes/[id]/scan/page.tsx
+++ b/src/app/dashboard/almacenes/[id]/scan/page.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { Html5Qrcode } from "html5-qrcode";
 import { useParams } from "next/navigation";
 import { decodeQR } from "@/lib/qr";
+import { apiFetch } from "@lib/api";
 
 export default function ScanAlmacenPage() {
   const { id } = useParams()
@@ -30,7 +31,7 @@ export default function ScanAlmacenPage() {
 
   useEffect(() => {
     if (!codigo) return
-    fetch('/api/qr/importar', {
+    apiFetch('/api/qr/importar', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ codigo }),
@@ -51,7 +52,7 @@ export default function ScanAlmacenPage() {
     if (!obj) return
     Object.entries(original).forEach(([k, v]) => {
       if (k !== 'id' && obj[k] != null && obj[k] !== v) {
-        fetch('/api/discrepancias', {
+        apiFetch('/api/discrepancias', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -91,13 +92,13 @@ export default function ScanAlmacenPage() {
     form.append('observaciones', observaciones)
     form.append('categoria', 'verificacion')
     archivos.forEach(a => form.append('archivos', a))
-    const res = await fetch('/api/reportes', {
+    const res = await apiFetch('/api/reportes', {
       method: 'POST',
       body: form,
     })
     if (res.ok) {
       const json = await res.json()
-      await fetch('/api/auditorias', {
+      await apiFetch('/api/auditorias', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ reporteId: json.reporte.id }),
@@ -123,7 +124,7 @@ export default function ScanAlmacenPage() {
       url = `/api/materiales/${mid}/unidades/${objetoId}`
     }
     if (!url) return
-    await fetch(url, {
+    await apiFetch(url, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
@@ -135,7 +136,7 @@ export default function ScanAlmacenPage() {
     if (!info?.tipo || info.tipo !== 'material') return
     const objetoId = info.material?.id
     if (!objetoId) return
-    const res = await fetch(`/api/materiales/${objetoId}/ajuste`, {
+    const res = await apiFetch(`/api/materiales/${objetoId}/ajuste`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ cantidad: Number(nuevoStock) })
@@ -152,7 +153,7 @@ export default function ScanAlmacenPage() {
     const uid = info.unidad?.id
     const mid = info.material?.id
     if (!uid || !mid) return
-    await fetch(`/api/materiales/${mid}/unidades/${uid}`, {
+    await apiFetch(`/api/materiales/${mid}/unidades/${uid}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ estado: 'confirmado' })

--- a/src/app/dashboard/almacenes/archivos/utils.ts
+++ b/src/app/dashboard/almacenes/archivos/utils.ts
@@ -5,6 +5,7 @@ import * as XLSX from 'xlsx'
 import JSZip from 'jszip'
 import { XMLParser } from 'fast-xml-parser'
 import YAML from 'yaml'
+import { apiFetch } from '@lib/api'
 
 export type Row = Record<string, any>
 
@@ -86,13 +87,13 @@ export const triggerDownload = (blob: Blob, filename: string) => {
 }
 
 export const fetchExport = async (tipo: string, formato: string): Promise<Blob> => {
-  const res = await fetch(`/api/archivos/export?tipo=${tipo}&formato=${formato}`)
+  const res = await apiFetch(`/api/archivos/export?tipo=${tipo}&formato=${formato}`)
   if (!res.ok) throw new Error('Export failed')
   return res.blob()
 }
 
 export const postImport = async (tipo: string, registros: Row[]) =>
-  fetch('/api/archivos/import', {
+  apiFetch('/api/archivos/import', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ tipo, registros }),

--- a/src/app/dashboard/almacenes/components/AlmacenDetailNavbar.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenDetailNavbar.tsx
@@ -8,6 +8,7 @@ import UserMenu from "@/components/UserMenu";
 import AlmacenTools from "./AlmacenTools";
 import TabsMenu from "./TabsMenu";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import { useDashboardUI } from "../../ui";
 import { useDetalleUI } from "../DetalleUI";
 import { NAVBAR_HEIGHT } from "../../constants";
@@ -51,7 +52,7 @@ export default function AlmacenDetailNavbar() {
   }, []);
 
   useEffect(() => {
-    fetch(`/api/almacenes/${id}`)
+    apiFetch(`/api/almacenes/${id}`)
       .then(jsonOrNull)
       .then((d) => {
         if (d?.almacen?.nombre) {
@@ -67,7 +68,7 @@ export default function AlmacenDetailNavbar() {
   const guardar = async () => {
     if (!cambios) return;
     setGuardando(true);
-    const res = await fetch(`/api/almacenes/${id}`, {
+    const res = await apiFetch(`/api/almacenes/${id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ nombre }),

--- a/src/app/dashboard/almacenes/operaciones/page.tsx
+++ b/src/app/dashboard/almacenes/operaciones/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
 import useSession from "@/hooks/useSession";
 import { useToast } from "@/components/Toast";
+import { apiFetch } from "@lib/api";
 
 interface Almacen { id: number; nombre: string }
 
@@ -20,7 +21,7 @@ export default function OperacionesPage() {
     if (!usuario) return;
     const ctrl = new AbortController();
     setLoadingAlmacenes(true);
-    fetch(`/api/almacenes?usuarioId=${usuario.id}`, { signal: ctrl.signal })
+    apiFetch(`/api/almacenes?usuarioId=${usuario.id}`, { signal: ctrl.signal })
       .then(jsonOrNull)
       .then((d) => setAlmacenes(d.almacenes || []))
       .catch(() => toast.show('Error al cargar', 'error'))
@@ -33,7 +34,7 @@ export default function OperacionesPage() {
     if (!cantidad || cantidad <= 0)
       return toast.show("Ingresa una cantidad válida", "error");
     setLoading(true);
-    const res = await fetch(`/api/almacenes/${almacenId}/movimientos`, {
+    const res = await apiFetch(`/api/almacenes/${almacenId}/movimientos`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ tipo, cantidad, contexto: { modulo: 'stock' } }),

--- a/src/app/dashboard/auditorias/page.tsx
+++ b/src/app/dashboard/auditorias/page.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Spinner from "@/components/Spinner";
 import useAuditorias from "@/hooks/useAuditorias";
+import { apiFetch } from "@lib/api";
 
 export default function AuditoriasPage() {
   const router = useRouter();
@@ -110,7 +111,7 @@ export default function AuditoriasPage() {
             className={`dashboard-card space-y-1 ${activo === a.id ? 'border-[var(--dashboard-accent)]' : 'hover:border-[var(--dashboard-accent)]'}`}
             onClick={async () => {
               setActivo(a.id);
-              const res = await fetch(`/api/auditorias/${a.id}`);
+              const res = await apiFetch(`/api/auditorias/${a.id}`);
               if (res.ok) {
                 const d = await res.json();
                 setDetalle(d.auditoria);

--- a/src/app/dashboard/components/widgets/AlertasWidget.tsx
+++ b/src/app/dashboard/components/widgets/AlertasWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 import { X } from "lucide-react";
 
 // Utilidad para pintar colores según prioridad
@@ -28,7 +29,7 @@ export default function AlertasWidget({ usuario }: { usuario: any }) {
     if (!usuario) return;
     setLoading(true);
     setErr(null);
-    fetch(`/api/alertas?usuarioId=${usuario.id}`)
+    apiFetch(`/api/alertas?usuarioId=${usuario.id}`)
       .then(async (res) => {
         if (!res.ok) throw new Error("Error consultando alertas");
         const data = await jsonOrNull(res);

--- a/src/app/dashboard/components/widgets/ReportesWidget.tsx
+++ b/src/app/dashboard/components/widgets/ReportesWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { jsonOrNull } from "@lib/http";
+import { apiFetch } from "@lib/api";
 
 interface Reporte {
   id: number;
@@ -13,7 +14,7 @@ export default function ReportesWidget() {
   const [items, setItems] = useState<Reporte[]>([]);
 
   useEffect(() => {
-    fetch("/api/reportes")
+    apiFetch("/api/reportes")
       .then((r) => jsonOrNull(r))
       .then((d) => setItems(d?.reportes?.slice(0, 3) || []))
       .catch(() => {});

--- a/src/app/dashboard/gamificacion/page.tsx
+++ b/src/app/dashboard/gamificacion/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { apiFetch } from "@lib/api";
 
 interface Logro {
   id: number;
@@ -13,7 +14,7 @@ export default function GamificacionPage() {
   const [completados, setCompletados] = useState<number[]>([]);
 
   useEffect(() => {
-    fetch("/api/gamificacion")
+    apiFetch("/api/gamificacion")
       .then((r) => r.json())
       .then((d) => setLogros(d.logros || []));
     try {

--- a/src/app/dashboard/story/page.tsx
+++ b/src/app/dashboard/story/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import Spinner from "@/components/Spinner";
+import { apiFetch } from "@lib/api";
 
 interface Slide {
   id: string;
@@ -13,7 +14,7 @@ export default function StoryPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("/api/paneles/story")
+    apiFetch("/api/paneles/story")
       .then((r) => r.ok ? r.json() : { slides: [] })
       .then((d) => {
         setSlides(d.slides || []);

--- a/src/app/dashboard/timeline/page.tsx
+++ b/src/app/dashboard/timeline/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import Spinner from "@/components/Spinner";
+import { apiFetch } from "@lib/api";
 
 interface Evento {
   id: number;
@@ -18,7 +19,7 @@ export default function TimelinePage() {
   const [activo, setActivo] = useState<number | null>(null);
 
   useEffect(() => {
-    fetch("/api/auditorias")
+    apiFetch("/api/auditorias")
       .then((r) => r.json())
       .then((d) => {
         setEventos(d.auditorias || []);

--- a/src/app/docs/minijuegos/ListaJuegos.tsx
+++ b/src/app/docs/minijuegos/ListaJuegos.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import type { Juego } from "./PanelMinijuegos";
+import { apiFetch } from "@lib/api";
 
 interface Props {
   onPlay: (juego: Juego) => void;
@@ -10,13 +11,13 @@ export default function ListaJuegos({ onPlay }: Props) {
   const [juegos, setJuegos] = useState<Juego[]>([]);
 
   useEffect(() => {
-    fetch("/api/minijuegos")
+    apiFetch("/api/minijuegos")
       .then((r) => r.json())
       .then((d) => setJuegos(d.juegos || []));
   }, []);
 
   async function eliminar(id: number) {
-    const res = await fetch(`/api/minijuegos/${id}`, { method: "DELETE" });
+    const res = await apiFetch(`/api/minijuegos/${id}`, { method: "DELETE" });
     if (res.ok) setJuegos((j) => j.filter((x) => x.id !== id));
   }
 

--- a/src/app/docs/minijuegos/SubirRomForm.tsx
+++ b/src/app/docs/minijuegos/SubirRomForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { apiFetch } from "@lib/api";
 
 interface Props {
   onUpload: () => void;
@@ -18,7 +19,7 @@ export default function SubirRomForm({ onUpload }: Props) {
     form.append("nombre", nombre);
     form.append("plataforma", plataforma);
     form.append("archivo", archivo);
-    const res = await fetch("/api/minijuegos/upload", { method: "POST", body: form });
+    const res = await apiFetch("/api/minijuegos/upload", { method: "POST", body: form });
     if (res.ok) {
       setNombre("");
       setArchivo(null);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { apiFetch } from "@lib/api";
 import Image from "next/image";
 import clsx from "clsx";
 
@@ -277,7 +278,7 @@ function KpiSection() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("/api/metrics")
+    apiFetch("/api/metrics")
       .then(r => r.json())
       .then(d => setData(d || null))
       .catch(() =>

--- a/src/hooks/useArchivosMaterial.ts
+++ b/src/hooks/useArchivosMaterial.ts
@@ -1,5 +1,6 @@
 import useSWR from 'swr'
 import fetcher from '@lib/swrFetcher'
+import { apiFetch } from '@lib/api'
 
 export interface ArchivoInfo {
   id: number
@@ -16,7 +17,7 @@ export default function useArchivosMaterial(materialId?: number) {
 
   const eliminar = async (archivoId: number) => {
     if (!url) return
-    await fetch(`/api/materiales/${id}/archivos/${archivoId}`, { method: 'DELETE' })
+    await apiFetch(`/api/materiales/${id}/archivos/${archivoId}`, { method: 'DELETE' })
     mutate()
   }
 

--- a/src/hooks/useArchivosUnidad.ts
+++ b/src/hooks/useArchivosUnidad.ts
@@ -1,5 +1,6 @@
 import useSWR from 'swr'
 import fetcher from '@lib/swrFetcher'
+import { apiFetch } from '@lib/api'
 
 export interface ArchivoInfo {
   id: number
@@ -20,7 +21,7 @@ export default function useArchivosUnidad(materialId?: number, unidadId?: number
 
   const eliminar = async (archivoId: number) => {
     if (!url) return
-    await fetch(`/api/materiales/${mid}/unidades/${uid}/archivos/${archivoId}`, {
+    await apiFetch(`/api/materiales/${mid}/unidades/${uid}/archivos/${archivoId}`, {
       method: 'DELETE',
     })
     mutate()


### PR DESCRIPTION
## Summary
- use `apiFetch` in client-side fetches so requests honor `NEXT_PUBLIC_BASE_PATH`
- clean up material/alert/scan utilities to call `apiFetch`

## Testing
- `npm test`
- `npm run build` *(fails: JWT_SECRET no definido en el entorno)*

------
