### PR TITLE
0.8.11

### DIFF
--- a/src/app/dashboard/almacenes/components/MaterialForm.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialForm.tsx
@@ -82,12 +82,21 @@ export default function MaterialForm({
   };
 
 
+  const numericFields: Array<keyof Material> = ['cantidad', 'minimo', 'maximo'];
+  const dateFields: Array<keyof Material> = ['fechaCaducidad'];
+
   const handle = useCallback(
     (campo: keyof Material) => (
       e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
     ) => {
-      if (campo === 'cantidad') {
-        onChange(campo, Number(e.target.value));
+      if (numericFields.includes(campo)) {
+        const val = e.target.value;
+        const num = val === '' ? (campo === 'cantidad' ? 0 : null) : Number(val);
+        onChange(campo, Number.isNaN(num) ? (campo === 'cantidad' ? 0 : null) : num);
+        return;
+      }
+      if (dateFields.includes(campo)) {
+        onChange(campo, e.target.value || null);
         return;
       }
       if (campo === 'unidad' || campo === 'estado') {
@@ -113,7 +122,7 @@ export default function MaterialForm({
         onChange('archivos', arr);
         return;
       }
-      onChange(campo, e.target.value);
+      onChange(campo, e.target.value || null);
     },
     [material.archivos, onChange, toast],
   );

--- a/src/hooks/useMateriales.ts
+++ b/src/hooks/useMateriales.ts
@@ -28,16 +28,24 @@ export default function useMateriales(almacenId?: number | string) {
       const form = new FormData()
       form.append('nombre', m.nombre)
       if (m.descripcion) form.append('descripcion', m.descripcion)
-      form.append('cantidad', String(m.cantidad))
+      if (typeof m.cantidad === 'number' && !Number.isNaN(m.cantidad)) {
+        form.append('cantidad', String(m.cantidad))
+      }
       if (m.unidad) form.append('unidad', m.unidad)
       if (m.lote) form.append('lote', m.lote)
-      if (m.fechaCaducidad) form.append('fechaCaducidad', m.fechaCaducidad)
+      if (m.fechaCaducidad && !Number.isNaN(Date.parse(m.fechaCaducidad))) {
+        form.append('fechaCaducidad', m.fechaCaducidad)
+      }
       if (m.ubicacion) form.append('ubicacion', m.ubicacion)
       if (m.proveedor) form.append('proveedor', m.proveedor)
       if (m.estado) form.append('estado', m.estado)
       if (m.observaciones) form.append('observaciones', m.observaciones)
-      if (typeof m.minimo === 'number') form.append('minimo', String(m.minimo))
-      if (typeof m.maximo === 'number') form.append('maximo', String(m.maximo))
+      if (typeof m.minimo === 'number' && !Number.isNaN(m.minimo)) {
+        form.append('minimo', String(m.minimo))
+      }
+      if (typeof m.maximo === 'number' && !Number.isNaN(m.maximo)) {
+        form.append('maximo', String(m.maximo))
+      }
       if (m.codigoBarra) form.append('codigoBarra', m.codigoBarra)
       if (m.codigoQR) form.append('codigoQR', m.codigoQR)
       if (m.miniatura) form.append('miniatura', m.miniatura)
@@ -75,16 +83,24 @@ export default function useMateriales(almacenId?: number | string) {
       const form = new FormData()
       form.append('nombre', m.nombre)
       if (m.descripcion) form.append('descripcion', m.descripcion)
-      form.append('cantidad', String(m.cantidad))
+      if (typeof m.cantidad === 'number' && !Number.isNaN(m.cantidad)) {
+        form.append('cantidad', String(m.cantidad))
+      }
       if (m.unidad) form.append('unidad', m.unidad)
       if (m.lote) form.append('lote', m.lote)
-      if (m.fechaCaducidad) form.append('fechaCaducidad', m.fechaCaducidad)
+      if (m.fechaCaducidad && !Number.isNaN(Date.parse(m.fechaCaducidad))) {
+        form.append('fechaCaducidad', m.fechaCaducidad)
+      }
       if (m.ubicacion) form.append('ubicacion', m.ubicacion)
       if (m.proveedor) form.append('proveedor', m.proveedor)
       if (m.estado) form.append('estado', m.estado)
       if (m.observaciones) form.append('observaciones', m.observaciones)
-      if (typeof m.minimo === 'number') form.append('minimo', String(m.minimo))
-      if (typeof m.maximo === 'number') form.append('maximo', String(m.maximo))
+      if (typeof m.minimo === 'number' && !Number.isNaN(m.minimo)) {
+        form.append('minimo', String(m.minimo))
+      }
+      if (typeof m.maximo === 'number' && !Number.isNaN(m.maximo)) {
+        form.append('maximo', String(m.maximo))
+      }
       if (m.codigoBarra) form.append('codigoBarra', m.codigoBarra)
       if (m.codigoQR) form.append('codigoQR', m.codigoQR)
       if (m.miniatura) form.append('miniatura', m.miniatura)

--- a/tests/materialListDeletion.test.tsx
+++ b/tests/materialListDeletion.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import React from 'react'
+(global as any).React = React
 import { renderToStaticMarkup } from 'react-dom/server'
 
 import MaterialList from '../src/app/dashboard/almacenes/components/MaterialList'

--- a/tests/useMateriales.test.ts
+++ b/tests/useMateriales.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import useMateriales from '../src/hooks/useMateriales'
 import useSWR from 'swr'
 import * as uuidFns from '../src/lib/uuid'
+import { materialSchema } from '../src/lib/validators/material'
 
 vi.mock('react', () => ({
   useMemo: (fn: any) => fn(),
@@ -13,6 +14,7 @@ vi.mock('swr', () => ({
 
 afterEach(() => {
   vi.restoreAllMocks()
+  vi.resetModules()
 })
 
 describe('useMateriales', () => {
@@ -54,5 +56,35 @@ describe('useMateriales', () => {
     expect(materiales[0].id).toBe('node-id')
     expect(nodeRand).toHaveBeenCalled()
     Object.defineProperty(globalThis, 'crypto', { value: originalCrypto, configurable: true })
+  })
+
+  it('crear genera FormData valida', async () => {
+    const swr = useSWR as unknown as ReturnType<typeof vi.fn>
+    swr.mockReturnValue({ data: null, error: null, isLoading: false, mutate: vi.fn() })
+    const apiFetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.doMock('../lib/api', () => ({ apiFetch, apiPath: (p: string) => p }))
+    const { default: useMats } = await import('../src/hooks/useMateriales')
+    const { crear } = useMats(1)
+    await crear({ id: '1', nombre: 'mat', cantidad: 2, lote: 'l1', fechaCaducidad: '' } as any)
+    const form = apiFetch.mock.calls[0][1].body as FormData
+    const obj = Object.fromEntries(Array.from(form.entries()))
+    expect(materialSchema.safeParse(obj).success).toBe(true)
+    expect(form.has('fechaCaducidad')).toBe(false)
+    vi.resetModules()
+  })
+
+  it('actualizar genera FormData valida', async () => {
+    const swr = useSWR as unknown as ReturnType<typeof vi.fn>
+    swr.mockReturnValue({ data: null, error: null, isLoading: false, mutate: vi.fn() })
+    const apiFetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.doMock('../lib/api', () => ({ apiFetch, apiPath: (p: string) => p }))
+    const { default: useMats } = await import('../src/hooks/useMateriales')
+    const { actualizar } = useMats(1)
+    await actualizar({ id: '1', dbId: 3, nombre: 'mat', cantidad: 2, lote: 'l1', fechaCaducidad: '2024-01-01' } as any)
+    const form = apiFetch.mock.calls[0][1].body as FormData
+    const obj = Object.fromEntries(Array.from(form.entries()))
+    expect(materialSchema.safeParse(obj).success).toBe(true)
+    expect(form.get('fechaCaducidad')).toBe('2024-01-01')
+    vi.resetModules()
   })
 })


### PR DESCRIPTION
## Summary
- convert empty numeric/date values to `null` in `MaterialForm`
- validate numbers and dates in `useMateriales` before appending to `FormData`
- fix missing React global in `materialListDeletion` test
- add tests for `useMateriales.crear` and `useMateriales.actualizar`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687708a169fc8328b794e90b6363b1fd