### PR TITLE
0.4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Actualmente se están implementando las funcionalidades principales. Se aceptan 
 
 ## Version
 
-0.4.5
+0.4.6
 
 ---
 
@@ -98,6 +98,12 @@ Para iniciar el entorno de desarrollo:
 
 ```sh
 pnpm dev
+```
+
+Para probar el PWA en local:
+
+```sh
+NEXT_PUBLIC_ENABLE_PWA=true pnpm run dev
 ```
 
 Este comando ejecuta `pnpm gen:dev`, el cual genera el cliente de Prisma con

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,7 +7,9 @@ const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
 
 const withPWA = nextPWA({
   dest: 'public',
-  disable: process.env.NODE_ENV === 'development',
+  disable:
+    process.env.NODE_ENV === 'development' &&
+    process.env.NEXT_PUBLIC_ENABLE_PWA !== 'true',
 });
 
 const nextConfig = {

--- a/src/components/PwaRegister.tsx
+++ b/src/components/PwaRegister.tsx
@@ -3,7 +3,10 @@ import { useEffect } from 'react'
 
 export default function PwaRegister() {
   useEffect(() => {
-    if (process.env.NODE_ENV === 'production') {
+    if (
+      process.env.NODE_ENV === 'production' ||
+      process.env.NEXT_PUBLIC_ENABLE_PWA === 'true'
+    ) {
       void import('next-pwa/register')
     }
   }, [])


### PR DESCRIPTION
## Summary
- permitir habilitar PWA durante el desarrollo
- registrar PWA en `PwaRegister` en local cuando la variable lo indica
- documentar la ejecución `NEXT_PUBLIC_ENABLE_PWA=true pnpm run dev`

## Testing
- `pnpm build` *(fails: JWT_SECRET no definido)*
- `pnpm test` *(fails: 1 failed test)*

------
