### PR TITLE
0.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.9
+- Tableros sin pestañas iniciales; se requiere crear una antes de agregar tarjetas.
+- Compactamos el layout al mover tarjetas para evitar traslapes.
+
 ## 0.6.8
 
 - Autonumeramos los nuevos materiales con un contador local.

--- a/src/app/dashboard/almacenes/components/AddCardButton.tsx
+++ b/src/app/dashboard/almacenes/components/AddCardButton.tsx
@@ -3,13 +3,15 @@ import { useState, useRef, useEffect } from "react";
 import { Plus } from "lucide-react";
 import { useTabStore, type TabType, type Tab } from "@/hooks/useTabs";
 import { useBoardStore } from "@/hooks/useBoards";
+import { useToast } from "@/components/Toast";
 import { generarUUID } from "@/lib/uuid";
 import { tabOptions } from "./tabOptions";
 import { usePrompt } from "@/hooks/usePrompt";
 
 export default function AddCardButton() {
   const { addAfterActive } = useTabStore();
-  const { activeId: boardId } = useBoardStore();
+  const { activeId: boardId, boards } = useBoardStore();
+  const toast = useToast();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const prompt = usePrompt();
@@ -25,6 +27,10 @@ export default function AddCardButton() {
   }, []);
 
   const create = async (type: TabType, label: string) => {
+    if (!boardId) {
+      toast.show("Crea una pestaña primero", "error");
+      return;
+    }
     const id = generarUUID();
     let title = label;
     const extra: Partial<Tab> = { boardId };
@@ -43,13 +49,20 @@ export default function AddCardButton() {
     setOpen(false);
   };
 
+  const disabled = !boardId || boards.length === 0;
   return (
     <div
       ref={ref}
       className="fixed bottom-6 right-6 md:bottom-10 md:right-10 z-40"
     >
       <button
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => {
+          if (disabled) {
+            toast.show("Crea una pestaña primero", "error");
+            return;
+          }
+          setOpen((v) => !v);
+        }}
         title="Añadir tarjeta"
         className="w-12 h-12 rounded-full bg-[var(--dashboard-accent)] text-black flex items-center justify-center shadow-lg hover:scale-105 transition"
       >

--- a/src/app/dashboard/almacenes/components/TabsMenu.tsx
+++ b/src/app/dashboard/almacenes/components/TabsMenu.tsx
@@ -3,6 +3,7 @@ import { useState, useRef, useEffect } from "react";
 import { Plus } from "lucide-react";
 import { useTabStore, type TabType, type Tab } from "@/hooks/useTabs";
 import { useBoardStore } from "@/hooks/useBoards";
+import { useToast } from "@/components/Toast";
 import { generarUUID } from "@/lib/uuid";
 import { tabOptions } from "./tabOptions";
 import { usePrompt } from "@/hooks/usePrompt";
@@ -11,7 +12,8 @@ export default function TabsMenu() {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const { addAfterActive, closeOthers, activeId } = useTabStore();
-  const { activeId: boardId } = useBoardStore();
+  const { activeId: boardId, boards } = useBoardStore();
+  const toast = useToast();
   const prompt = usePrompt();
 
   useEffect(() => {
@@ -23,6 +25,10 @@ export default function TabsMenu() {
   }, []);
 
   const create = async (type: TabType, label: string) => {
+    if (!boardId) {
+      toast.show("Crea una pestaña primero", "error");
+      return;
+    }
     const id = generarUUID();
     let title = label;
     const extra: Partial<Tab> = { boardId };
@@ -41,10 +47,17 @@ export default function TabsMenu() {
     setOpen(false);
   };
 
+  const disabled = !boardId || boards.length === 0;
   return (
     <div className="relative" ref={ref}>
       <button
-        onClick={() => setOpen(o => !o)}
+        onClick={() => {
+          if (disabled) {
+            toast.show("Crea una pestaña primero", "error");
+            return;
+          }
+          setOpen(o => !o);
+        }}
         className="p-2 hover:bg-white/10 rounded-lg"
         title="Agregar tarjeta"
       >

--- a/src/hooks/useBoards.ts
+++ b/src/hooks/useBoards.ts
@@ -35,10 +35,9 @@ interface BoardState {
 export const useBoardStore = create<BoardState>()(
   persist(
     (set) => {
-      const first: Board = { id: generarUUID(), title: 'New Tab' }
       return {
-        boards: [first],
-        activeId: first.id,
+        boards: [],
+        activeId: null,
         add: (b) =>
           set((s) => ({ boards: [...s.boards, b], activeId: b.id })),
         setActive: (id) => set({ activeId: id }),

--- a/src/hooks/useCardLayout.ts
+++ b/src/hooks/useCardLayout.ts
@@ -1,6 +1,7 @@
 "use client";
 import { useCallback, useEffect } from 'react';
 import type { Layout } from 'react-grid-layout';
+import { compactLayout } from '@lib/boardLayout';
 import type { Tab } from './useTabs';
 
 export function applyLayout(tabs: Tab[], layout: Layout[]) {
@@ -38,7 +39,7 @@ export default function useCardLayout(
           w: t.w ?? 1,
           h: t.h ?? 1,
         }));
-        localStorage.setItem(key, JSON.stringify(layout));
+        localStorage.setItem(key, JSON.stringify(compactLayout(layout)));
       }
     } catch {}
   }, [key, boardId, tabs, setTabs]);
@@ -55,8 +56,9 @@ export default function useCardLayout(
 
   const onLayoutChange = useCallback(
     (layout: Layout[]) => {
-      setTabs(applyLayout(tabs, layout));
-      save(layout);
+      const compacted = compactLayout(layout);
+      setTabs(applyLayout(tabs, compacted));
+      save(compacted);
     },
     [setTabs, save, tabs],
   );

--- a/tests/boardStore.test.ts
+++ b/tests/boardStore.test.ts
@@ -17,6 +17,11 @@ afterEach(() => {
 })
 
 describe('useBoardStore', () => {
+  it('initializes empty', () => {
+    const state = useBoardStore.getState()
+    expect(state.boards.length).toBe(0)
+    expect(state.activeId).toBeNull()
+  })
   it('adds boards and sets active', () => {
     useBoardStore.getState().add({ id: '1', title: 'b1' })
     const state = useBoardStore.getState()


### PR DESCRIPTION
## Summary
- no initial board tab when starting board store
- prevent adding cards without an active tab, with toast notice
- compact card layout on drag
- cover board store default state in tests

## Testing
- `npm run build` *(fails: Failed to collect page data for /api/login)*
- `npm test`

------
