### PR TITLE
0.8.8

### DIFF
--- a/src/app/dashboard/almacenes/page.tsx
+++ b/src/app/dashboard/almacenes/page.tsx
@@ -21,7 +21,7 @@ export default function AlmacenesPage() {
     loading,
     error,
     handleDragStart,
-    handleDragEnter,
+    handleDragOver,
     handleDragEnd,
     moveItem,
     eliminar,
@@ -65,7 +65,7 @@ export default function AlmacenesPage() {
           onDelete={eliminar}
           onOpen={(id) => router.push(`/dashboard/almacenes/${id}`)}
           onDragStart={handleDragStart}
-          onDragEnter={handleDragEnter}
+          onDragOver={handleDragOver}
           onDragEnd={handleDragEnd}
           onMove={(id, dir) => moveItem(id, dir)}
         />


### PR DESCRIPTION
## Summary
- migramos `AlmacenesList` a `dnd-kit` usando `SortableContext`
- manejamos `onDragStart`, `onDragOver` y `onDragEnd` en `useAlmacenesLogic`
- ajustamos la página de almacenes para consumir los nuevos handlers

## Testing
- `npm run build` *(falla: `JWT_SECRET no definido`)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876ebad93648328b4a841cbaae1b3ad