### PR TITLE
0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 ## 0.8.4
 - Las tarjetas nuevas ahora se ubican tras la última y conservan su posición luego de recargar.
 
+## 0.8.6
+- Aumentamos el contraste de los bordes del dashboard para que los separadores sean visibles en todos los temas.
+
 ## 0.8.5
 - Registramos auditorías también al escanear códigos.
 - Mejoramos el manejo de errores al crear reportes y auditorías.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,7 +16,7 @@
   --dashboard-card: #23232B;
   --dashboard-accent: #ffe066;
   --dashboard-accent-hover: #fff3a1;
-  --dashboard-border: #2a2a33;
+  --dashboard-border: #3f3f46;
   --dashboard-text: #ececec;
   --dashboard-muted: #9ca3af;
   --dashboard-shadow: 0 2px 16px #0005;
@@ -47,7 +47,7 @@
     --dashboard-sidebar: #1A1A1D;
     --dashboard-navbar: #0D0B11;
     --dashboard-card: #23232B;
-    --dashboard-border: #23232B;
+    --dashboard-border: #3f3f46;
     --dashboard-table-bg: #23232B;
     --dashboard-table-row: #23232B;
     --dashboard-table-hover: #1A1A1D;


### PR DESCRIPTION
## Summary
- reforzamos el color de `--dashboard-border` para resaltar los separadores
- documentamos el ajuste en el CHANGELOG
- actualizamos la version del paquete

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876e53a06f483288e0963d4304746a7