### PR TITLE
0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {
@@ -118,6 +118,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/react-grid-layout": "^1.3.5",
+    "@types/react-resizable": "^3.0.8",
     "autoprefixer": "^10.4.21",
     "dotenv": "^16.3.2",
     "eslint": "^9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,9 @@ importers:
       '@types/react-grid-layout':
         specifier: ^1.3.5
         version: 1.3.5
+      '@types/react-resizable':
+        specifier: ^3.0.8
+        version: 3.0.8
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.5)
@@ -5525,6 +5528,12 @@ packages:
     dependencies:
       '@types/react': 19.1.8
     dev: false
+
+  /@types/react-resizable@3.0.8:
+    resolution: {integrity: sha512-Pcvt2eGA7KNXldt1hkhVhAgZ8hK41m0mp89mFgQi7LAAEZiaLgm4fHJ5zbJZ/4m2LVaAyYrrRRv1LHDcrGQanA==}
+    dependencies:
+      '@types/react': 19.1.8
+    dev: true
 
   /@types/react@19.1.8:
     resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}

--- a/src/app/dashboard/almacenes/components/DraggableCard.tsx
+++ b/src/app/dashboard/almacenes/components/DraggableCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import { Resizable } from "react-resizable";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Pencil, Pin, PinOff, Minimize2, Maximize2, X } from "lucide-react";
@@ -62,8 +63,9 @@ export default function DraggableCard({ tab }: { tab: Tab }) {
   };
 
   return (
-    <div ref={setNodeRef} style={style} {...attributes} className="dashboard-card resize overflow-auto">
-      <div className="flex items-center justify-between mb-2 cursor-move" {...listeners}>
+    <Resizable resizeHandles={['se', 'sw', 'ne', 'nw']}>
+      <div ref={setNodeRef} style={style} {...attributes} className="dashboard-card overflow-auto">
+        <div className="flex items-center justify-between mb-2 cursor-move" {...listeners}>
         <span className="font-semibold" onDoubleClick={toggle}>{tab.title}</span>
         <div className="flex items-center gap-1">
           <button onPointerDown={stop} onClick={onRename} className="p-1 hover:bg-white/10 rounded" title="Renombrar">
@@ -104,7 +106,8 @@ export default function DraggableCard({ tab }: { tab: Tab }) {
           )}
         </div>
       </div>
-      {!tab.minimized && !tab.collapsed && <CardBody tab={tab} />}
-    </div>
+        {!tab.minimized && !tab.collapsed && <CardBody tab={tab} />}
+      </div>
+    </Resizable>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -404,7 +404,6 @@ html, body {
   background: var(--dashboard-card);
   border-color: var(--dashboard-border);
   box-shadow: var(--dashboard-shadow);
-  resize: both;
   overflow: auto;
 }
 .dashboard-card:hover {

--- a/tests/draggableCardHandles.test.tsx
+++ b/tests/draggableCardHandles.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import DraggableCard from '../src/app/dashboard/almacenes/components/DraggableCard'
+import type { Tab } from '../src/hooks/useTabs'
+
+describe('DraggableCard', () => {
+  it('incluye cuatro manejadores de redimension', () => {
+    const tab = { id: 't1', title: 'demo', type: 'test' } as Tab
+    const html = renderToStaticMarkup(<DraggableCard tab={tab} />)
+    const matches = html.match(/react-resizable-handle-(?:se|sw|ne|nw)/g) || []
+    expect(matches.length).toBe(4)
+  })
+})


### PR DESCRIPTION
## Summary
- envolvemos el contenido de `DraggableCard` con `Resizable`
- quitamos `resize: both` de `.dashboard-card`
- instalamos los tipos de `react-resizable`
- añadimos prueba para los manejadores de redimension

## Testing
- `npm run build` *(falla: JWT_SECRET no definido)*
- `npm test`

