### PR TITLE
0.8.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@
 - Incrementamos el padding máximo y min-width en `.dashboard-card`.
 - Evitamos que las tarjetas pierdan su orden al cambiar de pestaña.
 
+## 0.8.14
+- Restauramos las tarjetas de cada tablero al cambiar y recargar.
+
 ## 0.8.5
 - Registramos auditorías también al escanear códigos.
 - Mejoramos el manejo de errores al crear reportes y auditorías.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.8.13",
+  "version": "0.8.14",
     "": {
       "name": "honeylabs",
-      "version": "0.8.13",
+      "version": "0.8.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/components/CardBoard.tsx
+++ b/src/app/dashboard/almacenes/components/CardBoard.tsx
@@ -38,6 +38,22 @@ export default function CardBoard() {
   }, [setTabs])
 
   useEffect(() => {
+    if (!boardId) return
+    apiFetch("/api/dashboard/layout")
+      .then(jsonOrNull)
+      .then((d) => {
+        if (Array.isArray(d?.tabs)) {
+          const tabs = (d.tabs as Tab[]).filter(t => t.boardId === boardId)
+          setTabs(prev => {
+            const others = prev.filter(t => t.boardId !== boardId)
+            return [...others, ...tabs]
+          })
+        }
+      })
+      .catch(() => {})
+  }, [boardId, setTabs])
+
+  useEffect(() => {
     if (!boardId && boards.length > 0) setActive(boards[0].id)
   }, [boardId, boards, setActive])
 

--- a/src/hooks/useCardLayout.ts
+++ b/src/hooks/useCardLayout.ts
@@ -18,30 +18,24 @@ export default function useCardLayout(
   setTabs: (tabs: Tab[]) => void,
 ) {
   const key = boardId ? `card-layout-${boardId}` : null;
-  const loaded = useRef(false);
-
   useEffect(() => {
-    loaded.current = false;
-  }, [boardId]);
+    if (!key) return;
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw) {
+        const data = JSON.parse(raw) as Layout[];
+        if (Array.isArray(data)) {
+          setTabs(prev => applyLayout(prev, compactLayout(data)));
+        }
+      }
+    } catch {}
+  }, [key, setTabs]);
 
   useEffect(() => {
     if (!key) return;
     const boardTabs = tabs.filter(t => t.boardId === boardId);
     if (boardTabs.length === 0) return;
     try {
-      if (!loaded.current) {
-        loaded.current = true;
-        const raw = localStorage.getItem(key);
-        if (raw) {
-          const data = JSON.parse(raw) as Layout[];
-          if (Array.isArray(data)) {
-            const compacted = compactLayout(data);
-            setTabs(prev => applyLayout(prev, compacted));
-            return;
-          }
-        }
-      }
-
       const layout = boardTabs.map(t => ({
         i: t.id,
         x: t.x ?? 0,
@@ -51,7 +45,7 @@ export default function useCardLayout(
       }));
       localStorage.setItem(key, JSON.stringify(compactLayout(layout)));
     } catch {}
-  }, [key, boardId, tabs, setTabs]);
+  }, [key, boardId, tabs]);
 
   const save = useCallback(
     (layout: Layout[]) => {

--- a/tests/boardSwitchCards.test.ts
+++ b/tests/boardSwitchCards.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { applyLayout } from '../src/hooks/useCardLayout'
+import { compactLayout } from '../lib/boardLayout'
+
+beforeEach(() => {
+  const storage = {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+  }
+  Object.defineProperty(globalThis, 'localStorage', { value: storage, configurable: true })
+})
+
+describe('persistencia por tablero', () => {
+  it('mantiene tarjetas al cambiar y recargar', () => {
+    const layoutA = [{ i: 'a', x: 1, y: 0, w: 1, h: 1 }]
+    const layoutB = [{ i: 'b', x: 0, y: 1, w: 1, h: 1 }]
+    ;(localStorage.getItem as any).mockImplementation((key: string) => {
+      if (key === 'card-layout-b1') return JSON.stringify(layoutA)
+      if (key === 'card-layout-b2') return JSON.stringify(layoutB)
+      return null
+    })
+
+    let tabs = [
+      { id: 'a', boardId: 'b1', title: 'A', type: 'materiales', x: 0, y: 0 } as any,
+      { id: 'b', boardId: 'b2', title: 'B', type: 'materiales', x: 0, y: 0 } as any,
+    ]
+
+    // tablero b1
+    const storedA = JSON.parse(localStorage.getItem('card-layout-b1') as string)
+    tabs = applyLayout(tabs, compactLayout(storedA))
+    expect(tabs.find(t => t.id === 'a')?.x).toBe(1)
+
+    // cambio a b2
+    const storedB = JSON.parse(localStorage.getItem('card-layout-b2') as string)
+    tabs = applyLayout(tabs, compactLayout(storedB))
+    expect(tabs.find(t => t.id === 'b')?.y).toBe(0)
+
+    // recarga y regreso a b1
+    const reloadA = JSON.parse(localStorage.getItem('card-layout-b1') as string)
+    tabs = applyLayout(tabs, compactLayout(reloadA))
+    expect(tabs.find(t => t.id === 'a')?.x).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- restore board tabs after switching using `/api/dashboard/layout`
- load card layout from localStorage per active board
- test board switching keeps cards

## Testing
- `npm run build` *(fails: Failed to collect page data for /api/login)*
- `npm test`

------
