### PR TITLE
Add password recovery flow

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -206,6 +206,14 @@ export default function LoginPage() {
             Crear cuenta
           </Link>
         </p>
+        <p className="text-center text-sm text-gray-600 dark:text-zinc-300">
+          <Link
+            href="/olvide-contrasena"
+            className="text-amber-700 underline hover:text-amber-900 dark:text-amber-300 font-medium transition"
+          >
+            ¿Olvidaste tu contraseña?
+          </Link>
+        </p>
 
         {/* 🧾 Mensaje */}
         {mensaje && (

--- a/src/app/(auth)/olvide-contrasena/page.tsx
+++ b/src/app/(auth)/olvide-contrasena/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+import React, { useState } from "react";
+import { apiFetch } from "@lib/api";
+import { jsonOrNull } from "@lib/http";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+
+const schema = z.object({
+  correo: z.string().nonempty("Correo obligatorio").email("Correo inválido"),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function OlvideContrasenaPage() {
+  const [mensaje, setMensaje] = useState("");
+  const [enviando, setEnviando] = useState(false);
+
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    mode: "onTouched",
+  });
+
+  const onSubmit = async (data: FormData) => {
+    setEnviando(true);
+    setMensaje("");
+    const res = await apiFetch("/api/recuperar-contrasena", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (res.ok) {
+      setMensaje(
+        "Si tu correo existe, recibirás un enlace para restablecer tu contraseña."
+      );
+    } else {
+      const d = await jsonOrNull(res);
+      setMensaje(d?.error || "Error al enviar correo");
+    }
+    setEnviando(false);
+  };
+
+  return (
+    <main className="min-h-screen w-full flex items-center justify-center">
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="bg-white dark:bg-zinc-900 shadow-xl border border-amber-300 dark:border-zinc-700 p-8 rounded-2xl max-w-md w-full space-y-5"
+        noValidate
+      >
+        <h1 className="text-3xl font-bold text-center text-amber-700 dark:text-amber-300">
+          Recuperar contraseña
+        </h1>
+        <div className="space-y-1">
+          <input
+            {...register("correo")}
+            type="email"
+            placeholder="Correo electrónico"
+            disabled={enviando}
+            className={`w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-amber-500 ${errors.correo ? "border-red-400" : ""}`}
+            aria-invalid={!!errors.correo}
+          />
+          {errors.correo && (
+            <p className="text-sm text-red-500">{errors.correo.message}</p>
+          )}
+        </div>
+        <button
+          type="submit"
+          disabled={enviando}
+          className="w-full bg-amber-600 hover:bg-amber-700 text-white font-semibold py-2 px-4 rounded-md transition"
+        >
+          {enviando ? "Enviando..." : "Enviar correo"}
+        </button>
+        <p className="text-center text-sm text-gray-600 dark:text-zinc-300">
+          <Link
+            href="/login"
+            className="text-amber-700 underline hover:text-amber-900 dark:text-amber-300 font-medium transition"
+          >
+            Volver al login
+          </Link>
+        </p>
+        {mensaje && (
+          <div className="text-center text-sm mt-2 font-semibold text-amber-700 dark:text-amber-300" aria-live="polite">
+            {mensaje}
+          </div>
+        )}
+      </form>
+    </main>
+  );
+}

--- a/src/app/(auth)/restablecer-contrasena/[token]/page.tsx
+++ b/src/app/(auth)/restablecer-contrasena/[token]/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+import React, { useState } from "react";
+import { apiFetch } from "@lib/api";
+import { jsonOrNull } from "@lib/http";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+
+const schema = z
+  .object({
+    contrasena: z.string().min(6, "Mínimo 6 caracteres"),
+    confirmacion: z.string().min(6, "Mínimo 6 caracteres"),
+  })
+  .refine((d) => d.contrasena === d.confirmacion, {
+    message: "Las contraseñas no coinciden",
+    path: ["confirmacion"],
+  });
+
+type FormData = z.infer<typeof schema>;
+
+export default function RestablecerContrasenaPage({
+  params,
+}: {
+  params: { token: string };
+}) {
+  const router = useRouter();
+  const [mensaje, setMensaje] = useState("");
+  const [guardando, setGuardando] = useState(false);
+
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    mode: "onTouched",
+  });
+
+  const onSubmit = async (data: FormData) => {
+    setGuardando(true);
+    setMensaje("");
+    const res = await apiFetch(`/api/recuperar-contrasena/${params.token}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ contrasena: data.contrasena }),
+    });
+    if (res.ok) {
+      setMensaje("Contraseña actualizada");
+      setTimeout(() => router.replace("/login"), 1500);
+    } else {
+      const d = await jsonOrNull(res);
+      setMensaje(d?.error || "Error");
+    }
+    setGuardando(false);
+  };
+
+  return (
+    <main className="min-h-screen w-full flex items-center justify-center">
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="bg-white dark:bg-zinc-900 shadow-xl border border-amber-300 dark:border-zinc-700 p-8 rounded-2xl max-w-md w-full space-y-5"
+        noValidate
+      >
+        <h1 className="text-3xl font-bold text-center text-amber-700 dark:text-amber-300">
+          Nueva contraseña
+        </h1>
+        <div className="space-y-1">
+          <input
+            {...register("contrasena")}
+            type="password"
+            placeholder="Contraseña nueva"
+            disabled={guardando}
+            className={`w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-amber-500 ${errors.contrasena ? "border-red-400" : ""}`}
+            aria-invalid={!!errors.contrasena}
+          />
+          {errors.contrasena && (
+            <p className="text-sm text-red-500">{errors.contrasena.message}</p>
+          )}
+        </div>
+        <div className="space-y-1">
+          <input
+            {...register("confirmacion")}
+            type="password"
+            placeholder="Confirmar contraseña"
+            disabled={guardando}
+            className={`w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-amber-500 ${errors.confirmacion ? "border-red-400" : ""}`}
+            aria-invalid={!!errors.confirmacion}
+          />
+          {errors.confirmacion && (
+            <p className="text-sm text-red-500">{errors.confirmacion.message}</p>
+          )}
+        </div>
+        <button
+          type="submit"
+          disabled={guardando}
+          className="w-full bg-amber-600 hover:bg-amber-700 text-white font-semibold py-2 px-4 rounded-md transition"
+        >
+          {guardando ? "Guardando..." : "Aceptar cambios"}
+        </button>
+        {mensaje && (
+          <div className="text-center text-sm mt-2 font-semibold" aria-live="polite">
+            {mensaje}
+          </div>
+        )}
+      </form>
+    </main>
+  );
+}

--- a/src/app/api/recuperar-contrasena/[token]/route.ts
+++ b/src/app/api/recuperar-contrasena/[token]/route.ts
@@ -1,0 +1,41 @@
+export const runtime = 'nodejs';
+
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@lib/prisma';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import { respuestaError } from '@lib/http';
+
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET no definido');
+}
+
+function getToken(req: NextRequest): string | null {
+  const parts = req.nextUrl.pathname.split('/');
+  const idx = parts.findIndex((p) => p === 'recuperar-contrasena');
+  return idx !== -1 && parts.length > idx + 1 ? parts[idx + 1] : null;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const token = getToken(req);
+    if (!token) return respuestaError('Token inválido', '', 400);
+    let payload: any;
+    try {
+      payload = jwt.verify(token, JWT_SECRET);
+      if (payload.tipo !== 'reset') throw new Error('tipo');
+    } catch {
+      return respuestaError('Token inválido o expirado', '', 400);
+    }
+    const { contrasena } = await req.json();
+    if (!contrasena || contrasena.length < 6) {
+      return respuestaError('Contraseña insegura', '', 400);
+    }
+    const hash = await bcrypt.hash(contrasena, 10);
+    await prisma.usuario.update({ where: { id: payload.id }, data: { contrasena: hash } });
+    return NextResponse.json({ success: true });
+  } catch (error: any) {
+    return respuestaError('Error interno', error.message, 500);
+  }
+}

--- a/src/app/api/recuperar-contrasena/route.ts
+++ b/src/app/api/recuperar-contrasena/route.ts
@@ -1,0 +1,32 @@
+export const runtime = 'nodejs';
+
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@lib/prisma';
+import jwt from 'jsonwebtoken';
+import { enviarCorreoResetContrasena } from '@/lib/email/enviarResetContrasena';
+import { respuestaError } from '@lib/http';
+
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET no definido');
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { correo } = await req.json();
+    if (!correo) return respuestaError('Correo requerido', '', 400);
+    const user = await prisma.usuario.findUnique({
+      where: { correo: correo.toLowerCase().trim() },
+      select: { id: true, nombre: true, correo: true },
+    });
+    if (user) {
+      const token = jwt.sign({ id: user.id, tipo: 'reset' }, JWT_SECRET, { expiresIn: 60 * 60 });
+      const base = `${req.nextUrl.origin}${process.env.NEXT_PUBLIC_BASE_PATH || ''}`;
+      const enlace = `${base}/restablecer-contrasena/${token}`;
+      await enviarCorreoResetContrasena({ correo: user.correo, nombre: user.nombre, enlace });
+    }
+    return NextResponse.json({ success: true });
+  } catch (error: any) {
+    return respuestaError('Error interno', error.message, 500);
+  }
+}

--- a/src/lib/email/enviarResetContrasena.ts
+++ b/src/lib/email/enviarResetContrasena.ts
@@ -1,0 +1,42 @@
+import nodemailer from 'nodemailer';
+import { plantillaResetContrasenaHTML } from '@/templates/email/resetContrasena.html';
+
+const SMTP_USER = process.env.SMTP_USER;
+const SMTP_PASS = process.env.SMTP_PASS;
+
+if (!SMTP_USER || !SMTP_PASS) {
+  throw new Error('SMTP_USER o SMTP_PASS faltantes');
+}
+
+export async function enviarCorreoResetContrasena({
+  correo,
+  nombre,
+  enlace,
+}: {
+  correo: string;
+  nombre: string;
+  enlace: string;
+}) {
+  try {
+    const transporter = nodemailer.createTransport({
+      host: 'smtp.gmail.com',
+      port: 465,
+      secure: true,
+      auth: { user: SMTP_USER, pass: SMTP_PASS },
+    });
+
+    const html = plantillaResetContrasenaHTML({ nombre, enlace });
+    const info = await transporter.sendMail({
+      from: `"HoneyLabs" <${SMTP_USER}>`,
+      to: correo,
+      subject: 'Restablecer contraseña',
+      html,
+    });
+
+    console.log('[EMAIL_RESET_ENVIADO]', info.messageId);
+    return { enviado: true };
+  } catch (error: any) {
+    console.error('[ERROR_EMAIL_RESET]', error);
+    return { enviado: false, error: error.message };
+  }
+}

--- a/src/templates/email/resetContrasena.html.ts
+++ b/src/templates/email/resetContrasena.html.ts
@@ -1,0 +1,12 @@
+export function plantillaResetContrasenaHTML({ nombre, enlace }: { nombre: string; enlace: string; }) {
+  return `
+    <div style="font-family: Arial, sans-serif; color: #333; padding: 1rem; max-width: 600px;">
+      <h2 style="color: #a16f3d;">🔐 Recuperar contraseña</h2>
+      <p>Hola ${nombre}, has solicitado restablecer tu contraseña.</p>
+      <p>
+        <a href="${enlace}" style="display:inline-block;padding:8px 16px;background:#a16f3d;color:#fff;text-decoration:none;border-radius:4px;">Restablecer contraseña</a>
+      </p>
+      <p>Si no realizaste esta solicitud, ignora este mensaje.</p>
+    </div>
+  `;
+}

--- a/tests/recuperarContrasena.test.ts
+++ b/tests/recuperarContrasena.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import prisma from '../lib/prisma';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+
+process.env.JWT_SECRET = 'secret';
+
+const { POST: solicitar } = await import('../src/app/api/recuperar-contrasena/route');
+const { POST: restablecer } = await import('../src/app/api/recuperar-contrasena/[token]/route');
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('recuperar contrasena', () => {
+  it('requiere correo', async () => {
+    const req = new NextRequest('http://localhost/api/recuperar-contrasena', { method: 'POST', body: '{}' });
+    const res = await solicitar(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('restablece con token valido', async () => {
+    vi.spyOn(prisma.usuario, 'findUnique').mockResolvedValue({ id: 1, nombre: 'Test', correo: 't@example.com' } as any);
+    const update = vi.spyOn(prisma.usuario, 'update').mockResolvedValue({} as any);
+    vi.spyOn(bcrypt, 'hash').mockResolvedValue('nuevo' as any);
+    const token = jwt.sign({ id: 1, tipo: 'reset' }, 'secret');
+    const req = new NextRequest(`http://localhost/api/recuperar-contrasena/${token}`, {
+      method: 'POST',
+      body: JSON.stringify({ contrasena: '123456' }),
+    });
+    const res = await restablecer(req);
+    expect(res.status).toBe(200);
+    expect(update).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- link to a password recovery page on the login screen
- send a reset email when requesting password recovery
- allow a new password via token-specific page
- basic test of password recovery API

## Testing
- `npm test` *(fails: AddCardButton > permanece visible con contenedor bajo)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6880455b392c8328aef25add42f45177