### PR TITLE
0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.0
+- Soporte para nuevas pestañas de tablero y URL.
+
 ## 0.2.268
 - Validamos DATABASE_URL en workflows antes del build.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.4.24",
+  "version": "0.5.0",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/components/DraggableCard.tsx
+++ b/src/app/dashboard/almacenes/components/DraggableCard.tsx
@@ -11,6 +11,8 @@ import MaterialFormTab from "./tabs/MaterialFormTab";
 import AuditoriasTab from "./tabs/AuditoriasTab";
 import UnidadFormTab from "./tabs/UnidadFormTab";
 import AuditoriaFormTab from "./tabs/AuditoriaFormTab";
+import BoardTab from "./tabs/BoardTab";
+import UrlTab from "./tabs/UrlTab";
 
 function CardBody({ tab }: { tab: Tab }) {
   switch (tab.type) {
@@ -26,6 +28,10 @@ function CardBody({ tab }: { tab: Tab }) {
       return <UnidadFormTab tabId={tab.id} />;
     case "form-auditoria":
       return <AuditoriaFormTab tabId={tab.id} />;
+    case "board":
+      return <BoardTab />;
+    case "url":
+      return <UrlTab />;
     default:
       return <div className="p-4 text-sm text-gray-400">Sin contenido</div>;
   }

--- a/src/app/dashboard/almacenes/components/tabOptions.ts
+++ b/src/app/dashboard/almacenes/components/tabOptions.ts
@@ -4,4 +4,6 @@ export const tabOptions: Array<{ type: TabType; label: string }> = [
   { type: "materiales", label: "Materiales" },
   { type: "unidades", label: "Unidades" },
   { type: "auditorias", label: "Auditorías" },
+  { type: "board", label: "Tablero" },
+  { type: "url", label: "URL" },
 ];

--- a/src/app/dashboard/almacenes/components/tabs/BoardTab.tsx
+++ b/src/app/dashboard/almacenes/components/tabs/BoardTab.tsx
@@ -1,0 +1,11 @@
+"use client";
+import CardBoard from "../CardBoard";
+import { BoardProvider } from "../../board/BoardProvider";
+
+export default function BoardTab() {
+  return (
+    <BoardProvider>
+      <CardBoard />
+    </BoardProvider>
+  );
+}

--- a/src/app/dashboard/almacenes/components/tabs/UrlTab.tsx
+++ b/src/app/dashboard/almacenes/components/tabs/UrlTab.tsx
@@ -1,0 +1,7 @@
+"use client";
+import MediaWidget from "../../../components/widgets/MediaWidget";
+
+export default function UrlTab({ url }: { url?: string }) {
+  if (!url) return <div className="text-sm text-center">Sin URL</div>;
+  return <MediaWidget url={url} />;
+}

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -6,6 +6,8 @@ export type TabType =
   | "materiales"
   | "unidades"
   | "auditorias"
+  | "board"
+  | "url"
   | "form-material"
   | "form-unidad"
   | "form-auditoria";


### PR DESCRIPTION
## Summary
- extend `TabType` with `board` and `url`
- render `CardBoard` in new `BoardTab`
- add `UrlTab` to display external media via `MediaWidget`
- update `DraggableCard` and tab menu options
- bump version to 0.5.0

## Testing
- `npm test`
- `npm run build` *(fails: JWT_SECRET no definido)*

------
https://chatgpt.com/codex/tasks/task_e_6874408d14708328a4fd552138fac43f