### PR TITLE
0.6.0

### DIFF
--- a/src/app/api/almacenes/compartir/route.ts
+++ b/src/app/api/almacenes/compartir/route.ts
@@ -1,0 +1,48 @@
+export const runtime = 'nodejs'
+
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@lib/prisma'
+import { getUsuarioFromSession } from '@lib/auth'
+import * as logger from '@lib/logger'
+
+export async function POST(req: NextRequest) {
+  logger.debug(req, 'POST /api/almacenes/compartir')
+  try {
+    const usuario = await getUsuarioFromSession(req)
+    if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
+    const { codigo } = await req.json()
+    if (!codigo) return NextResponse.json({ error: 'Código requerido' }, { status: 400 })
+
+    const cod = await prisma.codigoAlmacen.findUnique({ where: { codigo } })
+    if (!cod || !cod.activo) return NextResponse.json({ error: 'Código inválido' }, { status: 404 })
+    if (cod.fechaExpiracion && cod.fechaExpiracion < new Date()) {
+      return NextResponse.json({ error: 'Código expirado' }, { status: 410 })
+    }
+    if (cod.usosDisponibles !== null && cod.usosDisponibles <= 0) {
+      return NextResponse.json({ error: 'Código sin usos' }, { status: 410 })
+    }
+
+    await prisma.usuarioAlmacen.upsert({
+      where: { usuarioId_almacenId: { usuarioId: usuario.id, almacenId: cod.almacenId } },
+      create: {
+        usuarioId: usuario.id,
+        almacenId: cod.almacenId,
+        rolEnAlmacen: cod.rolAsignado,
+        permisosExtra: cod.permisos,
+      },
+      update: {},
+    })
+
+    if (cod.usosDisponibles !== null) {
+      await prisma.codigoAlmacen.update({
+        where: { id: cod.id },
+        data: { usosDisponibles: { decrement: 1 } },
+      })
+    }
+
+    return NextResponse.json({ success: true, almacenId: cod.almacenId })
+  } catch (err) {
+    logger.error('POST /api/almacenes/compartir', err)
+    return NextResponse.json({ error: 'Error' }, { status: 500 })
+  }
+}

--- a/src/app/dashboard/almacenes/components/BoardTab.tsx
+++ b/src/app/dashboard/almacenes/components/BoardTab.tsx
@@ -1,21 +1,11 @@
 "use client";
-import { useRef } from "react";
 import { Pencil, Copy, X } from "lucide-react";
 import { useBoardStore, type Board } from "@/hooks/useBoards";
 import { usePrompt } from "@/hooks/usePrompt";
 
