### PR TITLE
0.6.10

### DIFF
--- a/src/app/dashboard/almacenes/components/CardBoard.tsx
+++ b/src/app/dashboard/almacenes/components/CardBoard.tsx
@@ -78,7 +78,7 @@ export default function CardBoard() {
         compactType="vertical"
       >
         {current.map(tab => (
-          <div key={tab.id}>
+          <div key={tab.id} className="h-full">
             <DraggableCard tab={tab} grid />
           </div>
         ))}

--- a/src/app/dashboard/almacenes/components/DraggableCard.tsx
+++ b/src/app/dashboard/almacenes/components/DraggableCard.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
 import { Pencil, Pin, PinOff, X } from "lucide-react";
 import { useTabStore, Tab } from "@/hooks/useTabs";
 import { usePrompt } from "@/hooks/usePrompt";
@@ -74,7 +75,7 @@ export default function DraggableCard({ tab, grid = false }: Props) {
         ref={sortable ? setNodeRef : undefined}
         style={style}
         {...(sortable ? attributes : {})}
-        className="dashboard-card overflow-auto"
+        className={cn("dashboard-card overflow-auto", grid && "h-full")}
         whileDrag={sortable ? { scale: 1.05 } : undefined}
       >
       <div className="flex items-center justify-between mb-2">

--- a/tests/draggableCardHandles.test.tsx
+++ b/tests/draggableCardHandles.test.tsx
@@ -11,4 +11,10 @@ describe('DraggableCard', () => {
     const matches = html.match(/react-resizable-handle-(?:se|sw|ne|nw)/g) || []
     expect(matches.length).toBe(0)
   })
+
+  it('usa h-full en modo grid', () => {
+    const tab = { id: 't2', title: 'demo', type: 'test' } as Tab
+    const html = renderToStaticMarkup(<DraggableCard tab={tab} grid />)
+    expect(html.includes('h-full')).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary
- agregamos `cn` en DraggableCard para unir clases
- añadimos `h-full` en tarjetas cuando se renderizan en grid
- los contenedores de CardBoard ahora expanden la tarjeta
- testeamos que DraggableCard incluya `h-full` en modo grid

## Testing
- `npm test`
- `npm run build` *(falla: JWT_SECRET no definido)*

------
https://chatgpt.com/codex/tasks/task_e_68768757fb4c8328b84d761698ab4840