### PR TITLE
Add tab options constant

### DIFF
--- a/src/app/dashboard/almacenes/components/AddTabButton.tsx
+++ b/src/app/dashboard/almacenes/components/AddTabButton.tsx
@@ -1,8 +1,9 @@
 "use client";
 import { useState, useRef, useEffect } from "react";
 import { Plus } from "lucide-react";
-import { useTabStore } from "@/hooks/useTabs";
+import { useTabStore, type TabType } from "@/hooks/useTabs";
 import { generarUUID } from "@/lib/uuid";
+import { tabOptions } from "./tabOptions";
 
 export default function AddTabButton() {
   const { addAfterActive } = useTabStore();
@@ -19,10 +20,10 @@ export default function AddTabButton() {
     return () => document.removeEventListener("click", onClick);
   }, []);
 
-  const create = (type: "materiales" | "unidades" | "auditorias") => {
+  const create = (type: TabType, label: string) => {
     addAfterActive({
       id: generarUUID(),
-      title: type.charAt(0).toUpperCase() + type.slice(1),
+      title: label,
       type,
       side: "left",
     });
@@ -43,9 +44,9 @@ export default function AddTabButton() {
       </button>
       {open && (
         <div className="absolute bottom-14 right-0 mb-2 w-40 rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 shadow-lg p-1 space-y-1">
-          <MenuItem label="Materiales" onClick={() => create("materiales")}/>
-          <MenuItem label="Unidades" onClick={() => create("unidades")}/>
-          <MenuItem label="Auditorias" onClick={() => create("auditorias")}/>
+          {tabOptions.map(opt => (
+            <MenuItem key={opt.type} label={opt.label} onClick={() => create(opt.type, opt.label)} />
+          ))}
         </div>
       )}
     </div>

--- a/src/app/dashboard/almacenes/components/TabsMenu.tsx
+++ b/src/app/dashboard/almacenes/components/TabsMenu.tsx
@@ -3,12 +3,7 @@ import { useState, useRef, useEffect } from "react";
 import { Plus } from "lucide-react";
 import { useTabStore, type TabType } from "@/hooks/useTabs";
 import { generarUUID } from "@/lib/uuid";
-
-const options: Array<{ type: TabType; label: string }> = [
-  { type: "materiales", label: "Materiales" },
-  { type: "unidades", label: "Unidades" },
-  { type: "auditorias", label: "Auditorías" },
-];
+import { tabOptions } from "./tabOptions";
 
 export default function TabsMenu() {
   const [open, setOpen] = useState(false);
@@ -39,7 +34,7 @@ export default function TabsMenu() {
       </button>
       {open && (
         <div className="absolute right-0 mt-2 w-48 rounded-md bg-[var(--dashboard-sidebar)] border border-[var(--dashboard-border)] shadow-lg z-50 text-sm">
-          {options.map(opt => (
+          {tabOptions.map(opt => (
             <button
               key={opt.type}
               onClick={() => create(opt.type, opt.label)}

--- a/src/app/dashboard/almacenes/components/tabOptions.ts
+++ b/src/app/dashboard/almacenes/components/tabOptions.ts
@@ -1,0 +1,7 @@
+import type { TabType } from "@/hooks/useTabs";
+
+export const tabOptions: Array<{ type: TabType; label: string }> = [
+  { type: "materiales", label: "Materiales" },
+  { type: "unidades", label: "Unidades" },
+  { type: "auditorias", label: "Auditorías" },
+];


### PR DESCRIPTION
## Summary
- unificamos las opciones de pestañas en un archivo común
- actualizamos AddTabButton y TabsMenu para reutilizar `tabOptions`

## Testing
- `pnpm run build` *(falla: JWT_SECRET no definido)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68743e114b00832897c35c87a5e8d944