### PR TITLE
0.1.1

### DIFF
--- a/src/app/dashboard/almacenes/components/AddCardButton.tsx
+++ b/src/app/dashboard/almacenes/components/AddCardButton.tsx
@@ -9,7 +9,8 @@ import type { TabType } from "@/hooks/useTabs";
 export default function AddCardButton() {
   const toast = useToast();
   const { create: createHook, disabled } = useCreateTab({
-    defaultLayout: { w: 1, h: 4 },
+    // Altura base suficiente para la mayoría de formularios
+    defaultLayout: { w: 1, h: 3 },
   });
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);

--- a/src/app/dashboard/almacenes/components/CardBoard.tsx
+++ b/src/app/dashboard/almacenes/components/CardBoard.tsx
@@ -77,7 +77,8 @@ export default function CardBoard() {
   const current = safeCards.filter((t) => t.boardId === boardId)
 
   const cols = width < 640 ? 1 : width < 1024 ? 2 : 3
-  const rowHeight = width < 640 ? 170 : 170
+  // Altura fija para todas las tarjetas
+  const rowHeight = 200
 
 
   const layout: Layout[] = computeBoardLayout(current)

--- a/src/app/dashboard/almacenes/components/CardBoardDnd.tsx
+++ b/src/app/dashboard/almacenes/components/CardBoardDnd.tsx
@@ -60,7 +60,8 @@ export default function CardBoardDnd() {
   const containerRef = useRef<HTMLDivElement>(null);
   const { width } = useElementSize(containerRef);
   const cols = width < 640 ? 1 : width < 1024 ? 2 : 3;
-  const rowHeight = width < 640 ? 200 : 200;
+  // Altura fija para todas las tarjetas
+  const rowHeight = 200;
   const marginX = 10;
   const marginY = 10;
   const colWidth = cols > 0 ? (width - marginX * (cols + 1)) / cols : 0;


### PR DESCRIPTION
## Summary
- fijamos `rowHeight` estático en ambos tableros
- ajustamos la altura por defecto al crear tarjetas

## Testing
- `npm run lint` *(errores existentes)*
- `npm run build` *(falló: JWT_SECRET no definido)*
- `npm test`


------
