### PR TITLE
0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 ## 0.8.4
 - Las tarjetas nuevas ahora se ubican tras la última y conservan su posición luego de recargar.
 
+## 0.8.5
+- Registramos auditorías también al escanear códigos.
+- Mejoramos el manejo de errores al crear reportes y auditorías.
+
 ## 0.7.1
 - Evitamos que las tarjetas de formularios se abran colapsadas y ajustamos su tamaño por defecto.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/api/almacenes/[id]/materiales/route.ts
+++ b/src/app/api/almacenes/[id]/materiales/route.ts
@@ -229,7 +229,7 @@ export async function POST(req: NextRequest) {
 
     await logAudit(usuario.id, 'creacion_material', 'almacen', { almacenId, materialId: material.id })
 
-    const auditoria = await registrarAuditoria(
+    const { auditoria, error: auditError } = await registrarAuditoria(
       req,
       'material',
       material.id,
@@ -238,7 +238,7 @@ export async function POST(req: NextRequest) {
       reportFiles,
     )
 
-    const res = NextResponse.json({ material, auditoria })
+    const res = NextResponse.json({ material, auditoria, auditError })
     logger.info(req, `Material ${material.id} creado`)
     return res
   } catch (err) {
@@ -265,7 +265,7 @@ export async function DELETE(req: NextRequest) {
     await prisma.material.deleteMany({ where: { almacenId } })
     await logAudit(usuario.id, 'eliminacion_materiales', 'almacen', { almacenId })
 
-    const auditoria = await registrarAuditoria(
+    const { auditoria, error: auditError } = await registrarAuditoria(
       req,
       'almacen',
       almacenId,
@@ -273,7 +273,7 @@ export async function DELETE(req: NextRequest) {
       { accion: 'vaciar_materiales' },
     )
 
-    return NextResponse.json({ success: true, auditoria })
+    return NextResponse.json({ success: true, auditoria, auditError })
   } catch (err) {
     logger.error('DELETE /api/almacenes/[id]/materiales', err)
     return NextResponse.json({ error: 'Error al vaciar' }, { status: 500 })

--- a/src/app/api/almacenes/[id]/route.ts
+++ b/src/app/api/almacenes/[id]/route.ts
@@ -196,14 +196,14 @@ export async function DELETE(req: NextRequest) {
 
   await logAudit(usuario.id, 'eliminacion', 'almacen', { almacenId: id })
 
-  const auditoria = await registrarAuditoria(
+  const { auditoria, error: auditError } = await registrarAuditoria(
     req,
     'almacen',
     id,
     'eliminacion',
     {},
   )
-    return NextResponse.json({ success: true, auditoria });
+    return NextResponse.json({ success: true, auditoria, auditError });
   } catch (err) {
     logger.error('DELETE /api/almacenes/[id]', err);
     return NextResponse.json({ error: 'Error al eliminar' }, { status: 500 });
@@ -284,7 +284,7 @@ export async function PUT(req: NextRequest) {
 
   await logAudit(usuario.id, 'modificacion', 'almacen', { almacenId: id })
 
-  const auditoria = await registrarAuditoria(
+  const { auditoria, error: auditError } = await registrarAuditoria(
     req,
     'almacen',
     id,
@@ -298,7 +298,7 @@ export async function PUT(req: NextRequest) {
       ? `/api/almacenes/foto?nombre=${encodeURIComponent(almacen.imagenNombre)}`
       : almacen.imagenUrl,
   }
-  return NextResponse.json({ almacen: resp, auditoria })
+  return NextResponse.json({ almacen: resp, auditoria, auditError })
   } catch (err) {
     logger.error('PUT /api/almacenes/[id]', err);
     return NextResponse.json({ error: 'Error al actualizar' }, { status: 500 });

--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -273,7 +273,7 @@ export async function POST(req: NextRequest) {
 
   await logAudit(usuario.id, 'creacion', 'almacen', { almacenId: almacen.id })
 
-  const auditoria = await registrarAuditoria(
+  const { auditoria, error: auditError } = await registrarAuditoria(
     req,
     'almacen',
     almacen.id,
@@ -287,7 +287,7 @@ export async function POST(req: NextRequest) {
       ? `/api/almacenes/foto?nombre=${encodeURIComponent(imagenNombre)}`
       : almacen.imagenUrl,
   }
-  return NextResponse.json({ almacen: resp, auditoria })
+  return NextResponse.json({ almacen: resp, auditoria, auditError })
   } catch (err) {
     logger.error('POST /api/almacenes', err);
     return NextResponse.json(

--- a/src/app/api/materiales/[id]/ajuste/route.ts
+++ b/src/app/api/materiales/[id]/ajuste/route.ts
@@ -49,7 +49,7 @@ export async function PATCH(req: NextRequest) {
       }
     })
 
-    const auditoria = await registrarAuditoria(
+    const { auditoria, error: auditError } = await registrarAuditoria(
       req,
       'material',
       id,
@@ -67,7 +67,7 @@ export async function PATCH(req: NextRequest) {
         }
       })
     }
-    return NextResponse.json({ success: true, auditoria })
+    return NextResponse.json({ success: true, auditoria, auditError })
   } catch (err) {
     logger.error('PATCH /api/materiales/[id]/ajuste', err)
     return NextResponse.json({ error: 'Error' }, { status: 500 })

--- a/src/app/api/materiales/[id]/route.ts
+++ b/src/app/api/materiales/[id]/route.ts
@@ -166,14 +166,14 @@ export async function PUT(req: NextRequest) {
     })
 
     await logAudit(usuario.id, 'modificacion_material', 'material', { materialId: id })
-    const auditoria = await registrarAuditoria(
+    const { auditoria, error: auditError } = await registrarAuditoria(
       req,
       'material',
       id,
       'modificacion',
       datos,
     )
-    return NextResponse.json({ material: actualizado, auditoria })
+    return NextResponse.json({ material: actualizado, auditoria, auditError })
   } catch (err) {
     logger.error('PUT /api/materiales/[id]', err)
     return NextResponse.json({ error: 'Error' }, { status: 500 })
@@ -205,14 +205,14 @@ export async function DELETE(req: NextRequest) {
       await tx.material.delete({ where: { id } })
     })
     await logAudit(usuario.id, 'eliminacion_material', 'material', { materialId: id })
-    const auditoria = await registrarAuditoria(
+    const { auditoria, error: auditError } = await registrarAuditoria(
       req,
       'material',
       id,
       'eliminacion',
       {},
     )
-    return NextResponse.json({ success: true, auditoria })
+    return NextResponse.json({ success: true, auditoria, auditError })
   } catch (err) {
     logger.error('DELETE /api/materiales/[id]', err)
     return NextResponse.json({ error: 'Error' }, { status: 500 })

--- a/src/app/api/materiales/[id]/unidades/[unidadId]/route.ts
+++ b/src/app/api/materiales/[id]/unidades/[unidadId]/route.ts
@@ -171,7 +171,7 @@ export async function PUT(req: NextRequest) {
       await snapshot(actualizado.id, usuario.id, 'Modificación')
       await logAudit(usuario.id, 'modificacion_unidad', 'material', { materialId, unidadId })
 
-      const auditoria = await registrarAuditoria(
+      const { auditoria, error: auditError } = await registrarAuditoria(
         req,
         'unidad',
         unidadId,
@@ -179,7 +179,7 @@ export async function PUT(req: NextRequest) {
         data,
       )
 
-      return NextResponse.json({ unidad: actualizado, auditoria })
+      return NextResponse.json({ unidad: actualizado, auditoria, auditError })
     } catch (e) {
       if (
         e instanceof Prisma.PrismaClientKnownRequestError &&
@@ -218,7 +218,7 @@ export async function DELETE(req: NextRequest) {
     await prisma.materialUnidad.delete({ where: { id: unidadId } })
     await logAudit(usuario.id, 'eliminacion_unidad', 'material', { materialId, unidadId })
 
-    const auditoria = await registrarAuditoria(
+    const { auditoria, error: auditError } = await registrarAuditoria(
       req,
       'unidad',
       unidadId,
@@ -226,7 +226,7 @@ export async function DELETE(req: NextRequest) {
       {},
     )
 
-    return NextResponse.json({ success: true, auditoria })
+    return NextResponse.json({ success: true, auditoria, auditError })
   } catch (err) {
     logger.error('DELETE /api/materiales/[id]/unidades/[unidadId]', err)
     if (process.env.NODE_ENV === 'development') console.error(err)

--- a/src/app/api/materiales/[id]/unidades/route.ts
+++ b/src/app/api/materiales/[id]/unidades/route.ts
@@ -149,7 +149,7 @@ export async function POST(req: NextRequest) {
       await snapshot(creado.id, usuario.id, 'Creación')
       await logAudit(usuario.id, 'creacion_unidad', 'material', { materialId, unidadId: creado.id })
 
-      const auditoria = await registrarAuditoria(
+      const { auditoria, error: auditError } = await registrarAuditoria(
         req,
         'unidad',
         creado.id,
@@ -157,7 +157,7 @@ export async function POST(req: NextRequest) {
         data,
       )
 
-      return NextResponse.json({ unidad: creado, auditoria })
+      return NextResponse.json({ unidad: creado, auditoria, auditError })
     } catch (e) {
       if (
         e instanceof Prisma.PrismaClientKnownRequestError &&

--- a/tests/almacenesAuditoria.test.ts
+++ b/tests/almacenesAuditoria.test.ts
@@ -17,7 +17,7 @@ describe('POST /api/almacenes', () => {
     const prismaMock = { $transaction: vi.fn().mockImplementation(async (cb:any)=> cb(tx)) }
     vi.doMock('../lib/prisma', () => ({ default: prismaMock }))
     vi.doMock('../src/lib/audit', () => ({ logAudit: vi.fn() }))
-    const registrarAuditoria = vi.fn().mockResolvedValue({ id: 9 })
+    const registrarAuditoria = vi.fn().mockResolvedValue({ auditoria: { id: 9 } })
     vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
     const { POST } = await import('../src/app/api/almacenes/route')
     const body = JSON.stringify({ nombre: 'A', descripcion: '', funciones: '', permisosPredeterminados: '' })
@@ -45,7 +45,7 @@ describe('PUT /api/almacenes/[id]', () => {
     const prismaMock = { usuarioAlmacen: { findFirst: vi.fn().mockResolvedValue({ id: 1 }) }, $transaction: vi.fn().mockImplementation(async (cb:any)=> cb(tx)) }
     vi.doMock('../lib/prisma', () => ({ default: prismaMock }))
     vi.doMock('../src/lib/audit', () => ({ logAudit: vi.fn() }))
-    const registrarAuditoria = vi.fn().mockResolvedValue({ id: 9 })
+    const registrarAuditoria = vi.fn().mockResolvedValue({ auditoria: { id: 9 } })
     vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
     const { PUT } = await import('../src/app/api/almacenes/[id]/route')
     const req = new NextRequest('http://localhost/api/almacenes/5', {
@@ -87,7 +87,7 @@ describe('DELETE /api/almacenes/[id]', () => {
     }
     vi.doMock('../lib/prisma', () => ({ default: prismaMock }))
     vi.doMock('../src/lib/audit', () => ({ logAudit: vi.fn() }))
-    const registrarAuditoria = vi.fn().mockResolvedValue({ id: 9 })
+    const registrarAuditoria = vi.fn().mockResolvedValue({ auditoria: { id: 9 } })
     vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
     const { DELETE } = await import('../src/app/api/almacenes/[id]/route')
     const req = new NextRequest('http://localhost/api/almacenes/5', { method: 'DELETE' })

--- a/tests/auditLog.test.ts
+++ b/tests/auditLog.test.ts
@@ -15,4 +15,15 @@ describe('logAudit', () => {
     )
     vi.unmock('../lib/prisma')
   })
+
+  it('retorna error cuando fetch falla', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('net'))
+    vi.stubGlobal('fetch', fetchMock)
+    const { registrarAuditoria } = await import('../lib/reporter')
+    const { NextRequest } = await import('next/server')
+    const req = new NextRequest('http://localhost/api/test')
+    const result = await registrarAuditoria(req, 'almacen', 1, 'creacion', {})
+    expect(result).toEqual({ error: 'Error de red al crear reporte' })
+    vi.unstubAllGlobals()
+  })
 })

--- a/tests/materialAjusteAuditoria.test.ts
+++ b/tests/materialAjusteAuditoria.test.ts
@@ -20,7 +20,7 @@ describe('PATCH /api/materiales/[id]/ajuste', () => {
       alerta: { create: vi.fn() },
     }
     vi.doMock('../lib/prisma', () => ({ default: prismaMock }))
-    const registrarAuditoria = vi.fn().mockResolvedValue({ id: 9 })
+    const registrarAuditoria = vi.fn().mockResolvedValue({ auditoria: { id: 9 } })
     vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
     const { PATCH } = await import('../src/app/api/materiales/[id]/ajuste/route')
     const req = new NextRequest('http://localhost/api/materiales/5/ajuste', {

--- a/tests/materialUpdateAuditoria.test.tsx
+++ b/tests/materialUpdateAuditoria.test.tsx
@@ -28,7 +28,7 @@ describe('PUT /api/materiales/[id]', () => {
     }
     vi.doMock('../lib/prisma', () => ({ default: prismaMock }))
     vi.doMock('../src/lib/audit', () => ({ logAudit: vi.fn() }))
-    const registrarAuditoria = vi.fn().mockResolvedValue({ id: 9 })
+    const registrarAuditoria = vi.fn().mockResolvedValue({ auditoria: { id: 9 } })
     vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
     const { PUT } = await import('../src/app/api/materiales/[id]/route')
     const body = JSON.stringify({ nombre: 'nuevo' })


### PR DESCRIPTION
## Summary
- log and propagate fetch errors when creating auditorias
- audit scan discrepancies and send report to client
- surface reporter errors via `auditError` in API responses
- adapt audit tests to new reporter result
- add failing fetch test for the reporter

## Testing
- `npm run build` *(fails: JWT_SECRET no definido en el entorno)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6876e2424ed0832887118f6af0ed0085