### PR TITLE
0.8.11

### DIFF
--- a/src/app/dashboard/almacenes/components/MaterialList.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialList.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react";
 import { useToast } from "@/components/Toast";
 import ImageModal from "@/components/ImageModal";
 import useObjectUrl from "@/hooks/useObjectUrl";
+import { parseId } from "@/lib/parseId";
 import type { Material } from "./MaterialRow";
 
 interface Props {
@@ -148,7 +149,12 @@ export default function MaterialList({
         <button
           type="button"
           onClick={() => {
-            if (selectedId) onEliminar(Number(selectedId));
+            const id = parseId(selectedId);
+            if (!id) {
+              toast.show('ID inválido', 'error');
+              return;
+            }
+            onEliminar(id);
           }}
           disabled={selectedId === null}
           className="flex-1 py-1 rounded-md bg-red-600 text-white text-sm disabled:opacity-50"

--- a/tests/materialListDeletion.test.tsx
+++ b/tests/materialListDeletion.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import MaterialList from '../src/app/dashboard/almacenes/components/MaterialList'
+
+vi.mock('../src/components/Toast', () => ({ useToast: () => toast }))
+
+const toast = { show: vi.fn() }
+
+function renderList(selectedId: string | null, onEliminar: any) {
+  const elems: any[] = []
+  const orig = React.createElement
+  const spy = vi
+    .spyOn(React, 'createElement')
+    .mockImplementation((type: any, props: any, ...children: any[]) => {
+      const el = orig(type as any, props, ...children)
+      elems.push(el)
+      return el
+    })
+
+  renderToStaticMarkup(
+    <MaterialList
+      materiales={[]}
+      selectedId={selectedId}
+      onSeleccion={() => {}}
+      busqueda=""
+      setBusqueda={() => {}}
+      orden="nombre"
+      setOrden={() => {}}
+      onNuevo={async () => {}}
+      onDuplicar={() => {}}
+      onEliminar={onEliminar}
+    />,
+  )
+  spy.mockRestore()
+  const btn = elems.find(e => e.props?.onClick && e.props.children === 'Eliminar')
+  return btn?.props.onClick
+}
+
+describe('MaterialList', () => {
+  it('no elimina con id inválido', () => {
+    const remove = vi.fn()
+    const click = renderList('abc', remove)
+    expect(click).toBeTypeOf('function')
+    click()
+    expect(remove).not.toHaveBeenCalled()
+    expect(toast.show).toHaveBeenCalledWith('ID inválido', 'error')
+  })
+})


### PR DESCRIPTION
## Summary
- parse selectedId with `parseId` in MaterialList
- avoid deleting when ID is invalid and notify the user
- cover invalid deletion case in MaterialList tests

## Testing
- `npm run build` *(fails: prisma not found)*
- `npm test` *(fails: vitest not found)*

------
