### PR TITLE
0.6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Clona el repositorio y ejecuta los siguientes comandos:
 git clone https://github.com/ArthurLabsNB/honeylabs.git
 cd honeylabs
 pnpm install
+# Este paso instala dependencias esenciales como `@dnd-kit/modifiers`.
+# Sin ellas, Next.js mostrará errores de "Module not found" al compilar.
 pnpm prisma migrate dev
 DATABASE_URL=$DIRECT_DB_URL pnpm prisma migrate deploy
 vercel --prod


### PR DESCRIPTION
## Summary
- clarify `pnpm install` is mandatory before running the build to avoid missing modules such as `@dnd-kit/modifiers`

## Testing
- `npm run build` *(fails: JWT_SECRET no definido en el entorno)*
- `npm test`

------
