### PR TITLE
Add height-aware board layout

### DIFF
--- a/lib/boardLayout.ts
+++ b/lib/boardLayout.ts
@@ -1,0 +1,25 @@
+import type { Layout } from 'react-grid-layout'
+import type { Tab } from '@/hooks/useTabs'
+
+export type { Layout } from 'react-grid-layout'
+
+export function computeBoardLayout(tabs: Tab[]): Layout[] {
+  let leftY = 0
+  let rightY = 0
+
+  return tabs.map(t => {
+    const x = typeof t.x === 'number' ? t.x : (t.side === 'right' ? 1 : 0)
+    const h = t.h ?? 1
+
+    const y = typeof t.y === 'number'
+      ? t.y
+      : (t.side === 'right' ? rightY : leftY)
+
+    if (typeof t.y !== 'number') {
+      if (t.side === 'right') rightY += h
+      else leftY += h
+    }
+
+    return { i: t.id, x, y, w: t.w ?? 1, h }
+  })
+}

--- a/src/app/dashboard/almacenes/components/CardBoard.tsx
+++ b/src/app/dashboard/almacenes/components/CardBoard.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useRef } from "react";
 import GridLayout, { Layout } from "react-grid-layout";
+import { computeBoardLayout } from "@lib/boardLayout";
 import { CARD_DRAG_THRESHOLD } from "../../constants";
 import { useTabStore, Tab } from "@/hooks/useTabs";
 import { useBoardStore } from "@/hooks/useBoards";
@@ -55,17 +56,7 @@ export default function CardBoard() {
   const rowHeight = width < 640 ? 140 : 150
 
 
-  const layout: Layout[] = (() => {
-    let leftY = 0;
-    let rightY = 0;
-    return current.map(t => {
-      const x = typeof t.x === 'number' ? t.x : (t.side === 'right' ? 1 : 0);
-      const y = typeof t.y === 'number'
-        ? t.y
-        : (t.side === 'right' ? rightY++ : leftY++);
-      return { i: t.id, x, y, w: t.w ?? 1, h: t.h ?? 1 };
-    });
-  })();
+  const layout: Layout[] = computeBoardLayout(current)
 
   const { onLayoutChange } = useCardLayout(boardId, safeCards, setTabs);
 

--- a/tests/boardLayout.test.ts
+++ b/tests/boardLayout.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { computeBoardLayout } from '../lib/boardLayout'
+
+// ensures cards without explicit y use cumulative height
+
+describe('computeBoardLayout', () => {
+  it('incrementa posiciones verticales segun h', () => {
+    const tabs = [
+      { id: 'a', boardId: 'x', side: 'left', h: 2 } as any,
+      { id: 'b', boardId: 'x', side: 'left', h: 3 } as any
+    ]
+    const layout = computeBoardLayout(tabs)
+    expect(layout[0].y).toBe(0)
+    expect(layout[1].y).toBe(2)
+  })
+
+  it('maneja lados separados', () => {
+    const tabs = [
+      { id: 'a', boardId: 'x', side: 'right', h: 2 } as any,
+      { id: 'b', boardId: 'x', side: 'left', h: 1 } as any,
+      { id: 'c', boardId: 'x', side: 'right', h: 1 } as any
+    ]
+    const layout = computeBoardLayout(tabs)
+    const byId = Object.fromEntries(layout.map(l => [l.i, l]))
+    expect(byId.a.y).toBe(0)
+    expect(byId.c.y).toBe(2)
+    expect(byId.b.y).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- extract board layout logic
- increment layout rows using `t.h ?? 1`
- test board layout supports tall cards

## Testing
- `npm test`
- `EMAIL_ADMIN=a SMTP_USER=a SMTP_PASS=a JWT_SECRET=secret npm run build`

------
