### PR TITLE
0.6.3

### DIFF
--- a/src/app/dashboard/almacenes/components/CardBoard.tsx
+++ b/src/app/dashboard/almacenes/components/CardBoard.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import GridLayout, { Layout } from "react-grid-layout";
 import { useTabStore, Tab } from "@/hooks/useTabs";
 import { useBoardStore } from "@/hooks/useBoards";
@@ -9,11 +9,15 @@ import DraggableCard from "./DraggableCard";
 import AddCardButton from "./AddCardButton";
 import { useDetalleUI } from "../DetalleUI";
 import useCardLayout from "@/hooks/useCardLayout";
+import useElementSize from "@/hooks/useElementSize";
 
 export default function CardBoard() {
   const { tabs: cards, setTabs } = useTabStore();
   const { activeId: boardId, boards, setActive } = useBoardStore();
   const { collapsed } = useDetalleUI();
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const { width } = useElementSize(containerRef)
 
   useEffect(() => {
     useTabStore.persist
@@ -47,6 +51,10 @@ export default function CardBoard() {
 
   const current = cards.filter((t) => t.boardId === boardId);
 
+  const cols = width < 640 ? 1 : 2
+  const rowHeight = width < 640 ? 140 : 150
+
+
   const layout: Layout[] = (() => {
     let leftY = 0;
     let rightY = 0;
@@ -63,13 +71,14 @@ export default function CardBoard() {
 
   return (
     <div
+      ref={containerRef}
       className={`transition-all duration-300 ${collapsed ? 'pt-0' : 'pt-2'} mt-[calc(var(--tabbar-height)+var(--tabbar-gap))]`}
     >
       <GridLayout
         layout={layout}
-        cols={2}
-        rowHeight={150}
-        width={800}
+        cols={cols}
+        rowHeight={rowHeight}
+        width={width || 800}
         onLayoutChange={onLayoutChange}
         draggableHandle=".cursor-move"
         compactType={null}

--- a/src/hooks/useElementSize.ts
+++ b/src/hooks/useElementSize.ts
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react'
+
+export default function useElementSize<T extends HTMLElement>(
+  ref: React.RefObject<T>,
+) {
+  const [size, setSize] = useState({ width: 0, height: 0 })
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const obs = new ResizeObserver(entries => {
+      const rect = entries[0]?.contentRect
+      if (rect) setSize({ width: rect.width, height: rect.height })
+    })
+    obs.observe(el)
+    return () => obs.disconnect()
+  }, [ref])
+
+  return size
+}


### PR DESCRIPTION
## Summary
- calculamos el ancho del tablero con `ResizeObserver`
- reemplazamos `width={800}` por el ancho medido en `GridLayout`
- adaptamos `cols` y `rowHeight` a un breakpoint móvil

## Testing
- `npm run lint`
- `npm test`


------
