### PR TITLE
0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.2
+- Centralizamos validación de IDs con `parseId` y actualizamos hooks.
+
 ## 0.6.1
 - Incrementamos la separación entre el tablero de tarjetas y la barra de pestañas.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/hooks/useMateriales.ts
+++ b/src/hooks/useMateriales.ts
@@ -4,6 +4,7 @@ import { jsonOrNull } from '@lib/http'
 import { useMemo } from 'react'
 import { generarUUID } from '@/lib/uuid'
 import { apiFetch } from '@lib/api'
+import { parseId } from '@/lib/parseId'
 import type { Material } from '@/app/dashboard/almacenes/components/MaterialRow'
 
 
@@ -12,8 +13,8 @@ const EMPTY_MATERIALS: Material[] = []
 const genId = () => generarUUID()
 
 export default function useMateriales(almacenId?: number | string) {
-  const id = Number(almacenId)
-  const url = !Number.isNaN(id) ? `/api/almacenes/${id}/materiales` : null
+  const id = parseId(almacenId)
+  const url = id ? `/api/almacenes/${id}/materiales` : null
 
   const { data, error, isLoading, mutate } = useSWR(url, fetcher, {
     refreshInterval: 10000,

--- a/src/hooks/useUnidades.ts
+++ b/src/hooks/useUnidades.ts
@@ -2,6 +2,7 @@ import useSWR from 'swr'
 import { jsonOrNull } from '@lib/http'
 import fetcher from '@lib/swrFetcher'
 import { apiFetch } from '@lib/api'
+import { parseId } from '@/lib/parseId'
 
 const fileToBase64 = (file: File) =>
   new Promise<string>((resolve, reject) => {
@@ -66,8 +67,8 @@ export interface Unidad {
 
 
 export default function useUnidades(materialId?: number | string) {
-  const id = Number(materialId)
-  const url = !Number.isNaN(id) && id > 0 ? `/api/materiales/${id}/unidades` : null
+  const id = parseId(materialId)
+  const url = id ? `/api/materiales/${id}/unidades` : null
 
   const { data, error, isLoading, mutate } = useSWR(url, fetcher)
 

--- a/src/lib/parseId.ts
+++ b/src/lib/parseId.ts
@@ -1,0 +1,4 @@
+export function parseId(value?: number | string | null): number | null {
+  const n = Number(value)
+  return Number.isNaN(n) || n <= 0 ? null : n
+}

--- a/tests/parseId.test.ts
+++ b/tests/parseId.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { parseId } from '../src/lib/parseId'
+
+describe('parseId', () => {
+  it('retorna el id cuando es válido', () => {
+    expect(parseId('5')).toBe(5)
+    expect(parseId(3)).toBe(3)
+  })
+
+  it('retorna null con valores inválidos', () => {
+    expect(parseId(undefined)).toBeNull()
+    expect(parseId(null)).toBeNull()
+    expect(parseId('abc')).toBeNull()
+    expect(parseId(0)).toBeNull()
+    expect(parseId(-1)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- centralizamos la validación de identificadores con `parseId`
- usamos `parseId` en `useMateriales` y `useUnidades`
- añadimos pruebas para `parseId`
- actualizamos a la versión **0.6.2**

## Testing
- `npm test`
- `CI=1 npm run build` *(falla: `JWT_SECRET no definido`)*

------