-export default function BoardTab({ tab, index }: { tab: Board; index: number }) {
-  const { activeId, setActive, move, rename, remove, duplicate } = useBoardStore();
+export default function BoardTab({ tab }: { tab: Board }) {
+  const { activeId, setActive, rename, remove, duplicate } = useBoardStore();
   const prompt = usePrompt();
-  const ref = useRef<HTMLDivElement>(null);
-
-  const onDragStart = (e: React.DragEvent) => {
-    e.dataTransfer.setData("board-index", String(index));
-  };
-  const onDrop = (e: React.DragEvent) => {
-    const from = Number(e.dataTransfer.getData("board-index"));
-    move(from, index);
-  };
 
   const onRename = async () => {
     const name = await prompt("Renombrar pestaña", tab.title);
@@ -27,14 +17,11 @@ export default function BoardTab({ tab, index }: { tab: Board; index: number }) 
 
   return (
     <div
-      ref={ref}
-      draggable
-      onDragStart={onDragStart}
-      onDrop={onDrop}
-      onDragOver={(e) => e.preventDefault()}
       onClick={() => setActive(tab.id)}
-      className={`px-2 py-0.5 rounded cursor-pointer select-none flex items-center gap-1 text-sm whitespace-nowrap ${
-        activeId === tab.id ? "bg-[var(--dashboard-accent)] text-black" : "bg-[var(--dashboard-sidebar)] text-white"
+      className={`px-3 py-1 rounded-md cursor-pointer select-none flex items-center gap-1 text-sm whitespace-nowrap transition-colors ${
+        activeId === tab.id
+          ? "bg-[var(--dashboard-accent)] text-black"
+          : "bg-[var(--dashboard-sidebar)] text-white hover:bg-white/10"
       }`}
     >
       <span className="px-1">{tab.title}</span>

--- a/src/app/dashboard/almacenes/components/TabBar.tsx
+++ b/src/app/dashboard/almacenes/components/TabBar.tsx
@@ -29,7 +29,7 @@ function DropIndicator() {
   return <div className="w-px bg-blue-500 h-full" />;
 }
 
-function SortableItem({ tab, index }: { tab: Board; index: number }) {
+function SortableItem({ tab }: { tab: Board }) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: tab.id });
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -37,7 +37,7 @@ function SortableItem({ tab, index }: { tab: Board; index: number }) {
   } as React.CSSProperties;
   return (
     <div ref={setNodeRef} style={style} {...attributes} {...listeners} className="touch-none">
-      <BoardTab tab={tab} index={index} />
+      <BoardTab tab={tab} />
     </div>
   );
 }
@@ -100,7 +100,7 @@ export default function TabBar() {
 
   return (
     <div
-      className="fixed z-20 w-full overflow-x-auto whitespace-nowrap border-b border-[var(--dashboard-border)] bg-[var(--dashboard-card)] shadow-sm transition-all"
+      className="sticky z-20 w-full overflow-x-auto whitespace-nowrap border-b border-[var(--dashboard-border)] bg-[var(--dashboard-card)]/80 backdrop-blur shadow-sm transition-all"
       style={{ top, height: 'var(--tabbar-height)', '--tabbar-height': TABBAR_HEIGHT } as React.CSSProperties}
       role="tablist"
     >
@@ -118,7 +118,7 @@ export default function TabBar() {
             {boards.map((tab, idx) => (
               <Fragment key={tab.id}>
                 {dropIndex === idx && <DropIndicator />}
-                <SortableItem tab={tab} index={idx} />
+                <SortableItem tab={tab} />
               </Fragment>
             ))}
             {dropIndex === boards.length && <DropIndicator />}

--- a/tests/almacenesRoute.test.ts
+++ b/tests/almacenesRoute.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { GET } from '../src/app/api/almacenes/route'
+import { NextRequest } from 'next/server'
+import * as auth from '../lib/auth'
+import * as permisos from '../lib/permisos'
+import prisma from '../lib/prisma'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('GET /api/almacenes', () => {
+  it('requiere sesion', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue(null as any)
+    const res = await GET(new NextRequest('http://localhost/api/almacenes'))
+    expect(res.status).toBe(401)
+  })
+
+  it('rechaza si no es el mismo usuario y no es admin', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ id: 1 } as any)
+    vi.spyOn(permisos, 'hasManagePerms').mockReturnValue(false)
+    const req = new NextRequest('http://localhost/api/almacenes?usuarioId=2')
+    const res = await GET(req)
+    expect(res.status).toBe(403)
+  })
+
+  it('filtra por usuario', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ id: 3 } as any)
+    vi.spyOn(permisos, 'hasManagePerms').mockReturnValue(true)
+    const find = vi.spyOn(prisma.almacen, 'findMany').mockResolvedValue([] as any)
+    const req = new NextRequest('http://localhost/api/almacenes?usuarioId=5')
+    await GET(req)
+    expect(find).toHaveBeenCalledWith(expect.objectContaining({ where: { usuarios: { some: { usuarioId: 5 } } } }))
+  })
+})

--- a/tests/almacenesShare.test.ts
+++ b/tests/almacenesShare.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { POST } from '../src/app/api/almacenes/compartir/route'
+import { NextRequest } from 'next/server'
+import prisma from '../lib/prisma'
+import * as auth from '../lib/auth'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('POST /api/almacenes/compartir', () => {
+  it('requiere sesion', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue(null as any)
+    const req = new NextRequest('http://localhost/api/almacenes/compartir', { method: 'POST', body: '{}' })
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('asocia usuario y decrementa usos', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ id: 1 } as any)
+    const code = {
+      id: 9,
+      almacenId: 2,
+      codigo: 'abc',
+      rolAsignado: 'lector',
+      permisos: null,
+      usosDisponibles: 1,
+      activo: true,
+      fechaExpiracion: null,
+    }
+    vi.spyOn(prisma.codigoAlmacen, 'findUnique').mockResolvedValue(code as any)
+    const upsert = vi.spyOn(prisma.usuarioAlmacen, 'upsert').mockResolvedValue({} as any)
+    const update = vi.spyOn(prisma.codigoAlmacen, 'update').mockResolvedValue({} as any)
+
+    const req = new NextRequest('http://localhost/api/almacenes/compartir', {
+      method: 'POST',
+      body: JSON.stringify({ codigo: 'abc' }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    expect(upsert).toHaveBeenCalled()
+    expect(update).toHaveBeenCalled()
+  })
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -15,6 +15,14 @@ class PrismaClient {
   }
   usuarioAlmacen = {
     findFirst: () => Promise.resolve(),
+    upsert: () => Promise.resolve(),
+  }
+  almacen = {
+    findMany: () => Promise.resolve(),
+  }
+  codigoAlmacen = {
+    findUnique: () => Promise.resolve(),
+    update: () => Promise.resolve(),
   }
   material = {
     findMany: () => Promise.resolve(),


### PR DESCRIPTION
## Summary
- reposition sticky TabBar below nav
- improve BoardTab style and disable native drag
- secure GET /api/almacenes to require session and target user
- allow joining almacenes via share code
- test share route and user filter

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687476bcc4708328b06b8b9426ddfa57