### PR TITLE
0.2.3

### DIFF
--- a/src/app/dashboard/almacenes/components/AddBoardButton.tsx
+++ b/src/app/dashboard/almacenes/components/AddBoardButton.tsx
@@ -1,13 +1,41 @@
 "use client";
 import { Plus } from "lucide-react";
 import { generarUUID } from "@/lib/uuid";
+import { apiFetch } from "@lib/api";
 import { useBoardStore } from "@/hooks/useBoards";
+import { useTabStore } from "@/hooks/useTabs";
+import { useCreateTab } from "@/hooks/useCreateTab";
 
 export default function AddBoardButton() {
   const { add } = useBoardStore();
+  const { create: addMateriales } = useCreateTab({
+    defaultLayout: { side: 'right', x: 1, y: 0, h: 2 },
+  });
+  const { create: addUnidades } = useCreateTab({
+    defaultLayout: { side: 'right', x: 1, y: 2 },
+  });
+  const { create: addAuditorias } = useCreateTab({
+    defaultLayout: { side: 'right', x: 2, y: 2 },
+  });
+  const { create: addForm } = useCreateTab({
+    defaultLayout: { side: 'left', x: 0, y: 0, h: 3 },
+  });
 
-  const create = () => {
-    add({ id: generarUUID(), title: "New Tab" });
+  const create = async () => {
+    const id = generarUUID();
+    add({ id, title: 'New Tab' });
+    await addMateriales('materiales', 'Materiales');
+    await addUnidades('unidades', 'Unidades');
+    await addAuditorias('auditorias', 'Auditorias');
+    await addForm('form-material', 'Material');
+    const boardTabs = useTabStore
+      .getState()
+      .tabs.filter((t) => t.boardId === id);
+    apiFetch('/api/dashboard/layout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ [id]: boardTabs }),
+    }).catch(() => {});
   };
 
   return (

--- a/tests/useCreateTab.test.ts
+++ b/tests/useCreateTab.test.ts
@@ -69,6 +69,12 @@ describe('useCreateTab', () => {
     expect(tabs[0].y).toBeUndefined()
   })
 
+  it('aplica x y iniciales si se proporcionan', async () => {
+    const { create } = useCreateTab({ defaultLayout: { x: 1, y: 2, h: 1, w: 1 } })
+    await create('materiales', 'Mat')
+    expect(tabs[0]).toMatchObject({ x: 1, y: 2 })
+  })
+
   it('solicita datos adicionales para url', async () => {
     prompt.mockResolvedValueOnce('http://test')
     const { create } = useCreateTab()


### PR DESCRIPTION
## Summary
- insert default dashboard tabs when creating a board
- persist the initial layout
- validate default tab positions in `useCreateTab`

## Testing
- `npm test`
- `npm run build` *(fails: Failed to collect page data for /api/login)*

------
https://chatgpt.com/codex/tasks/task_e_687d922039248328805a9963fc96b435