### PR TITLE
0.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 - Reporte y seguimiento de incidencias
 - Panel de control intuitivo
 - Notificaciones y alertas
+- Auditoría automática de operaciones
 
 ---
 

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from 'next/server'
+
+export async function registrarAuditoria(
+  req: NextRequest,
+  tipo: 'almacen' | 'material' | 'unidad',
+  objetoId: number,
+  categoria: string,
+  datos: any,
+  archivos: File[] = [],
+) {
+  try {
+    const form = new FormData()
+    form.set('tipo', tipo)
+    form.set('objetoId', String(objetoId))
+    form.set('categoria', categoria)
+    form.set('observaciones', JSON.stringify(datos ?? {}))
+    for (const a of archivos) form.append('archivos', a)
+    const url = new URL('/api/reportes', req.url)
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { cookie: req.headers.get('cookie') ?? '' },
+      body: form,
+    })
+    if (!res.ok) return null
+    const { reporte } = await res.json()
+    const res2 = await fetch(new URL('/api/auditorias', req.url), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        cookie: req.headers.get('cookie') ?? '',
+      },
+      body: JSON.stringify({ reporteId: reporte.id }),
+    })
+    if (!res2.ok) return null
+    const { auditoria } = await res2.json()
+    return auditoria
+  } catch {
+    return null
+  }
+}

--- a/src/hooks/useMateriales.ts
+++ b/src/hooks/useMateriales.ts
@@ -5,6 +5,7 @@ import { useMemo } from 'react'
 import { generarUUID } from '@/lib/uuid'
 import { apiFetch } from '@lib/api'
 import { parseId } from '@/lib/parseId'
+import { AUDIT_PREVIEW_EVENT } from '@/lib/ui-events'
 import type { Material } from '@/app/dashboard/almacenes/components/MaterialRow'
 
 
@@ -57,6 +58,9 @@ export default function useMateriales(almacenId?: number | string) {
         )
       }
       mutate()
+      if (data?.auditoria?.id) {
+        window.dispatchEvent(new CustomEvent(AUDIT_PREVIEW_EVENT, { detail: true }))
+      }
     }
     return data
   }
@@ -96,6 +100,9 @@ export default function useMateriales(almacenId?: number | string) {
         )
       }
       mutate()
+      if (data?.auditoria?.id) {
+        window.dispatchEvent(new CustomEvent(AUDIT_PREVIEW_EVENT, { detail: true }))
+      }
     }
     return data
   }
@@ -103,7 +110,12 @@ export default function useMateriales(almacenId?: number | string) {
   const eliminar = async (materialId: number) => {
     const res = await apiFetch(`/api/materiales/${materialId}`, { method: 'DELETE' })
     const data = await jsonOrNull(res)
-    if (res.ok) mutate()
+    if (res.ok) {
+      mutate()
+      if (data?.auditoria?.id) {
+        window.dispatchEvent(new CustomEvent(AUDIT_PREVIEW_EVENT, { detail: true }))
+      }
+    }
     return data
   }
 

--- a/src/hooks/useUnidades.ts
+++ b/src/hooks/useUnidades.ts
@@ -3,6 +3,7 @@ import { jsonOrNull } from '@lib/http'
 import fetcher from '@lib/swrFetcher'
 import { apiFetch } from '@lib/api'
 import { parseId } from '@/lib/parseId'
+import { AUDIT_PREVIEW_EVENT } from '@/lib/ui-events'
 
 const fileToBase64 = (file: File) =>
   new Promise<string>((resolve, reject) => {
@@ -117,6 +118,9 @@ export default function useUnidades(materialId?: number | string) {
       }
       mutate()
       registrar(`Entrada - ${datos.nombre} (unidad ${unidad?.id ?? ''})`)
+      if (result?.auditoria?.id) {
+        window.dispatchEvent(new CustomEvent(AUDIT_PREVIEW_EVENT, { detail: true }))
+      }
     }
     return result
   }
@@ -151,6 +155,9 @@ export default function useUnidades(materialId?: number | string) {
       }
       mutate()
       registrar(`Modificacion - ${payload.nombre ?? ''} (unidad ${uid})`)
+      if (result?.auditoria?.id) {
+        window.dispatchEvent(new CustomEvent(AUDIT_PREVIEW_EVENT, { detail: true }))
+      }
     }
     return result
   }
@@ -166,6 +173,9 @@ export default function useUnidades(materialId?: number | string) {
     if (res.ok) {
       mutate()
       registrar(`Eliminacion - unidad ${unidadId}`)
+      if (result?.auditoria?.id) {
+        window.dispatchEvent(new CustomEvent(AUDIT_PREVIEW_EVENT, { detail: true }))
+      }
     }
     return result
   }


### PR DESCRIPTION
## Summary
- registramos reportes y auditorías automáticas al crear, modificar o borrar materiales y unidades
- propagamos la auditoría en hooks `useMateriales` y `useUnidades`
- nuevo helper `registrarAuditoria` para centralizar la lógica
- documentación de auditoría automática

## Testing
- `npm run build` *(fails: JWT_SECRET no definido)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687552c2d11c8328bab7fee830efddd4