### PR TITLE
0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.7.1
+- Evitamos que las tarjetas de formularios se abran colapsadas y ajustamos su tamaño por defecto.
+
 ## 0.7.0
 - Permite borrar materiales desde la lista con confirmación.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/components/AddCardButton.tsx
+++ b/src/app/dashboard/almacenes/components/AddCardButton.tsx
@@ -45,7 +45,7 @@ export default function AddCardButton() {
       extra.boardId = board;
       title = board;
     }
-    addAfterActive({ id, title, type, side: "left", x: 0, y: 0, w: 1, h: 1, ...extra });
+    addAfterActive({ id, title, type, side: "left", x: 0, y: 0, w: 1, h: 2, ...extra });
     setOpen(false);
   };
 

--- a/src/hooks/useTabHelpers.ts
+++ b/src/hooks/useTabHelpers.ts
@@ -28,6 +28,8 @@ export function useTabHelpers() {
           side: 'left',
           x: undefined,
           y: undefined,
+          collapsed: false,
+          h: 2,
         })
         setActive(form.id)
       } else {
@@ -39,6 +41,8 @@ export function useTabHelpers() {
           boardId: activeId,
           x: undefined,
           y: undefined,
+          collapsed: false,
+          h: 2,
         })
       }
     },

--- a/tests/tabHelpers.test.ts
+++ b/tests/tabHelpers.test.ts
@@ -67,8 +67,12 @@ describe('useTabHelpers', () => {
     openForm('form-unidad', 'Unidad')
     const formsB1 = tabs.filter(t => t.boardId === 'b1')
     expect(formsB1.length).toBe(1)
-    expect(formsB1[0].type).toBe('form-unidad')
-    expect(formsB1[0].side).toBe('left')
+    expect(formsB1[0]).toMatchObject({
+      type: 'form-unidad',
+      side: 'left',
+      collapsed: false,
+      h: 2,
+    })
     expect(formsB1[0].x).toBeUndefined()
     expect(formsB1[0].y).toBeUndefined()
 
@@ -78,7 +82,7 @@ describe('useTabHelpers', () => {
     openForm('form-material', 'Material')
     const formB2 = tabs.find(t => t.boardId === 'b2')
     expect(formB2).toBeTruthy()
-    expect(formB2?.side).toBe('left')
+    expect(formB2).toMatchObject({ side: 'left', collapsed: false, h: 2 })
     expect(formB2?.x).toBeUndefined()
     expect(formB2?.y).toBeUndefined()
   })


### PR DESCRIPTION
## Summary
- prevent collapsed form cards when opened via `openForm`
- expand default card height for new cards
- update tests for new form behavior
- bump version to 0.7.1

## Testing
- `npm run build`
- `npm test`


------
