### PR TITLE
0.8.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@
 ## 0.8.16
 - Reaplicamos layouts guardados al recibir tarjetas remotas.
 
+## 0.8.17
+- Evitamos sobreescribir layouts vacíos al cambiar de tablero.
+
 ## 0.8.5
 - Registramos auditorías también al escanear códigos.
 - Mejoramos el manejo de errores al crear reportes y auditorías.

--- a/src/app/dashboard/almacenes/components/CardBoard.tsx
+++ b/src/app/dashboard/almacenes/components/CardBoard.tsx
@@ -22,6 +22,8 @@ export default function CardBoard() {
 
   const containerRef = useRef<HTMLDivElement>(null)
   const { width } = useElementSize(containerRef)
+  const prevBoardId = useRef<string>()
+  const lastLayout = useRef<string>("[]")
 
   useEffect(() => {
     useTabStore.persist
@@ -67,12 +69,22 @@ export default function CardBoard() {
   useEffect(() => {
     if (!boardId) return
     const boardTabs = safeCards.filter(t => t.boardId === boardId)
+    const serialized = JSON.stringify(boardTabs)
+    const changedBoard = prevBoardId.current !== boardId
+    prevBoardId.current = boardId
+
+    if (changedBoard && boardTabs.length === 0) {
+      lastLayout.current = serialized
+      return
+    }
+    if (!changedBoard && lastLayout.current === serialized) return
+    lastLayout.current = serialized
     apiFetch("/api/dashboard/layout", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ [boardId]: boardTabs }),
-    }).catch(() => {});
-  }, [boardId, safeCards]);
+    }).catch(() => {})
+  }, [boardId, safeCards])
 
   const current = safeCards.filter((t) => t.boardId === boardId)
 


### PR DESCRIPTION
## Summary
- evitemos que al cambiar de tablero se envíe un layout vacío
- registramos el ID anterior y sólo persistimos si cambian las tarjetas

## Testing
- `npm test`


------
