### PR TITLE
0.2.3

### DIFF
--- a/src/app/dashboard/almacenes/components/CardBoard.tsx
+++ b/src/app/dashboard/almacenes/components/CardBoard.tsx
@@ -33,8 +33,18 @@ export default function CardBoard() {
           .then(jsonOrNull)
           .then((d) => {
             if (d && typeof d === "object") {
-              const all = Object.values(d).flat() as Tab[]
-              setTabs(all)
+              setTabs((prev) => {
+                let updated = prev
+                for (const [id, arr] of Object.entries(d)) {
+                  if (Array.isArray(arr) && arr.length > 0) {
+                    updated = [
+                      ...updated.filter((t) => t.boardId !== id),
+                      ...(arr as Tab[]),
+                    ]
+                  }
+                }
+                return updated
+              })
             }
           })
           .catch(() => {})
@@ -52,10 +62,12 @@ export default function CardBoard() {
         if (currentBoardId !== boardId) return
         if (d && typeof d === "object") {
           const tabs = (d[currentBoardId] as Tab[]) ?? []
-          setTabs(prev => {
-            const others = prev.filter(t => t.boardId !== currentBoardId)
-            return [...others, ...tabs]
-          })
+          if (tabs.length > 0) {
+            setTabs(prev => {
+              const others = prev.filter(t => t.boardId !== currentBoardId)
+              return [...others, ...tabs]
+            })
+          }
         }
       })
       .catch(() => {})

--- a/tests/boardSwitchCards.test.ts
+++ b/tests/boardSwitchCards.test.ts
@@ -70,4 +70,14 @@ describe('persistencia por tablero', () => {
     tabs = applyLayout(tabs, compactLayout(reloadA))
     expect(tabs.find(t => t.id === 'a')?.x).toBe(1)
   })
+
+  it('layout vacio no elimina tarjetas existentes', () => {
+    ;(localStorage.getItem as any).mockImplementation(() => JSON.stringify([]))
+
+    let tabs = [{ id: 'a', boardId: 'b1', title: 'A', type: 'materiales', x: 0, y: 0 } as any]
+    const stored = JSON.parse(localStorage.getItem('card-layout-b1') as string)
+    tabs = applyLayout(tabs, compactLayout(stored))
+    expect(tabs).toHaveLength(1)
+    expect(tabs[0].id).toBe('a')
+  })
 })

--- a/tests/cardBoardFetchEffect.test.ts
+++ b/tests/cardBoardFetchEffect.test.ts
@@ -53,10 +53,12 @@ describe('cambio rapido de tablero', () => {
           if (currentBoardId !== boardId) return
           if (d && typeof d === 'object') {
             const boardTabs = (d[currentBoardId] as Tab[]) ?? []
-            setTabs(prev => {
-              const others = prev.filter(t => t.boardId !== currentBoardId)
-              return [...others, ...boardTabs]
-            })
+            if (boardTabs.length > 0) {
+              setTabs(prev => {
+                const others = prev.filter(t => t.boardId !== currentBoardId)
+                return [...others, ...boardTabs]
+              })
+            }
           }
         })
         .catch(() => {})


### PR DESCRIPTION
## Summary
- merge board cards from server with local store only when data is present
- ignore empty server layouts when switching boards
- ensure blank layouts don't remove cards

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ef33b5a2c8328b26dcedb70bdfd21