### PR TITLE
0.8.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@
 ## 0.8.14
 - Restauramos las tarjetas de cada tablero al cambiar y recargar.
 
+## 0.8.15
+- Desactivamos `useCSSTransforms` y reducimos `CARD_DRAG_THRESHOLD` a 4 px para movimientos más fluidos.
+
 ## 0.8.5
 - Registramos auditorías también al escanear códigos.
 - Mejoramos el manejo de errores al crear reportes y auditorías.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ honeylabs/
 * El menú de usuario ahora también se abre al hacer clic en el avatar del dashboard.
 * Ajustamos el tablero de tarjetas para usar `useCSSTransforms` y un umbral de arrastre de 8 px.
 * El drag es más suave con umbral reducido a 5 px y sin colisiones entre tarjetas.
+* Desactivamos `useCSSTransforms` para animaciones estables y bajamos el umbral a 4 px.
 
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.8.14",
+  "version": "0.8.15",
     "": {
       "name": "honeylabs",
-      "version": "0.8.14",
+      "version": "0.8.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/app/dashboard/almacenes/components/CardBoard.tsx
+++ b/src/app/dashboard/almacenes/components/CardBoard.tsx
@@ -97,7 +97,7 @@ export default function CardBoard() {
         margin={[10,10]}
         isBounded
         preventCollision={false}
-        useCSSTransforms
+        useCSSTransforms={false}
         {...({ dragStartThreshold: CARD_DRAG_THRESHOLD } as any)}
         onLayoutChange={onLayoutChange}
         draggableHandle=".drag-handle"

--- a/src/app/dashboard/constants.ts
+++ b/src/app/dashboard/constants.ts
@@ -9,4 +9,4 @@ export const TABBAR_GAP = 'var(--tabbar-gap)';
 export const POINTER_ACTIVATION_DISTANCE = 5;
 
 // Ajuste para react-grid-layout; controla desde qué distancia inicia el drag
-export const CARD_DRAG_THRESHOLD = 8;
+export const CARD_DRAG_THRESHOLD = 4;

--- a/tests/cardBoardDrop.test.ts
+++ b/tests/cardBoardDrop.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { computeBoardLayout } from '../lib/boardLayout'
+
+function arrayMove<T>(arr: T[], from: number, to: number): T[] {
+  const copy = arr.slice()
+  const [item] = copy.splice(from, 1)
+  copy.splice(to, 0, item)
+  return copy
+}
+
+describe('drag and drop', () => {
+  it('reordena tarjetas al soltar', () => {
+    const tabs = [
+      { id: 'a', boardId: 'x', side: 'left', h: 1 } as any,
+      { id: 'b', boardId: 'x', side: 'left', h: 1 } as any,
+      { id: 'c', boardId: 'x', side: 'left', h: 1 } as any,
+    ]
+    const layout = computeBoardLayout(tabs)
+    expect(layout.map(l => l.i)).toEqual(['a','b','c'])
+    const moved = arrayMove(tabs, 0, 2)
+    const after = computeBoardLayout(moved)
+    expect(after.map(l => l.i)).toEqual(['b','c','a'])
+  })
+})
+


### PR DESCRIPTION
## Summary
- reduce card drag threshold
- disable CSS transforms for GridLayout
- add drag-and-drop test to confirm reordering
- document new smoother drag behavior

## Testing
- `npm test`
- `npm run build` *(fails: JWT_SECRET no definido en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_6879e01759708328b658cabee761a572