### PR TITLE
0.4.7

### DIFF
--- a/src/app/api/app/url/route.ts
+++ b/src/app/api/app/url/route.ts
@@ -1,6 +1,6 @@
 export const runtime = 'nodejs'
 
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import fs from 'fs/promises'
 import path from 'path'
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
@@ -20,10 +20,11 @@ export async function GET() {
   }
 }
 
-export async function HEAD() {
+export async function HEAD(req: NextRequest) {
   try {
     const raw = await fs.readFile(appInfoPath, 'utf8')
-    const { url } = JSON.parse(raw) as { url: string }
+    let { url } = JSON.parse(raw) as { url: string }
+    url = new URL(url, req.nextUrl.origin).href
     let res: Response
     try {
       res = await fetch(url, { method: 'HEAD' })

--- a/tests/appUrlHead.test.ts
+++ b/tests/appUrlHead.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { NextRequest } from 'next/server'
 import { HEAD } from '../src/app/api/app/url/route'
 import fs from 'fs/promises'
 import path from 'path'
@@ -16,7 +17,8 @@ describe('HEAD /api/app/url', () => {
     global.fetch = mockFetch(403)
     const backup = await fs.readFile(file, 'utf8')
     await fs.writeFile(file, JSON.stringify({ version: '1', url: appUrl, sha256: 'a' }))
-    const res = await HEAD()
+    const req = new NextRequest('http://localhost/api/app/url', { method: 'HEAD' })
+    const res = await HEAD(req)
     expect([200,403]).toContain(res.status)
     await fs.writeFile(file, backup)
     global.fetch = original
@@ -27,9 +29,22 @@ describe('HEAD /api/app/url', () => {
     global.fetch = vi.fn().mockRejectedValue(new Error('offline'))
     const backup = await fs.readFile(file, 'utf8')
     await fs.writeFile(file, JSON.stringify({ version: '1', url: appUrl, sha256: 'a' }))
-    const res = await HEAD()
+    const req = new NextRequest('http://localhost/api/app/url', { method: 'HEAD' })
+    const res = await HEAD(req)
     expect(res.status).toBe(502)
     expect(await res.json()).toEqual({ error: 'unreachable' })
+    await fs.writeFile(file, backup)
+    global.fetch = original
+  })
+
+  it('handles relative url', async () => {
+    const original = global.fetch
+    global.fetch = mockFetch(200)
+    const backup = await fs.readFile(file, 'utf8')
+    await fs.writeFile(file, JSON.stringify({ version: '1', url: '/rel.apk', sha256: 'a' }))
+    const req = new NextRequest('http://localhost/api/app/url', { method: 'HEAD' })
+    const res = await HEAD(req)
+    expect(res.status).toBe(200)
     await fs.writeFile(file, backup)
     global.fetch = original
   })


### PR DESCRIPTION
## Summary
- accept `NextRequest` in `HEAD` for `/api/app/url`
- normalize relative URLs in `HEAD`
- update tests and cover relative paths

## Testing
- `npm run build` *(fails: prisma not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688055d58a788328bbbe57c9a1abd78d