### PR TITLE
Handle unreachable fetch in app url HEAD

### DIFF
--- a/src/app/api/app/url/route.ts
+++ b/src/app/api/app/url/route.ts
@@ -24,7 +24,12 @@ export async function HEAD() {
   try {
     const raw = await fs.readFile(appInfoPath, 'utf8')
     const { url } = JSON.parse(raw) as { url: string }
-    const res = await fetch(url, { method: 'HEAD' })
+    let res: Response
+    try {
+      res = await fetch(url, { method: 'HEAD' })
+    } catch {
+      return NextResponse.json({ error: 'unreachable' }, { status: 502 })
+    }
     if (res.ok) return new Response(null)
     if (!res.ok && process.env.AWS_APK_URL) {
       return NextResponse.json({ url: process.env.AWS_APK_URL })

--- a/tests/appUrlHead.test.ts
+++ b/tests/appUrlHead.test.ts
@@ -21,4 +21,16 @@ describe('HEAD /api/app/url', () => {
     await fs.writeFile(file, backup)
     global.fetch = original
   })
+
+  it('returns error unreachable when fetch fails', async () => {
+    const original = global.fetch
+    global.fetch = vi.fn().mockRejectedValue(new Error('offline'))
+    const backup = await fs.readFile(file, 'utf8')
+    await fs.writeFile(file, JSON.stringify({ version: '1', url: appUrl, sha256: 'a' }))
+    const res = await HEAD()
+    expect(res.status).toBe(502)
+    expect(await res.json()).toEqual({ error: 'unreachable' })
+    await fs.writeFile(file, backup)
+    global.fetch = original
+  })
 })


### PR DESCRIPTION
## Summary
- return `{ error: 'unreachable' }` when fetching the app URL fails
- verify this scenario with a new test

## Testing
- `npm run build` *(fails: prisma not found)*
- `npm test`

------
