### PR TITLE
0.6.13

### DIFF
--- a/src/app/api/materiales/[id]/duplicar/route.ts
+++ b/src/app/api/materiales/[id]/duplicar/route.ts
@@ -1,0 +1,96 @@
+export const runtime = 'nodejs'
+
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@lib/prisma'
+import { getUsuarioFromSession } from '@lib/auth'
+import { hasManagePerms } from '@lib/permisos'
+import crypto from 'node:crypto'
+import * as logger from '@lib/logger'
+
+function getId(req: NextRequest): number | null {
+  const parts = req.nextUrl.pathname.split('/')
+  const idx = parts.findIndex((p) => p === 'materiales')
+  const id = idx !== -1 && parts.length > idx + 1 ? Number(parts[idx + 1]) : null
+  return id && !Number.isNaN(id) ? id : null
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const usuario = await getUsuarioFromSession(req)
+    if (!usuario) {
+      return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
+    }
+    const id = getId(req)
+    if (!id) return NextResponse.json({ error: 'ID inválido' }, { status: 400 })
+
+    const material = await prisma.material.findUnique({
+      where: { id },
+      include: { archivos: true },
+    })
+    if (!material) {
+      return NextResponse.json({ error: 'No encontrado' }, { status: 404 })
+    }
+
+    const pertenece = await prisma.usuarioAlmacen.findFirst({
+      where: { usuarioId: usuario.id, almacenId: material.almacenId },
+      select: { id: true },
+    })
+    if (!pertenece && !hasManagePerms(usuario)) {
+      return NextResponse.json({ error: 'Sin permisos' }, { status: 403 })
+    }
+
+    const miniOriginal = material.miniaturaNombre
+      ? material.miniaturaNombre.split('_').slice(1).join('_')
+      : null
+    const miniaturaNombre = miniOriginal
+      ? `${crypto.randomUUID()}_${miniOriginal}`
+      : null
+
+    const nuevo = await prisma.$transaction(async (tx) => {
+      const creado = await tx.material.create({
+        data: {
+          nombre: `${material.nombre} copia`,
+          descripcion: material.descripcion,
+          miniatura: material.miniatura as any,
+          miniaturaNombre,
+          cantidad: material.cantidad,
+          unidad: material.unidad,
+          lote: material.lote,
+          fechaCaducidad: material.fechaCaducidad,
+          ubicacion: material.ubicacion,
+          proveedor: material.proveedor,
+          estado: material.estado,
+          observaciones: material.observaciones,
+          codigoBarra: material.codigoBarra,
+          codigoQR: material.codigoQR,
+          minimo: material.minimo,
+          maximo: material.maximo,
+          reorderLevel: material.reorderLevel,
+          almacenId: material.almacenId,
+          usuarioId: usuario.id,
+        },
+        select: { id: true, nombre: true },
+      })
+
+      for (const a of material.archivos) {
+        const orig = a.archivoNombre ? a.archivoNombre.split('_').slice(1).join('_') : null
+        const archivoNombre = orig ? `${crypto.randomUUID()}_${orig}` : null
+        await tx.archivoMaterial.create({
+          data: {
+            nombre: a.nombre,
+            archivo: a.archivo as any,
+            archivoNombre,
+            materialId: creado.id,
+            subidoPorId: usuario.id,
+          },
+        })
+      }
+      return creado
+    })
+
+    return NextResponse.json({ material: nuevo })
+  } catch (err) {
+    logger.error('POST /api/materiales/[id]/duplicar', err)
+    return NextResponse.json({ error: 'Error al duplicar' }, { status: 500 })
+  }
+}

--- a/src/app/dashboard/almacenes/board/BoardProvider.tsx
+++ b/src/app/dashboard/almacenes/board/BoardProvider.tsx
@@ -18,6 +18,7 @@ interface BoardState {
   crear: (m: Material) => Promise<any>;
   actualizar: (m: Material) => Promise<any>;
   eliminar: (id: number) => Promise<any>;
+  duplicar: (id: number) => Promise<any>;
   mutate: () => void;
 }
 
