### PR TITLE
0.5.4

### DIFF
--- a/src/app/dashboard/almacenes/[id]/AuditoriasPanel.tsx
+++ b/src/app/dashboard/almacenes/[id]/AuditoriasPanel.tsx
@@ -127,8 +127,13 @@ export default function HistorialMovimientosPanel({ material, almacenId, unidadI
     if (pref === 'h') {
       try {
         const res = await apiFetch(`/api/historial/material/${real}`);
-        const data = await res.json();
-        if (data.entry?.estado) {
+        let data: any = null;
+        if (res.headers.get('content-type')?.includes('json')) {
+          try {
+            data = await res.json();
+          } catch {}
+        }
+        if (data?.entry?.estado) {
           setDetalle({ ...data.entry, id });
           onSelectHistorial && onSelectHistorial(data.entry);
         } else {
@@ -152,8 +157,13 @@ export default function HistorialMovimientosPanel({ material, almacenId, unidadI
     } else if (pref === 'hu') {
       try {
         const res = await apiFetch(`/api/historial/unidad/${real}`);
-        const data = await res.json();
-        if (data.entry?.estado) {
+        let data: any = null;
+        if (res.headers.get('content-type')?.includes('json')) {
+          try {
+            data = await res.json();
+          } catch {}
+        }
+        if (data?.entry?.estado) {
           setDetalle({ ...data.entry, id });
           onSelectHistorial && onSelectHistorial(data.entry);
         } else {

--- a/src/app/dashboard/almacenes/[id]/QuickInventoryModal.tsx
+++ b/src/app/dashboard/almacenes/[id]/QuickInventoryModal.tsx
@@ -7,13 +7,26 @@ export default function QuickInventoryModal({ data, onClose }: { data: { entrada
       if (e.key === "Escape") onClose();
     };
     window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener("keydown", handler);
+      document.body.style.overflow = "auto";
+    };
   }, [onClose]);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
-      <div className="bg-white dark:bg-zinc-800 p-4 rounded-md min-w-[200px]" onClick={(e) => e.stopPropagation()}>
-        <h2 className="text-lg font-semibold mb-2">Inventario</h2>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="inv-title"
+    >
+      <div
+        className="bg-white dark:bg-zinc-800 p-4 rounded-md min-w-[200px]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="inv-title" className="text-lg font-semibold mb-2">Inventario</h2>
         <p>Entradas: {data.entradas}</p>
         <p>Salidas: {data.salidas}</p>
         <p>Total materiales: {data.inventario}</p>

--- a/src/app/dashboard/almacenes/inventario/page.tsx
+++ b/src/app/dashboard/almacenes/inventario/page.tsx
@@ -12,7 +12,7 @@ export default function InventarioPage() {
   const [almacenId, setAlmacenId] = useState<number | null>(null);
   const {
     materiales,
-    loading: loadingMateriales,
+    isLoading: loadingMateriales,
   } = useMateriales(almacenId ?? undefined);
   const [busqueda, setBusqueda] = useState("");
   const [orden, setOrden] = useState<"nombre" | "cantidad">("nombre");

--- a/src/app/dashboard/auditorias/page.tsx
+++ b/src/app/dashboard/auditorias/page.tsx
@@ -113,8 +113,12 @@ export default function AuditoriasPage() {
               setActivo(a.id);
               const res = await apiFetch(`/api/auditorias/${a.id}`);
               if (res.ok) {
-                const d = await res.json();
-                setDetalle(d.auditoria);
+                try {
+                  if (res.headers.get('content-type')?.includes('json')) {
+                    const d = await res.json();
+                    setDetalle(d.auditoria);
+                  }
+                } catch {}
               }
             }}
           >

--- a/src/hooks/useMateriales.ts
+++ b/src/hooks/useMateriales.ts
@@ -123,7 +123,7 @@ export default function useMateriales(almacenId?: number | string) {
 
   return {
     materiales: mats ?? EMPTY_MATERIALS,
-    loading: isLoading,
+    isLoading,
     error,
     mutate,
     crear,


### PR DESCRIPTION
## Summary
- ajustamos `useMateriales` para exponer `isLoading` y `error`
- mejoramos `BoardProvider` reseteando estado por id y propagando carga/errores
- añadimos control de overflow y atributos ARIA al modal de inventario rápido
- validamos el tamaño de imagen y agrupamos campos con `useReducer` en creación de almacén
- protegemos conversiones JSON de auditorías
- actualizamos consumo de `useMateriales` en inventario

## Testing
- `npm run build` *(falla: JWT_SECRET no definido)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68747ef989188328abdc1195ac5f53f0