### PR TITLE
0.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 - Validamos el ID seleccionado antes de llamar la API para duplicar o eliminar materiales.
 - Mostramos notificaciones de éxito o error al guardar o borrar materiales.
 
+## 0.8.8
+- Mantuvimos abiertos los formularios tras guardar para seguir editando.
+- Ajustamos las nuevas tarjetas a altura mayor por defecto.
+
 ## 0.8.5
 - Registramos auditorías también al escanear códigos.
 - Mejoramos el manejo de errores al crear reportes y auditorías.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "honeylabs",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "honeylabs",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "hasInstallScript": true,
       "dependencies": {
         "@capacitor/core": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/components/AddCardButton.tsx
+++ b/src/app/dashboard/almacenes/components/AddCardButton.tsx
@@ -9,7 +9,7 @@ import type { TabType } from "@/hooks/useTabs";
 export default function AddCardButton() {
   const toast = useToast();
   const { create: createHook, disabled } = useCreateTab({
-    defaultLayout: { w: 1, h: 2 },
+    defaultLayout: { w: 1, h: 3 },
   });
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);

--- a/src/app/dashboard/almacenes/components/tabs/MaterialFormTab.tsx
+++ b/src/app/dashboard/almacenes/components/tabs/MaterialFormTab.tsx
@@ -47,9 +47,12 @@ export default function MaterialFormTab({ tabId }: { tabId: string }) {
     }
     toast.show('Material guardado', 'success')
     mutate()
-    setSelectedId(null)
-    close(tabId)
-  }, [draft, actualizar, crear, mutate, setSelectedId, close, tabId, toast])
+    if (res?.material?.id) {
+      const id = String(res.material.id)
+      setDraft(d => d ? { ...d, dbId: res.material.id, id } : d)
+      setSelectedId(id)
+    }
+  }, [draft, actualizar, crear, mutate, setSelectedId, toast])
 
   const duplicar = useCallback(async () => {
     if (!draft) return

--- a/src/app/dashboard/almacenes/components/tabs/UnidadFormTab.tsx
+++ b/src/app/dashboard/almacenes/components/tabs/UnidadFormTab.tsx
@@ -20,8 +20,10 @@ export default function UnidadFormTab({ tabId }: { tabId: string }) {
     }
     toast.show('Unidad guardada', 'success')
     mutate()
-    setUnidadSel(null)
-    close(tabId)
+    if (res?.unidad?.id) {
+      const id = res.unidad.id
+      setUnidadSel(u => (u ? { ...u, id } : u))
+    }
   }
 
   const cancelar = () => {

--- a/src/hooks/useTabHelpers.ts
+++ b/src/hooks/useTabHelpers.ts
@@ -29,7 +29,7 @@ export function useTabHelpers() {
           x: undefined,
           y: undefined,
           collapsed: false,
-          h: 2,
+          h: 3,
         })
         setActive(form.id)
       } else {
@@ -42,7 +42,7 @@ export function useTabHelpers() {
           x: undefined,
           y: undefined,
           collapsed: false,
-          h: 2,
+          h: 3,
         })
       }
     },

--- a/tests/materialUpdateAuditoria.test.tsx
+++ b/tests/materialUpdateAuditoria.test.tsx
@@ -122,7 +122,7 @@ describe('MaterialFormTab y UnidadFormTab', () => {
     await (global as any).matGuardar()
     expect(toast.show).toHaveBeenCalledWith('Material guardado', 'success')
     expect(mutate).toHaveBeenCalled()
-    expect(close).toHaveBeenCalledWith('t1')
+    expect(close).not.toHaveBeenCalled()
   })
 
   it('muestra error sin cerrar', async () => {
@@ -159,6 +159,6 @@ describe('MaterialFormTab y UnidadFormTab', () => {
     await (global as any).uniGuardar()
     expect(toast.show).toHaveBeenCalledWith('Unidad guardada', 'success')
     expect(mutate).toHaveBeenCalled()
-    expect(close).toHaveBeenCalledWith('t3')
+    expect(close).not.toHaveBeenCalled()
   })
 })

--- a/tests/tabHelpers.test.ts
+++ b/tests/tabHelpers.test.ts
@@ -71,7 +71,7 @@ describe('useTabHelpers', () => {
       type: 'form-unidad',
       side: 'left',
       collapsed: false,
-      h: 2,
+      h: 3,
     })
     expect(formsB1[0].x).toBeUndefined()
     expect(formsB1[0].y).toBeUndefined()
@@ -82,7 +82,7 @@ describe('useTabHelpers', () => {
     openForm('form-material', 'Material')
     const formB2 = tabs.find(t => t.boardId === 'b2')
     expect(formB2).toBeTruthy()
-    expect(formB2).toMatchObject({ side: 'left', collapsed: false, h: 2 })
+    expect(formB2).toMatchObject({ side: 'left', collapsed: false, h: 3 })
     expect(formB2?.x).toBeUndefined()
     expect(formB2?.y).toBeUndefined()
   })


### PR DESCRIPTION
## Summary
- keep forms open on save
- enlarge new cards by default
- bump version to 0.8.8

## Testing
- `npm test`
- `npm run build` *(fails: Failed to collect page data for /api/login)*

------
https://chatgpt.com/codex/tasks/task_e_6876f57c4be88328bed7c376116e24d4