@@ -25,7 +26,7 @@ const Context = createContext<BoardState | null>(null);
 
 export function BoardProvider({ children }: { children: React.ReactNode }) {
   const { id } = useParams();
-  const { materiales, isLoading, error, crear, actualizar, eliminar, mutate } =
+  const { materiales, isLoading, error, crear, actualizar, eliminar, duplicar, mutate } =
     useMateriales(id as string);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [unidadSel, setUnidadSel] = useState<UnidadDetalle | null>(null);
@@ -55,9 +56,10 @@ export function BoardProvider({ children }: { children: React.ReactNode }) {
       crear,
       actualizar,
       eliminar,
+      duplicar,
       mutate,
     }),
-    [materiales, selectedId, unidadSel, auditoriaSel, crear, actualizar, eliminar, isLoading, error, mutate, setSelId, setUni, setAud]
+    [materiales, selectedId, unidadSel, auditoriaSel, crear, actualizar, eliminar, duplicar, isLoading, error, mutate, setSelId, setUni, setAud]
   );
 
   if (!id) return <>{children}</>;

--- a/src/app/dashboard/almacenes/components/tabs/MaterialesTab.tsx
+++ b/src/app/dashboard/almacenes/components/tabs/MaterialesTab.tsx
@@ -6,6 +6,7 @@ import { useBoard } from '../../board/BoardProvider'
 import { useTabHelpers } from '@/hooks/useTabHelpers'
 import { generarUUID } from '@/lib/uuid'
 import { openMaterial as doOpenMaterial } from '../../utils/openMaterial'
+import { useToast } from '@/components/Toast'
 
 export default function MaterialesTab() {
   const {
@@ -14,8 +15,10 @@ export default function MaterialesTab() {
     setSelectedId,
     setUnidadSel,
     crear,
+    duplicar,
   } = useBoard()
   const { ensureTab, openForm } = useTabHelpers()
+  const toast = useToast()
   const [busqueda, setBusqueda] = useState('')
   const [orden, setOrden] = useState<'nombre' | 'cantidad'>('nombre')
   const nameCounter = useRef(0)
@@ -66,7 +69,16 @@ export default function MaterialesTab() {
         if (mid) openMaterial(String(mid))
         return res
       }}
-      onDuplicar={() => {}}
+      onDuplicar={async () => {
+        if (!selectedId) return
+        const res = await duplicar(Number(selectedId))
+        if (res?.material?.id) {
+          toast.show('Material duplicado', 'success')
+          openMaterial(String(res.material.id))
+        } else {
+          toast.show(res?.error || 'Error al duplicar', 'error')
+        }
+      }}
     />
   )
 }

--- a/src/hooks/useMateriales.ts
+++ b/src/hooks/useMateriales.ts
@@ -131,6 +131,19 @@ export default function useMateriales(almacenId?: number | string) {
     }
   }
 
+  const duplicar = async (materialId: number) => {
+    try {
+      const res = await apiFetch(`/api/materiales/${materialId}/duplicar`, { method: 'POST' })
+      const data = await jsonOrNull(res)
+      if (res.ok && data?.material) {
+        mutate()
+      }
+      return data
+    } catch {
+      return { error: 'Error de red' }
+    }
+  }
+
   const mats = useMemo(
     () =>
       (data?.materiales as any[] | undefined)?.map((m) => ({
@@ -154,5 +167,6 @@ export default function useMateriales(almacenId?: number | string) {
     crear,
     actualizar,
     eliminar,
+    duplicar,
   }
 }


### PR DESCRIPTION
## Summary
- implement POST `/api/materiales/[id]/duplicar` to copy a material and its files
- support duplication in `useMateriales` hook
- expose new method through `BoardProvider`
- connect duplicate action in `MaterialesTab` with toast feedback

## Testing
- `npm run build` *(fails: JWT_SECRET no definido)*
- `npm test`

------
