### PR TITLE
0.2.3

### DIFF
--- a/src/app/dashboard/almacenes/components/tabs/MaterialesTab.tsx
+++ b/src/app/dashboard/almacenes/components/tabs/MaterialesTab.tsx
@@ -3,7 +3,6 @@ import { useState, useCallback, useEffect, useRef } from 'react'
 import MaterialList from '../MaterialList'
 import type { Material } from '../MaterialRow'
 import { useBoard } from '../../board/BoardProvider'
-import { useTabHelpers } from '@/hooks/useTabHelpers'
 import { generarUUID } from '@/lib/uuid'
 import { openMaterial as doOpenMaterial } from '../../utils/openMaterial'
 import { useToast } from '@/components/Toast'
@@ -20,7 +19,6 @@ export default function MaterialesTab() {
     eliminar,
     mutate,
   } = useBoard()
-  const { ensureTab, openForm } = useTabHelpers()
   const toast = useToast()
   const [busqueda, setBusqueda] = useState('')
   const [orden, setOrden] = useState<'nombre' | 'cantidad'>('nombre')
@@ -61,10 +59,8 @@ export default function MaterialesTab() {
       doOpenMaterial(id, {
         setSelectedId,
         setUnidadSel,
-        ensureTab,
-        openForm,
       }),
-    [ensureTab, openForm, setSelectedId, setUnidadSel]
+    [setSelectedId, setUnidadSel]
   )
 
   return (

--- a/src/app/dashboard/almacenes/components/tabs/UnidadesTab.tsx
+++ b/src/app/dashboard/almacenes/components/tabs/UnidadesTab.tsx
@@ -1,7 +1,6 @@
 "use client";
 import UnidadesPanel from '../../[id]/UnidadesPanel'
 import { useBoard } from '../../board/BoardProvider'
-import { useTabHelpers } from '@/hooks/useTabHelpers'
 import useUnidades from '@/hooks/useUnidades'
 import { useCallback } from 'react'
 
@@ -9,7 +8,6 @@ export default function UnidadesTab() {
   const { materiales, selectedId, setUnidadSel } = useBoard()
   const selected = materiales.find(m => m.id === selectedId) || null
   const { obtener } = useUnidades(selected?.dbId)
-  const { openForm } = useTabHelpers()
 
   const openUnidad = useCallback(
     async (u: any) => {
@@ -17,9 +15,8 @@ export default function UnidadesTab() {
       const info = await obtener(u.id)
       if (!info) return
       setUnidadSel(info)
-      openForm('form-unidad', 'Unidad')
     },
-    [obtener, setUnidadSel, openForm]
+    [obtener, setUnidadSel]
   )
 
   return (

--- a/src/app/dashboard/almacenes/utils/openMaterial.ts
+++ b/src/app/dashboard/almacenes/utils/openMaterial.ts
@@ -1,16 +1,10 @@
-import type { TabType } from '@/hooks/useTabs'
-
 export interface OpenMaterialOptions {
   setSelectedId: (id: string) => void
   setUnidadSel: (u: any) => void
-  ensureTab: (type: TabType, title: string, side: 'left' | 'right') => void
-  openForm: (type: 'form-material' | 'form-unidad', title: string) => void
 }
 
 export function openMaterial(id: string | null, opts: OpenMaterialOptions) {
   if (!id) return
   opts.setSelectedId(id)
   opts.setUnidadSel(null)
-  opts.ensureTab('unidades', 'Unidades', 'right')
-  opts.openForm('form-material', 'Material')
 }

--- a/tests/openMaterial.test.ts
+++ b/tests/openMaterial.test.ts
@@ -1,35 +1,32 @@
 import { describe, it, expect } from 'vitest'
 import { openMaterial } from '../src/app/dashboard/almacenes/utils/openMaterial'
-import type { TabType } from '../src/hooks/useTabs'
-
 function createOpts() {
   let sel: string | null = null
-  const tabs: { type: TabType }[] = []
   const calls: string[] = []
   return {
     opts: {
-      setSelectedId: (id: string) => { sel = id; calls.push('setSelectedId') },
-      setUnidadSel: () => { calls.push('setUnidadSel') },
-      ensureTab: (type: TabType) => { tabs.push({ type }); calls.push('ensureTab') },
-      openForm: () => { calls.push('openForm') },
+      setSelectedId: (id: string) => {
+        sel = id
+        calls.push('setSelectedId')
+      },
+      setUnidadSel: () => {
+        calls.push('setUnidadSel')
+      },
     },
-    get selected() { return sel },
-    get tabs() { return tabs },
-    get calls() { return calls },
+    get selected() {
+      return sel
+    },
+    get calls() {
+      return calls
+    },
   }
 }
 
 describe('openMaterial', () => {
-  it('actualiza selectedId y prepara tarjetas', () => {
+  it('actualiza selectedId y limpia unidad', () => {
     const ctx = createOpts()
     openMaterial('m1', ctx.opts)
     expect(ctx.selected).toBe('m1')
-    expect(ctx.tabs.some(t => t.type === 'unidades')).toBe(true)
-    expect(ctx.calls).toEqual([
-      'setSelectedId',
-      'setUnidadSel',
-      'ensureTab',
-      'openForm',
-    ])
+    expect(ctx.calls).toEqual(['setSelectedId', 'setUnidadSel'])
   })
 })


### PR DESCRIPTION
## Summary
- simplificamos `openMaterial` eliminando la gestión de pestañas
- actualizamos `MaterialesTab` y `UnidadesTab` para no abrir formularios
- limpiamos test de `openMaterial`

## Testing
- `JWT_SECRET=dummy SMTP_USER=a SMTP_PASS=b EMAIL_ADMIN=a@b.c npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688128d6afd08328ad576daa9b735f2d