### PR TITLE
0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.5.0
 - Soporte para nuevas pestañas de tablero y URL.
 
+## 0.6.0
+- Tarjetas BoardCard y UrlCard permiten definir destino al crearse.
+
 ## 0.2.268
 - Validamos DATABASE_URL en workflows antes del build.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/components/AddTabButton.tsx
+++ b/src/app/dashboard/almacenes/components/AddTabButton.tsx
@@ -2,11 +2,13 @@
 import { useState, useRef, useEffect } from "react";
 import { Plus } from "lucide-react";
 import { useTabStore, type TabType } from "@/hooks/useTabs";
+import { usePrompt } from "@/hooks/usePrompt";
 import { generarUUID } from "@/lib/uuid";
 import { tabOptions } from "./tabOptions";
 
 export default function AddTabButton() {
   const { addAfterActive } = useTabStore();
+  const prompt = usePrompt();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -20,11 +22,22 @@ export default function AddTabButton() {
     return () => document.removeEventListener("click", onClick);
   }, []);
 
-  const create = (type: TabType, label: string) => {
+  const create = async (type: TabType, label: string) => {
+    let url: string | undefined;
+    let board: string | undefined;
+    if (type === "url") {
+      url = await prompt("URL de destino");
+      if (!url) return;
+    } else if (type === "board") {
+      board = await prompt("Tablero destino");
+      if (!board) return;
+    }
     addAfterActive({
       id: generarUUID(),
       title: label,
       type,
+      url,
+      board,
       side: "left",
     });
     setOpen(false);

--- a/src/app/dashboard/almacenes/components/BoardCard.tsx
+++ b/src/app/dashboard/almacenes/components/BoardCard.tsx
@@ -1,0 +1,11 @@
+"use client";
+import CardBoard from "./CardBoard";
+import { BoardProvider } from "../board/BoardProvider";
+
+export default function BoardCard({ board }: { board?: string }) {
+  return (
+    <BoardProvider>
+      <CardBoard />
+    </BoardProvider>
+  );
+}

--- a/src/app/dashboard/almacenes/components/DraggableCard.tsx
+++ b/src/app/dashboard/almacenes/components/DraggableCard.tsx
@@ -11,8 +11,8 @@ import MaterialFormTab from "./tabs/MaterialFormTab";
 import AuditoriasTab from "./tabs/AuditoriasTab";
 import UnidadFormTab from "./tabs/UnidadFormTab";
 import AuditoriaFormTab from "./tabs/AuditoriaFormTab";
-import BoardTab from "./tabs/BoardTab";
-import UrlTab from "./tabs/UrlTab";
+import BoardCard from "./BoardCard";
+import UrlCard from "./UrlCard";
 
 function CardBody({ tab }: { tab: Tab }) {
   switch (tab.type) {
@@ -29,9 +29,9 @@ function CardBody({ tab }: { tab: Tab }) {
     case "form-auditoria":
       return <AuditoriaFormTab tabId={tab.id} />;
     case "board":
-      return <BoardTab />;
+      return <BoardCard board={tab.board} />;
     case "url":
-      return <UrlTab />;
+      return <UrlCard url={tab.url} />;
     default:
       return <div className="p-4 text-sm text-gray-400">Sin contenido</div>;
   }

--- a/src/app/dashboard/almacenes/components/TabsMenu.tsx
+++ b/src/app/dashboard/almacenes/components/TabsMenu.tsx
@@ -2,6 +2,7 @@
 import { useState, useRef, useEffect } from "react";
 import { Plus } from "lucide-react";
 import { useTabStore, type TabType } from "@/hooks/useTabs";
+import { usePrompt } from "@/hooks/usePrompt";
 import { generarUUID } from "@/lib/uuid";
 import { tabOptions } from "./tabOptions";
 
@@ -9,6 +10,7 @@ export default function TabsMenu() {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const { addAfterActive, minimizeAll, restoreAll, closeOthers, activeId } = useTabStore();
+  const prompt = usePrompt();
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -18,8 +20,17 @@ export default function TabsMenu() {
     return () => document.removeEventListener("mousedown", handler);
   }, []);
 
-  const create = (type: TabType, label: string) => {
-    addAfterActive({ id: generarUUID(), title: label, type, side: "left" });
+  const create = async (type: TabType, label: string) => {
+    let url: string | undefined;
+    let board: string | undefined;
+    if (type === "url") {
+      url = await prompt("URL de destino");
+      if (!url) return;
+    } else if (type === "board") {
+      board = await prompt("Tablero destino");
+      if (!board) return;
+    }
+    addAfterActive({ id: generarUUID(), title: label, type, url, board, side: "left" });
     setOpen(false);
   };
 

--- a/src/app/dashboard/almacenes/components/UrlCard.tsx
+++ b/src/app/dashboard/almacenes/components/UrlCard.tsx
@@ -1,0 +1,7 @@
+"use client";
+import MediaWidget from "../../components/widgets/MediaWidget";
+
+export default function UrlCard({ url }: { url?: string }) {
+  if (!url) return <div className="text-sm text-center">Sin URL</div>;
+  return <MediaWidget url={url} />;
+}

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -16,6 +16,8 @@ export interface Tab {
   id: string;
   title: string;
   type: TabType;
+  url?: string;
+  board?: string;
   side?: "left" | "right";
   pinned?: boolean;
   collapsed?: boolean;


### PR DESCRIPTION
## Summary
- añadimos componentes `BoardCard` y `UrlCard`
- solicitamos URL o tablero al crear tarjetas en el tablero
- guardamos estos datos en la estructura de tabs

## Testing
- `npm run build` *(falla: JWT_SECRET no definido)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874451dfaa88328b58f4243f2480482