### PR TITLE
0.0.1

### DIFF
--- a/src/app/dashboard/almacenes/components/MaterialForm.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialForm.tsx
@@ -122,7 +122,7 @@ export default function MaterialForm({
       }
       onChange(campo, e.target.value || null);
     },
-    [material.archivos, onChange, toast],
+    [material?.archivos, onChange, toast],
   );
 
   if (!material) {

--- a/tests/materialFormNull.test.tsx
+++ b/tests/materialFormNull.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+(global as any).React = React
+import { renderToStaticMarkup } from 'react-dom/server'
+
+vi.mock('../src/components/Toast', () => ({ useToast: () => ({ show: vi.fn() }) }))
+vi.mock('../src/hooks/useUnidades', () => ({ __esModule: true, default: () => ({ unidades: [] }) }))
+vi.mock('../src/hooks/useArchivosMaterial', () => ({ __esModule: true, default: () => ({ archivos: [], eliminar: vi.fn(), mutate: vi.fn() }) }))
+vi.mock('../src/hooks/useObjectUrl', () => ({ __esModule: true, default: () => null }))
+
+import MaterialForm from '../src/app/dashboard/almacenes/components/MaterialForm'
+
+function noop() {}
+
+describe('MaterialForm', () => {
+  it('renderiza placeholder con material nulo', () => {
+    const html = renderToStaticMarkup(
+      <MaterialForm
+        material={null}
+        onChange={noop}
+        onGuardar={noop}
+        onCancelar={noop}
+        onDuplicar={noop}
+        onEliminar={noop}
+      />
+    )
+    expect(html).toContain('Selecciona o crea un material')
+  })
+})


### PR DESCRIPTION
## Summary
- corregimos dependencia en `MaterialForm` para evitar `null`
- añadimos test que renderiza `MaterialForm` con `material` nulo

## Testing
- `npm test`
- `npm run build` *(fails: InvalidDatasourceError, JWT_SECRET missing)*

------
https://chatgpt.com/codex/tasks/task_e_68813ecf6d188328a5172dba97492eed