### PR TITLE
0.8.15

### DIFF
--- a/src/app/api/qr/importar/route.ts
+++ b/src/app/api/qr/importar/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@lib/prisma'
 import { getUsuarioFromSession } from '@lib/auth'
 import * as logger from '@lib/logger'
+import { decodeQR } from '@/lib/qr'
 
 export async function POST(req: NextRequest) {
   logger.debug(req, 'POST /api/qr/importar')
@@ -13,6 +14,11 @@ export async function POST(req: NextRequest) {
     const { codigo } = await req.json()
     if (typeof codigo !== 'string' || !codigo.trim()) {
       return NextResponse.json({ error: 'Código requerido' }, { status: 400 })
+    }
+
+    const decoded = decodeQR<any>(codigo)
+    if (decoded && typeof decoded === 'object' && decoded.tipo) {
+      return NextResponse.json(decoded)
     }
 
     const unidad = await prisma.materialUnidad.findUnique({

--- a/src/app/dashboard/almacenes/components/MaterialCodes.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialCodes.tsx
@@ -2,25 +2,35 @@
 import { useEffect, useRef } from "react";
 import { QRCodeSVG } from "qrcode.react";
 import { encodeQR } from "@/lib/qr";
+import { buildQRPayload, QRObjectType } from "@/lib/buildQRPayload";
 import JsBarcode from "jsbarcode";
 
 export default function MaterialCodes({
   value,
+  tipo,
+  codigo,
   onRegenerate,
 }: {
   value: string | Record<string, any>
+  tipo?: QRObjectType
+  codigo?: string
   onRegenerate?: () => void
 }) {
   const barRef = useRef<SVGSVGElement>(null);
-  const qrValue = typeof value === 'string' ? value : encodeQR(value);
+  const qrData =
+    typeof value === 'object' && tipo ? buildQRPayload(tipo, value) : value;
+  const qrValue = typeof qrData === 'string' ? qrData : encodeQR(qrData);
+
+  const barValue = codigo ??
+    (typeof value === 'object' ? (value as any).codigoQR ?? (value as any).codigoUnico : value);
 
   useEffect(() => {
-    if (barRef.current) {
+    if (barRef.current && barValue) {
       try {
-        JsBarcode(barRef.current, String(value), { format: "CODE128", displayValue: false });
+        JsBarcode(barRef.current, String(barValue), { format: 'CODE128', displayValue: false });
       } catch {}
     }
-  }, [value]);
+  }, [barValue]);
 
   return (
     <div className="flex flex-col items-start gap-2">

--- a/src/app/dashboard/almacenes/components/MaterialForm.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialForm.tsx
@@ -398,7 +398,9 @@ export default function MaterialForm({
         )}
       </div>
       <MaterialCodes
-        value={material.codigoQR || ''}
+        value={material}
+        tipo="material"
+        codigo={material.codigoQR || ''}
         onRegenerate={() => onChange('codigoQR', generarUUID())}
       />
       <div className="flex gap-2 pt-2">

--- a/src/app/dashboard/almacenes/components/UnidadForm.tsx
+++ b/src/app/dashboard/almacenes/components/UnidadForm.tsx
@@ -126,7 +126,9 @@ export default function UnidadForm({ unidad, onChange, onGuardar, onCancelar }: 
             className="dashboard-input no-drag w-full mt-1"
           />
           <MaterialCodes
-            value={unidad.codigoQR || ''}
+            value={unidad}
+            tipo="unidad"
+            codigo={unidad.codigoQR || ''}
             onRegenerate={() => onChange('codigoQR', generarUUID())}
           />
         </div>

--- a/src/lib/buildQRPayload.ts
+++ b/src/lib/buildQRPayload.ts
@@ -1,0 +1,31 @@
+export type QRObjectType = 'material' | 'unidad' | 'almacen'
+
+function isFileLike(val: any): val is { name: string } {
+  return (
+    val &&
+    typeof val === 'object' &&
+    typeof val.name === 'string'
+  )
+}
+
+function mapValue(v: any): any {
+  if (isFileLike(v)) return v.name
+  if (Array.isArray(v)) return v.map(mapValue)
+  if (v && typeof v === 'object') {
+    if ('archivoNombre' in v && typeof v.archivoNombre === 'string') {
+      return v.archivoNombre
+    }
+    if ('nombre' in v && typeof v.nombre === 'string') {
+      return v.nombre
+    }
+  }
+  return v
+}
+
+export function buildQRPayload<T extends Record<string, any>>(tipo: QRObjectType, obj: T): Record<string, any> {
+  const out: Record<string, any> = { tipo }
+  for (const [k, v] of Object.entries(obj)) {
+    out[k] = mapValue(v)
+  }
+  return out
+}

--- a/tests/qrPayload.test.ts
+++ b/tests/qrPayload.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { encodeQR, decodeQR } from '../src/lib/qr'
+import { buildQRPayload } from '../src/lib/buildQRPayload'
+
+const file = (name: string) => ({ name }) as any
+
+describe('buildQRPayload', () => {
+  it('incluye nombres de archivos de material', () => {
+    const material = {
+      id: 1,
+      codigoQR: 'abc',
+      miniatura: file('img.png'),
+      archivosPrevios: [
+        { nombre: 'Manual', archivoNombre: 'manual.pdf' },
+        { archivoNombre: 'spec.pdf' },
+      ],
+    }
+    const payload = buildQRPayload('material', material)
+    expect(payload.miniatura).toBe('img.png')
+    expect(payload.archivosPrevios).toEqual(['manual.pdf', 'spec.pdf'])
+    const decoded = decodeQR(encodeQR(payload))
+    expect(decoded).toEqual(payload)
+  })
+
+  it('funciona con unidades', () => {
+    const unidad = {
+      id: 2,
+      codigoQR: 'u1',
+      imagen: file('u.png'),
+      archivosPrevios: [{ archivoNombre: 'ficha.pdf' }],
+    }
+    const payload = buildQRPayload('unidad', unidad)
+    expect(payload.imagen).toBe('u.png')
+    expect(payload.archivosPrevios).toEqual(['ficha.pdf'])
+    expect(decodeQR(encodeQR(payload))).toEqual(payload)
+  })
+
+  it('extrae nombres de documentos de almacén', () => {
+    const almacen = {
+      id: 3,
+      codigoUnico: 'x1',
+      documentos: [{ nombre: 'rules.docx', url: 'a' }],
+    }
+    const payload = buildQRPayload('almacen', almacen)
+    expect(payload.documentos).toEqual(['rules.docx'])
+    expect(decodeQR(encodeQR(payload))).toEqual(payload)
+  })
+})


### PR DESCRIPTION
## Summary
- crear helper `buildQRPayload` para incluir nombres de adjuntos
- generar QR en formularios usando `buildQRPayload`
- decodificar en `/api/qr/importar` si el código ya contiene datos
- añadir pruebas unitarias para validar el nuevo payload QR

## Testing
- `pnpm test`
- `pnpm run build` *(falló: "Failed to collect page data for /api/registro")*

------
