### PR TITLE
Remove react-resizable from DraggableCard

### DIFF
--- a/src/app/dashboard/almacenes/components/DraggableCard.tsx
+++ b/src/app/dashboard/almacenes/components/DraggableCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 import React from "react";
-import { Resizable } from "react-resizable";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { motion } from "framer-motion";
@@ -116,5 +115,5 @@ export default function DraggableCard({ tab, grid = false }: Props) {
       </motion.div>
   );
 
-  return sortable ? <Resizable resizeHandles={['se', 'sw', 'ne', 'nw']}>{content}</Resizable> : content;
+  return content;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -248,54 +248,6 @@ html, body {
   box-shadow: inset 0 0 0 2px var(--dashboard-accent);
   transition: box-shadow 0.2s, background 0.2s;
 }
-.react-resizable-handle {
-  position: absolute;
-  width: 16px;
-  height: 16px;
-  z-index: 20;
-  background: none;
-}
-.react-resizable-handle-se {
-  right: 2px;
-  bottom: 2px;
-  cursor: se-resize;
-}
-.react-resizable-handle-sw {
-  left: 2px;
-  bottom: 2px;
-  cursor: sw-resize;
-}
-.react-resizable-handle-nw {
-  left: 2px;
-  top: 2px;
-  cursor: nw-resize;
-}
-.react-resizable-handle-ne {
-  right: 2px;
-  top: 2px;
-  cursor: ne-resize;
-}
-/* Ocultamos las asas superiores para evitar conflictos con
-   los botones de la cabecera */
-.react-resizable-handle-nw,
-.react-resizable-handle-ne {
-  display: none;
-}
-.react-resizable-handle::after {
-  content: "";
-  display: block;
-  width: 16px; height: 16px;
-  border-right: 2.5px solid var(--dashboard-widget-resize);
-  border-bottom: 2.5px solid var(--dashboard-widget-resize);
-  opacity: 0.7;
-  border-radius: 4px;
-  margin: 0 0 2px 2px;
-  transition: opacity 0.17s;
-}
-.react-resizable-handle-sw::after { transform: rotate(90deg); }
-.react-resizable-handle-nw::after { transform: rotate(180deg); }
-.react-resizable-handle-ne::after { transform: rotate(270deg); }
-.react-resizable-handle:hover::after { opacity: 1; }
 
 .dashboard-widget-card {
   @apply rounded-xl shadow-lg p-5 border;

--- a/tests/draggableCardHandles.test.tsx
+++ b/tests/draggableCardHandles.test.tsx
@@ -5,10 +5,10 @@ import DraggableCard from '../src/app/dashboard/almacenes/components/DraggableCa
 import type { Tab } from '../src/hooks/useTabs'
 
 describe('DraggableCard', () => {
-  it('incluye cuatro manejadores de redimension', () => {
+  it('no incluye manejadores de redimension', () => {
     const tab = { id: 't1', title: 'demo', type: 'test' } as Tab
     const html = renderToStaticMarkup(<DraggableCard tab={tab} />)
     const matches = html.match(/react-resizable-handle-(?:se|sw|ne|nw)/g) || []
-    expect(matches.length).toBe(4)
+    expect(matches.length).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
- remove `react-resizable` wrapper in `DraggableCard`
- clean global styles no longer used
- adjust test expectations

## Testing
- `npm run build --silent`
- `npm test --silent`

------
