### PR TITLE
0.5.4

### DIFF
--- a/src/app/dashboard/almacenes/components/tabs/MaterialesTab.tsx
+++ b/src/app/dashboard/almacenes/components/tabs/MaterialesTab.tsx
@@ -11,9 +11,10 @@ export default function MaterialesTab() {
     materiales,
     selectedId,
     setSelectedId,
+    setUnidadSel,
     crear,
   } = useBoard()
-  const { ensureTab } = useTabHelpers()
+  const { ensureTab, openForm } = useTabHelpers()
   const [busqueda, setBusqueda] = useState('')
   const [orden, setOrden] = useState<'nombre' | 'cantidad'>('nombre')
 
@@ -21,10 +22,11 @@ export default function MaterialesTab() {
     (id: string | null) => {
       if (!id) return
       setSelectedId(id)
+      setUnidadSel(null)
       ensureTab('unidades', 'Unidades', 'right')
-      ensureTab('form-material', 'Material', 'left')
+      openForm('form-material', 'Material')
     },
-    [ensureTab, setSelectedId]
+    [ensureTab, openForm, setSelectedId, setUnidadSel]
   )
 
   return (

--- a/src/app/dashboard/almacenes/components/tabs/UnidadesTab.tsx
+++ b/src/app/dashboard/almacenes/components/tabs/UnidadesTab.tsx
@@ -9,7 +9,7 @@ export default function UnidadesTab() {
   const { materiales, selectedId, setUnidadSel } = useBoard()
   const selected = materiales.find(m => m.id === selectedId) || null
   const { obtener } = useUnidades(selected?.dbId)
-  const { ensureTab } = useTabHelpers()
+  const { openForm } = useTabHelpers()
 
   const openUnidad = useCallback(
     async (u: any) => {
@@ -17,9 +17,9 @@ export default function UnidadesTab() {
       const info = await obtener(u.id)
       if (!info) return
       setUnidadSel({ nombreMaterial: u.nombre, ...info })
-      ensureTab('form-unidad', 'Unidad', 'left')
+      openForm('form-unidad', 'Unidad')
     },
-    [obtener, setUnidadSel, ensureTab]
+    [obtener, setUnidadSel, openForm]
   )
 
   return (

--- a/src/hooks/useTabHelpers.ts
+++ b/src/hooks/useTabHelpers.ts
@@ -3,7 +3,7 @@ import { useTabStore, TabType } from './useTabs'
 import { generarUUID } from '@/lib/uuid'
 
 export function useTabHelpers() {
-  const { tabs, addAfterActive, setActive } = useTabStore()
+  const { tabs, addAfterActive, setActive, update } = useTabStore()
 
   const ensureTab = useCallback(
     (type: TabType, title: string, side: 'left' | 'right') => {
@@ -14,5 +14,18 @@ export function useTabHelpers() {
     [tabs, addAfterActive, setActive]
   )
 
-  return { ensureTab }
+  const openForm = useCallback(
+    (type: 'form-material' | 'form-unidad', title: string) => {
+      const form = tabs.find(t => t.type === 'form-material' || t.type === 'form-unidad')
+      if (form) {
+        update(form.id, { type, title, side: 'left' })
+        setActive(form.id)
+      } else {
+        addAfterActive({ id: generarUUID(), title, type, side: 'left' })
+      }
+    },
+    [tabs, addAfterActive, setActive, update]
+  )
+
+  return { ensureTab, openForm }
 }


### PR DESCRIPTION
## Summary
- ajustamos `useTabHelpers` para intercambiar los formularios de material y unidad
- limpiamos la unidad seleccionada al cambiar de material
- actualizamos las tarjetas de Material y Unidad para reutilizar la misma pestaña

## Testing
- `npm run build` *(fails: JWT_SECRET no definido)*
- `npm test`

------
