### PR TITLE
0.8.15

### DIFF
--- a/src/app/api/dashboard/layout/route.ts
+++ b/src/app/api/dashboard/layout/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
     const usuario = await getUsuarioFromSession();
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
     const prefs = usuario.preferencias ? JSON.parse(usuario.preferencias) : {};
-    const layout = prefs.dashboardLayout || { tabs: [], layout: [] };
+    const layout = prefs.dashboardLayout || {};
     return NextResponse.json(layout);
   } catch (err) {
     logger.error('GET /api/dashboard/layout', err);
@@ -24,8 +24,12 @@ export async function POST(req: NextRequest) {
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
     const data = await req.json();
     const prefs = usuario.preferencias ? JSON.parse(usuario.preferencias) : {};
-    prefs.dashboardLayout = data;
-    await prisma.usuario.update({ where: { id: usuario.id }, data: { preferencias: JSON.stringify(prefs) } });
+    const layout = prefs.dashboardLayout || {};
+    prefs.dashboardLayout = { ...layout, ...data };
+    await prisma.usuario.update({
+      where: { id: usuario.id },
+      data: { preferencias: JSON.stringify(prefs) },
+    });
     return NextResponse.json({ ok: true });
   } catch (err) {
     logger.error('POST /api/dashboard/layout', err);

--- a/src/app/dashboard/almacenes/components/CardBoard.tsx
+++ b/src/app/dashboard/almacenes/components/CardBoard.tsx
@@ -28,8 +28,9 @@ export default function CardBoard() {
         apiFetch("/api/dashboard/layout")
           .then(jsonOrNull)
           .then((d) => {
-            if (Array.isArray(d?.tabs)) {
-              setTabs(d.tabs as Tab[])
+            if (d && typeof d === "object") {
+              const all = Object.values(d).flat() as Tab[]
+              setTabs(all)
             }
           })
           .catch(() => {})
@@ -42,8 +43,8 @@ export default function CardBoard() {
     apiFetch("/api/dashboard/layout")
       .then(jsonOrNull)
       .then((d) => {
-        if (Array.isArray(d?.tabs)) {
-          const tabs = (d.tabs as Tab[]).filter(t => t.boardId === boardId)
+        if (d && typeof d === "object") {
+          const tabs = (d[boardId] as Tab[]) ?? []
           setTabs(prev => {
             const others = prev.filter(t => t.boardId !== boardId)
             return [...others, ...tabs]
@@ -58,12 +59,14 @@ export default function CardBoard() {
   }, [boardId, boards, setActive])
 
   useEffect(() => {
+    if (!boardId) return
+    const boardTabs = cards.filter(t => t.boardId === boardId)
     apiFetch("/api/dashboard/layout", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ tabs: cards }),
+      body: JSON.stringify({ [boardId]: boardTabs }),
     }).catch(() => {});
-  }, [cards]);
+  }, [boardId, cards]);
 
   const safeCards = Array.isArray(cards) ? cards : []
   const current = safeCards.filter((t) => t.boardId === boardId)

--- a/tests/dashboardLayoutRoute.test.ts
+++ b/tests/dashboardLayoutRoute.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import prisma from '../lib/prisma'
+import * as auth from '../lib/auth'
+
+const { GET, POST } = await import('../src/app/api/dashboard/layout/route')
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('dashboard layout api', () => {
+  it('returns stored layout', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({
+      preferencias: JSON.stringify({ dashboardLayout: { b1: [{ id: 'a' }] } })
+    } as any)
+    const res = await GET()
+    const data = await res.json()
+    expect(data.b1[0].id).toBe('a')
+  })
+
+  it('merges board tabs on POST', async () => {
+    const user = {
+      id: 1,
+      preferencias: JSON.stringify({ dashboardLayout: { b1: [{ id: 'a' }] } })
+    }
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue(user as any)
+    const update = vi.spyOn(prisma.usuario, 'update').mockResolvedValue({} as any)
+    const body = JSON.stringify({ b2: [{ id: 'b' }] })
+    const req = new NextRequest('http://localhost/api/dashboard/layout', { method: 'POST', body })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    expect(update).toHaveBeenCalledWith({
+      where: { id: user.id },
+      data: {
+        preferencias: JSON.stringify({
+          dashboardLayout: { b1: [{ id: 'a' }], b2: [{ id: 'b' }] }
+        })
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- persistimos las tarjetas del dashboard por board
- enviamos solo las tarjetas del board actual al guardar
- actualizamos el API de `/api/dashboard/layout` para manejar diccionario
- añadimos test del endpoint

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879c6eb92d08328b89852525dedb2b8