### PR TITLE
0.5.4

### DIFF
--- a/src/app/dashboard/almacenes/[id]/layout.tsx
+++ b/src/app/dashboard/almacenes/[id]/layout.tsx
@@ -7,7 +7,7 @@ import Spinner from "@/components/Spinner";
 import useSession from "@/hooks/useSession";
 import CardBoard from "../components/CardBoard";
 import TabBar from "../components/TabBar";
-import { TABBAR_HEIGHT, NAVBAR_HEIGHT } from "../../constants";
+import { NAVBAR_HEIGHT } from "../../constants";
 import { BoardProvider } from "../board/BoardProvider";
 import { DetalleUIProvider, useDetalleUI } from "../DetalleUI";
 
@@ -56,7 +56,6 @@ function ProtectedAlmacen({ children }: { children: React.ReactNode }) {
           paddingTop: `calc(${fullscreen ? '0' : NAVBAR_HEIGHT} + ${
             collapsed ? '0' : NAVBAR_HEIGHT
           } + var(--tabbar-height))`,
-          '--tabbar-height': TABBAR_HEIGHT,
         } as React.CSSProperties}
         data-oid="9d4tqvn"
       >

--- a/src/app/dashboard/almacenes/components/CardBoard.tsx
+++ b/src/app/dashboard/almacenes/components/CardBoard.tsx
@@ -95,7 +95,9 @@ export default function CardBoard() {
   const right = current.filter((t) => (t.side ?? "left") === "right");
 
   return (
-    <div className={`flex gap-4 transition-all duration-300 ${collapsed ? 'pt-0' : 'pt-2'}`}>\
+    <div
+      className={`flex gap-4 transition-all duration-300 ${collapsed ? 'pt-0' : 'pt-2'} mt-[var(--tabbar-height)]`}
+    >
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
         <Column id="left">
           <SortableContext items={left.map((t) => t.id)} strategy={verticalListSortingStrategy}>

--- a/src/app/dashboard/almacenes/components/TabBar.tsx
+++ b/src/app/dashboard/almacenes/components/TabBar.tsx
@@ -109,7 +109,7 @@ export default function TabBar() {
   return (
     <div
       className="fixed z-20 w-full overflow-x-auto whitespace-nowrap border-b border-[var(--dashboard-border)] bg-[var(--dashboard-card)]/80 backdrop-blur shadow-sm transition-all"
-      style={{ top, height: 'var(--tabbar-height)', '--tabbar-height': TABBAR_HEIGHT } as React.CSSProperties}
+      style={{ top, height: 'var(--tabbar-height)' } as React.CSSProperties}
       role="tablist"
     >
       <DndContext

--- a/src/app/dashboard/constants.ts
+++ b/src/app/dashboard/constants.ts
@@ -2,4 +2,4 @@ export const SIDEBAR_GLOBAL_WIDTH = 'var(--sidebar-width)';
 export const SIDEBAR_GLOBAL_COLLAPSED_WIDTH = 'var(--sidebar-collapsed-width)';
 export const NAVBAR_HEIGHT = 'var(--navbar-height)';
 // Altura de la barra de pestañas ligeramente menor para mejor proporción
-export const TABBAR_HEIGHT = '3rem';
+export const TABBAR_HEIGHT = 'var(--tabbar-height)';

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -30,6 +30,7 @@
   --tools-sidebar-width: clamp(10rem, 12vw, 11rem);
   --sidebar-gap: clamp(0.5rem, 1vw, 0.75rem);
   --navbar-height: clamp(3.5rem, 5vh, 4.375rem);
+  --tabbar-height: 3rem;
 
   font-size: clamp(15px, 1vw, 16px);
 }


### PR DESCRIPTION
## Summary
- añadimos mt con la variable `--tabbar-height` en CardBoard
- centralizamos la constante `TABBAR_HEIGHT` como variable CSS
- ajustamos TabBar y layout de almacenes a la nueva variable global

## Testing
- `npm run build` *(falló: prisma no encontrado)*
- `npm test` *(falló: vitest no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_687491f0fb708328a4f99ef497d2faf0