### PR TITLE
0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ## 0.8.2
 - Extraemos `useCreateTab` para unificar la creación de tarjetas.
 
+## 0.8.3
+- Corregimos el margen superior del tablero para que las tarjetas no se superpongan con la barra de pestañas.
+
 ## 0.7.1
 - Evitamos que las tarjetas de formularios se abran colapsadas y ajustamos su tamaño por defecto.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/components/CardBoard.tsx
+++ b/src/app/dashboard/almacenes/components/CardBoard.tsx
@@ -63,7 +63,8 @@ export default function CardBoard() {
   return (
     <div
       ref={containerRef}
-      className={`transition-all duration-300 min-h-screen pb-10 border-t border-[var(--dashboard-border)] ${collapsed ? 'pt-0' : 'pt-2'} mt-[calc(${TABBAR_HEIGHT}+${TABBAR_GAP})]`}
+      className={`transition-all duration-300 min-h-screen pb-10 border-t border-[var(--dashboard-border)] ${collapsed ? 'pt-0' : 'pt-2'}`}
+      style={{ marginTop: `calc(${TABBAR_HEIGHT} + ${TABBAR_GAP})` }}
     >
       <GridLayout
         layout={layout}


### PR DESCRIPTION
## Summary
- prevent tab overlap by setting margin top via style in `CardBoard`
- bump version to 0.8.3 and document fix

## Testing
- `npm test`
- `npm run build` *(fails: JWT_SECRET no definido en el entorno)*

------
