### PR TITLE
0.6.5

### DIFF
--- a/src/app/dashboard/almacenes/components/tabs/MaterialesTab.tsx
+++ b/src/app/dashboard/almacenes/components/tabs/MaterialesTab.tsx
@@ -5,6 +5,7 @@ import type { Material } from '../MaterialRow'
 import { useBoard } from '../../board/BoardProvider'
 import { useTabHelpers } from '@/hooks/useTabHelpers'
 import { generarUUID } from '@/lib/uuid'
+import { openMaterial as doOpenMaterial } from '../../utils/openMaterial'
 
 export default function MaterialesTab() {
   const {
@@ -19,13 +20,13 @@ export default function MaterialesTab() {
   const [orden, setOrden] = useState<'nombre' | 'cantidad'>('nombre')
 
   const openMaterial = useCallback(
-    (id: string | null) => {
-      if (!id) return
-      setSelectedId(id)
-      setUnidadSel(null)
-      ensureTab('unidades', 'Unidades', 'right')
-      openForm('form-material', 'Material')
-    },
+    (id: string | null) =>
+      doOpenMaterial(id, {
+        setSelectedId,
+        setUnidadSel,
+        ensureTab,
+        openForm,
+      }),
     [ensureTab, openForm, setSelectedId, setUnidadSel]
   )
 

--- a/src/app/dashboard/almacenes/utils/openMaterial.ts
+++ b/src/app/dashboard/almacenes/utils/openMaterial.ts
@@ -1,0 +1,16 @@
+import type { TabType } from '@/hooks/useTabs'
+
+export interface OpenMaterialOptions {
+  setSelectedId: (id: string) => void
+  setUnidadSel: (u: any) => void
+  ensureTab: (type: TabType, title: string, side: 'left' | 'right') => void
+  openForm: (type: 'form-material' | 'form-unidad', title: string) => void
+}
+
+export function openMaterial(id: string | null, opts: OpenMaterialOptions) {
+  if (!id) return
+  opts.setSelectedId(id)
+  opts.setUnidadSel(null)
+  opts.ensureTab('unidades', 'Unidades', 'right')
+  opts.openForm('form-material', 'Material')
+}

--- a/tests/openMaterial.test.ts
+++ b/tests/openMaterial.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { openMaterial } from '../src/app/dashboard/almacenes/utils/openMaterial'
+import type { TabType } from '../src/hooks/useTabs'
+
+function createOpts() {
+  let sel: string | null = null
+  const tabs: { type: TabType }[] = []
+  return {
+    opts: {
+      setSelectedId: (id: string) => { sel = id },
+      setUnidadSel: () => {},
+      ensureTab: (type: TabType) => { tabs.push({ type }) },
+      openForm: () => {},
+    },
+    get selected() { return sel },
+    get tabs() { return tabs },
+  }
+}
+
+describe('openMaterial', () => {
+  it('actualiza selectedId y prepara tarjetas', () => {
+    const ctx = createOpts()
+    openMaterial('m1', ctx.opts)
+    expect(ctx.selected).toBe('m1')
+    expect(ctx.tabs.some(t => t.type === 'unidades')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- extraemos `openMaterial` a util para facilitar pruebas
- ajustamos `MaterialesTab` para usar la nueva utilidad
- añadimos prueba de la cadena de selección

## Testing
- `pnpm test`
- `npm run build` *(falla: `JWT_SECRET no definido en el entorno`)*

------
