### PR TITLE
0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 - Eliminamos la función de minimizar tarjetas y pestañas.
 
+## 0.6.4
+
+- Aplicamos siempre el layout del servidor al hidratar las tarjetas.
+- Sincronizamos `localStorage` con el servidor al cambiar de tablero.
+
 ## 0.6.2
 
 - Ajustamos la separación límite entre el tablero de tarjetas y la barra de pestañas.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/components/CardBoard.tsx
+++ b/src/app/dashboard/almacenes/components/CardBoard.tsx
@@ -26,9 +26,7 @@ export default function CardBoard() {
         apiFetch("/api/dashboard/layout")
           .then(jsonOrNull)
           .then((d) => {
-            if (
-              Array.isArray(d?.tabs) && cards.length === 0
-            ) {
+            if (Array.isArray(d?.tabs)) {
               setTabs(d.tabs as Tab[])
             }
           })

--- a/src/hooks/useCardLayout.ts
+++ b/src/hooks/useCardLayout.ts
@@ -19,19 +19,29 @@ export default function useCardLayout(
 
   useEffect(() => {
     if (!key) return;
+    const boardTabs = tabs.filter(t => t.boardId === boardId);
+    if (boardTabs.length === 0) return;
+    const missing = boardTabs.some(t => typeof t.x !== 'number' || typeof t.y !== 'number');
     try {
-      const raw = localStorage.getItem(key);
-      if (!raw) return;
-      const data = JSON.parse(raw) as Layout[];
-      if (!Array.isArray(data)) return;
-      setTabs(prev =>
-        prev.map(t => {
-          const it = data.find(l => l.i === t.id);
-          return it ? { ...t, x: it.x, y: it.y, w: it.w, h: it.h } : t;
-        }),
-      );
+      if (missing) {
+        const raw = localStorage.getItem(key);
+        if (!raw) return;
+        const data = JSON.parse(raw) as Layout[];
+        if (Array.isArray(data)) {
+          setTabs(prev => applyLayout(prev, data));
+        }
+      } else {
+        const layout = boardTabs.map(t => ({
+          i: t.id,
+          x: t.x ?? 0,
+          y: t.y ?? 0,
+          w: t.w ?? 1,
+          h: t.h ?? 1,
+        }));
+        localStorage.setItem(key, JSON.stringify(layout));
+      }
     } catch {}
-  }, [key, setTabs]);
+  }, [key, boardId, tabs, setTabs]);
 
   const save = useCallback(
     (layout: Layout[]) => {

--- a/tests/cardLayout.test.ts
+++ b/tests/cardLayout.test.ts
@@ -18,4 +18,18 @@ describe('useCardLayout', () => {
     const updated = applyLayout(tabs, layout as any)
     expect(updated[0].x).toBe(1)
   })
+
+  it('restaura el orden con datos remotos', () => {
+    const tabs = [
+      { id: 'a', title: 'A', type: 'materiales', x: 0, y: 0 } as any,
+      { id: 'b', title: 'B', type: 'materiales', x: 0, y: 1 } as any,
+    ]
+    const remote = [
+      { i: 'a', x: 2, y: 0, w: 1, h: 1 },
+      { i: 'b', x: 2, y: 1, w: 1, h: 1 },
+    ]
+    const updated = applyLayout(tabs, remote as any)
+    expect(updated[0].x).toBe(2)
+    expect(updated[1].y).toBe(1)
+  })
 })


### PR DESCRIPTION
## Summary
- always hydrate CardBoard with server layout
- keep localStorage in sync with server when switching boards
- ensure card layout order restores from remote data

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any etc.)*
- `npm run build` *(fails: JWT_SECRET no definido en el entorno)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875ce68b0848328a4bd193a1a258e3a