### PR TITLE
0.8.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@
 ## 0.8.15
 - Desactivamos `useCSSTransforms` y reducimos `CARD_DRAG_THRESHOLD` a 4 px para movimientos más fluidos.
 
+## 0.8.16
+- Reaplicamos layouts guardados al recibir tarjetas remotas.
+
 ## 0.8.5
 - Registramos auditorías también al escanear códigos.
 - Mejoramos el manejo de errores al crear reportes y auditorías.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeylabs",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "packageManager": "pnpm@8.15.4",
   "private": true,
   "scripts": {

--- a/src/hooks/useCardLayout.ts
+++ b/src/hooks/useCardLayout.ts
@@ -1,5 +1,5 @@
 "use client";
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 import type { Layout } from 'react-grid-layout';
 import { compactLayout } from '@lib/boardLayout';
 import type { Tab } from './useTabs';
@@ -22,14 +22,30 @@ export default function useCardLayout(
     if (!key) return;
     try {
       const raw = localStorage.getItem(key);
-      if (raw) {
-        const data = JSON.parse(raw) as Layout[];
-        if (Array.isArray(data)) {
-          setTabs(prev => applyLayout(prev, compactLayout(data)));
-        }
+      if (!raw) return;
+      const data = JSON.parse(raw) as Layout[];
+      if (Array.isArray(data)) {
+        setTabs(prev => applyLayout(prev, compactLayout(data)));
       }
     } catch {}
   }, [key, setTabs]);
+
+  useEffect(() => {
+    if (!key) return;
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) return;
+      const data = JSON.parse(raw) as Layout[];
+      if (!Array.isArray(data)) return;
+      const compacted = compactLayout(data);
+      const updated = applyLayout(tabs, compacted);
+      const changed = tabs.some(t => {
+        const it = updated.find(u => u.id === t.id);
+        return it && (t.x !== it.x || t.y !== it.y || t.w !== it.w || t.h !== it.h);
+      });
+      if (changed) setTabs(updated);
+    } catch {}
+  }, [key, tabs, setTabs]);
 
   useEffect(() => {
     if (!key) return;

--- a/tests/boardSwitchCards.test.ts
+++ b/tests/boardSwitchCards.test.ts
@@ -42,4 +42,32 @@ describe('persistencia por tablero', () => {
     tabs = applyLayout(tabs, compactLayout(reloadA))
     expect(tabs.find(t => t.id === 'a')?.x).toBe(1)
   })
+
+  it('reaplica posiciones tras recargar de servidor', () => {
+    const layoutA = [{ i: 'a', x: 1, y: 0, w: 1, h: 1 }]
+    const layoutB = [{ i: 'b', x: 0, y: 1, w: 1, h: 1 }]
+    ;(localStorage.getItem as any).mockImplementation((key: string) => {
+      if (key === 'card-layout-b1') return JSON.stringify(layoutA)
+      if (key === 'card-layout-b2') return JSON.stringify(layoutB)
+      return null
+    })
+
+    // carga inicial desde API reemplaza posiciones
+    let tabs = [{ id: 'a', boardId: 'b1', title: 'A', type: 'materiales', x: 0, y: 0 } as any]
+    const storedA = JSON.parse(localStorage.getItem('card-layout-b1') as string)
+    tabs = applyLayout(tabs, compactLayout(storedA))
+    expect(tabs.find(t => t.id === 'a')?.x).toBe(1)
+
+    // cambio a b2 con datos remotos nuevos
+    tabs = [{ id: 'b', boardId: 'b2', title: 'B', type: 'materiales', x: 0, y: 0 } as any]
+    const storedB = JSON.parse(localStorage.getItem('card-layout-b2') as string)
+    tabs = applyLayout(tabs, compactLayout(storedB))
+    expect(tabs.find(t => t.id === 'b')?.y).toBe(0)
+
+    // regreso a b1 con tabs recargadas sin posiciones
+    tabs = [{ id: 'a', boardId: 'b1', title: 'A', type: 'materiales', x: 0, y: 0 } as any]
+    const reloadA = JSON.parse(localStorage.getItem('card-layout-b1') as string)
+    tabs = applyLayout(tabs, compactLayout(reloadA))
+    expect(tabs.find(t => t.id === 'a')?.x).toBe(1)
+  })
 })


### PR DESCRIPTION
## Summary
- ensure saved layouts reapply after replacing tabs
- test board switching with saved layouts
- bump version to 0.8.16

## Testing
- `pnpm test`
- `pnpm build` *(fails: JWT_SECRET no definido en el entorno)*

------
