### PR TITLE
0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ## 0.8.3
 - Corregimos el margen superior del tablero para que las tarjetas no se superpongan con la barra de pestañas.
 
+## 0.8.4
+- Las tarjetas nuevas ahora se ubican tras la última y conservan su posición luego de recargar.
+
 ## 0.7.1
 - Evitamos que las tarjetas de formularios se abran colapsadas y ajustamos su tamaño por defecto.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/components/AddCardButton.tsx
+++ b/src/app/dashboard/almacenes/components/AddCardButton.tsx
@@ -9,7 +9,7 @@ import type { TabType } from "@/hooks/useTabs";
 export default function AddCardButton() {
   const toast = useToast();
   const { create: createHook, disabled } = useCreateTab({
-    defaultLayout: { x: 0, y: 0, w: 1, h: 2 },
+    defaultLayout: { w: 1, h: 2 },
   });
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);

--- a/tests/useCreateTab.test.ts
+++ b/tests/useCreateTab.test.ts
@@ -55,18 +55,18 @@ describe('useCreateTab', () => {
   })
 
   it('crea tabs con layout por defecto', async () => {
-    const { create } = useCreateTab({ defaultLayout: { x: 0, y: 0, w: 1, h: 2 } })
+    const { create } = useCreateTab({ defaultLayout: { w: 1, h: 2 } })
     await create('unidades', 'Unid')
     expect(tabs[0]).toMatchObject({
       id: 'uid',
       title: 'Unid',
       type: 'unidades',
       boardId: 'b1',
-      x: 0,
-      y: 0,
       w: 1,
       h: 2,
     })
+    expect(tabs[0].x).toBeUndefined()
+    expect(tabs[0].y).toBeUndefined()
   })
 
   it('solicita datos adicionales para url', async () => {


### PR DESCRIPTION
## Summary
- insert new cards after the last one by omitting `x` and `y`
- update test expectations for the new default layout
- document behaviour in CHANGELOG

## Testing
- `npm test`
- `npm run build`


------
