### PR TITLE
0.2.0

### DIFF
--- a/lib/apiPaths.ts
+++ b/lib/apiPaths.ts
@@ -2,3 +2,4 @@ export const API_APP = '/api/app';
 export const API_APP_URL = '/api/app/url';
 export const API_BUILD_MOBILE = '/api/build-mobile';
 export const API_BUILD_PROGRESS = '/api/build-mobile/progress';
+export const API_EVENTS = '/api/events';

--- a/src/app/api/almacenes/[id]/usuarios/route.ts
+++ b/src/app/api/almacenes/[id]/usuarios/route.ts
@@ -1,0 +1,77 @@
+export const runtime = 'nodejs'
+
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@lib/prisma'
+import { getUsuarioFromSession } from '@lib/auth'
+import { hasManagePerms } from '@lib/permisos'
+import { emitEvent } from '@/lib/events'
+import * as logger from '@lib/logger'
+
+function getAlmacenId(req: NextRequest): number | null {
+  const parts = req.nextUrl.pathname.split('/')
+  const idx = parts.findIndex((p) => p === 'almacenes')
+  const id = idx !== -1 && parts.length > idx + 1 ? Number(parts[idx + 1]) : null
+  return id && !Number.isNaN(id) ? id : null
+}
+
+export async function GET(req: NextRequest) {
+  logger.debug(req, 'GET /api/almacenes/[id]/usuarios')
+  try {
+    const usuario = await getUsuarioFromSession(req)
+    if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
+    const almacenId = getAlmacenId(req)
+    if (!almacenId) return NextResponse.json({ error: 'ID inválido' }, { status: 400 })
+    const pertenece = await prisma.usuarioAlmacen.findFirst({
+      where: { usuarioId: usuario.id, almacenId },
+      select: { id: true },
+    })
+    if (!pertenece && !hasManagePerms(usuario)) {
+      return NextResponse.json({ error: 'Sin permisos' }, { status: 403 })
+    }
+    const registros = await prisma.usuarioAlmacen.findMany({
+      where: { almacenId },
+      select: {
+        rolEnAlmacen: true,
+        usuario: { select: { correo: true, nombre: true } },
+      },
+    })
+    const usuarios = registros.map((r) => ({
+      correo: r.usuario.correo,
+      nombre: r.usuario.nombre,
+      rol: r.rolEnAlmacen,
+    }))
+    return NextResponse.json({ usuarios })
+  } catch (err) {
+    logger.error('GET /api/almacenes/[id]/usuarios', err)
+    return NextResponse.json({ error: 'Error' }, { status: 500 })
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  logger.debug(req, 'DELETE /api/almacenes/[id]/usuarios')
+  try {
+    const usuario = await getUsuarioFromSession(req)
+    if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
+    const almacenId = getAlmacenId(req)
+    if (!almacenId) return NextResponse.json({ error: 'ID inválido' }, { status: 400 })
+    const correo = req.nextUrl.searchParams.get('correo') || ''
+    if (!correo) return NextResponse.json({ error: 'Correo requerido' }, { status: 400 })
+    const pertenece = await prisma.usuarioAlmacen.findFirst({
+      where: { usuarioId: usuario.id, almacenId },
+      select: { id: true },
+    })
+    if (!pertenece && !hasManagePerms(usuario)) {
+      return NextResponse.json({ error: 'Sin permisos' }, { status: 403 })
+    }
+    const u = await prisma.usuario.findUnique({ where: { correo } })
+    if (!u) return NextResponse.json({ error: 'No encontrado' }, { status: 404 })
+    await prisma.usuarioAlmacen.delete({
+      where: { usuarioId_almacenId: { usuarioId: u.id, almacenId } },
+    })
+    emitEvent({ type: 'usuarios_update', payload: { almacenId } })
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    logger.error('DELETE /api/almacenes/[id]/usuarios', err)
+    return NextResponse.json({ error: 'Error' }, { status: 500 })
+  }
+}

--- a/src/app/api/almacenes/compartir/route.ts
+++ b/src/app/api/almacenes/compartir/route.ts
@@ -3,6 +3,7 @@ export const runtime = 'nodejs'
 import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@lib/prisma'
 import { getUsuarioFromSession } from '@lib/auth'
+import { emitEvent } from '@/lib/events'
 import * as logger from '@lib/logger'
 
 export async function POST(req: NextRequest) {
@@ -32,6 +33,8 @@ export async function POST(req: NextRequest) {
       },
       update: {},
     })
+
+    emitEvent({ type: 'usuarios_update', payload: { almacenId: cod.almacenId } })
 
     if (cod.usosDisponibles !== null) {
       await prisma.codigoAlmacen.update({

--- a/src/app/dashboard/almacenes/components/ShareAlmacenModal.tsx
+++ b/src/app/dashboard/almacenes/components/ShareAlmacenModal.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { apiFetch } from "@lib/api";
 import { jsonOrNull } from "@lib/http";
 import { useToast } from "@/components/Toast";
+import useAlmacenUsuarios from "@/hooks/useAlmacenUsuarios";
 
 interface Props {
   id: number | string;
@@ -12,6 +13,7 @@ interface Props {
 
 export default function ShareAlmacenModal({ id, nombre, onClose }: Props) {
   const toast = useToast();
+  const { usuarios, revocar } = useAlmacenUsuarios(id);
   const [correos, setCorreos] = useState("");
   const [acceso, setAcceso] = useState<"restricto" | "dominio" | "publico">(
     "restricto",
@@ -19,6 +21,7 @@ export default function ShareAlmacenModal({ id, nombre, onClose }: Props) {
   const [terminacion, setTerminacion] = useState("");
   const [codigo, setCodigo] = useState<string | null>(null);
   const [guardando, setGuardando] = useState(false);
+  const [rol, setRol] = useState<"visualizacion" | "edicion">("visualizacion");
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -39,7 +42,7 @@ export default function ShareAlmacenModal({ id, nombre, onClose }: Props) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           almacenId: id,
-          rolAsignado: "lector",
+          rolAsignado: rol,
           permisos: {
             correos: correos
               .split(",")
@@ -107,6 +110,21 @@ export default function ShareAlmacenModal({ id, nombre, onClose }: Props) {
           className="w-full h-16 p-2 bg-white/10 rounded text-sm mb-2"
           placeholder="correo@ejemplo.com, otro@ej.com"
         />
+        {usuarios.length > 0 && (
+          <ul className="mb-3 space-y-1 text-sm">
+            {usuarios.map((u) => (
+              <li key={u.correo} className="flex justify-between items-center">
+                <span>{u.correo} ({u.rol})</span>
+                <button
+                  className="text-red-500 text-xs"
+                  onClick={() => revocar(u.correo)}
+                >
+                  revocar
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
         <div className="mb-3">
           <p className="text-xs mb-1">Accesos</p>
           <label className="flex items-center gap-1 text-sm">
@@ -140,6 +158,25 @@ export default function ShareAlmacenModal({ id, nombre, onClose }: Props) {
               onChange={() => setAcceso("publico")}
             />
             Cualquiera con enlace
+          </label>
+        </div>
+        <div className="mb-3">
+          <p className="text-xs mb-1">Rol</p>
+          <label className="flex items-center gap-1 text-sm">
+            <input
+              type="radio"
+              checked={rol === "visualizacion"}
+              onChange={() => setRol("visualizacion")}
+            />
+            visualizacion
+          </label>
+          <label className="flex items-center gap-1 text-sm mt-1">
+            <input
+              type="radio"
+              checked={rol === "edicion"}
+              onChange={() => setRol("edicion")}
+            />
+            edicion
           </label>
         </div>
         <div className="flex justify-end gap-2">

--- a/src/hooks/useAlmacenUsuarios.ts
+++ b/src/hooks/useAlmacenUsuarios.ts
@@ -1,0 +1,82 @@
+import { useEffect } from 'react'
+import useSWR from 'swr'
+import { apiFetch } from '@lib/api'
+import fetcher from '@lib/swrFetcher'
+import { API_EVENTS } from '@lib/apiPaths'
+
+export interface AlmacenUsuario {
+  correo: string
+  nombre?: string | null
+  rol: string
+}
+
+export function startAlmacenUsuariosUpdates(
+  almacenId: number,
+  onUpdate: () => void,
+  maxRetries = 5,
+) {
+  let es: EventSource
+  let retry = 1
+  let attempts = 0
+  const connect = () => {
+    es = new EventSource(API_EVENTS)
+    es.addEventListener('open', () => {
+      retry = 1
+      attempts = 0
+    })
+    es.onmessage = (e) => {
+      try {
+        const ev = JSON.parse(e.data)
+        if (
+          ev.type === 'usuarios_update' &&
+          ev.payload?.almacenId === almacenId
+        ) {
+          onUpdate()
+        }
+      } catch {}
+    }
+    es.onerror = async () => {
+      es.close()
+      attempts += 1
+      try {
+        const r = await fetch(API_EVENTS, { method: 'HEAD' })
+        if (r.status === 401) return
+      } catch {}
+      if (attempts <= maxRetries) {
+        setTimeout(connect, retry * 1000)
+        retry = Math.min(retry * 2, 30)
+      }
+    }
+  }
+  connect()
+  return () => es.close()
+}
+
+export default function useAlmacenUsuarios(almacenId?: number | string) {
+  const id = Number(almacenId)
+  const url = !Number.isNaN(id) ? `/api/almacenes/${id}/usuarios` : null
+  const { data, error, isLoading, mutate } = useSWR(url, fetcher)
+
+  useEffect(() => {
+    if (!url) return
+    const stop = startAlmacenUsuariosUpdates(id, mutate)
+    return stop
+  }, [id, url, mutate])
+
+  const revocar = async (correo: string) => {
+    if (!url) return
+    await apiFetch(
+      `/api/almacenes/${id}/usuarios?correo=${encodeURIComponent(correo)}`,
+      { method: 'DELETE' },
+    )
+    mutate()
+  }
+
+  return {
+    usuarios: (data?.usuarios as AlmacenUsuario[]) ?? [],
+    loading: isLoading,
+    error,
+    revocar,
+    mutate,
+  }
+}

--- a/tests/almacenUsuariosRoute.test.ts
+++ b/tests/almacenUsuariosRoute.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import prisma from '../lib/prisma'
+import * as auth from '../lib/auth'
+import * as permisos from '../lib/permisos'
+
+const { GET, DELETE } = await import('../src/app/api/almacenes/[id]/usuarios/route')
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('GET /api/almacenes/[id]/usuarios', () => {
+  it('requiere sesion', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue(null as any)
+    const req = new NextRequest('http://localhost/api/almacenes/1/usuarios')
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('lista usuarios', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ id: 1 } as any)
+    vi.spyOn(prisma.usuarioAlmacen, 'findFirst').mockResolvedValue({ id: 9 } as any)
+    const find = vi.spyOn(prisma.usuarioAlmacen, 'findMany').mockResolvedValue([
+      { usuario: { correo: 'a@x.com', nombre: 'A' }, rolEnAlmacen: 'visualizacion' },
+    ] as any)
+    const req = new NextRequest('http://localhost/api/almacenes/1/usuarios')
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    expect(find).toHaveBeenCalled()
+  })
+})
+
+describe('DELETE /api/almacenes/[id]/usuarios', () => {
+  it('revoca acceso', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ id: 1 } as any)
+    vi.spyOn(prisma.usuarioAlmacen, 'findFirst').mockResolvedValue({ id: 9 } as any)
+    vi.spyOn(prisma.usuario, 'findUnique').mockResolvedValue({ id: 2 } as any)
+    const del = vi.spyOn(prisma.usuarioAlmacen, 'delete').mockResolvedValue({} as any)
+    const req = new NextRequest('http://localhost/api/almacenes/1/usuarios?correo=a%40x.com', { method: 'DELETE' })
+    const res = await DELETE(req)
+    expect(res.status).toBe(200)
+    expect(del).toHaveBeenCalled()
+  })
+})

--- a/tests/almacenesShare.test.ts
+++ b/tests/almacenesShare.test.ts
@@ -20,7 +20,7 @@ describe('POST /api/almacenes/compartir', () => {
       id: 9,
       almacenId: 2,
       codigo: 'abc',
-      rolAsignado: 'lector',
+      rolAsignado: 'visualizacion',
       permisos: null,
       usosDisponibles: 1,
       activo: true,
@@ -36,7 +36,11 @@ describe('POST /api/almacenes/compartir', () => {
     })
     const res = await POST(req)
     expect(res.status).toBe(200)
-    expect(upsert).toHaveBeenCalled()
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ rolEnAlmacen: 'visualizacion' }),
+      }),
+    )
     expect(update).toHaveBeenCalled()
   })
 })

--- a/tests/codigosGenerar.test.ts
+++ b/tests/codigosGenerar.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import prisma from '../lib/prisma'
+
+const { POST } = await import('../src/app/api/codigos/generar/route')
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('POST /api/codigos/generar', () => {
+  it('guarda rol asignado', async () => {
+    const create = vi
+      .spyOn(prisma.codigoAlmacen, 'create')
+      .mockResolvedValue({ codigo: 'xyz' } as any)
+    const req = new NextRequest('http://localhost/api/codigos/generar', {
+      method: 'POST',
+      body: JSON.stringify({ almacenId: 1, rolAsignado: 'edicion' }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(201)
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ rolAsignado: 'edicion' }),
+      }),
+    )
+  })
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -16,6 +16,8 @@ class PrismaClient {
   usuarioAlmacen = {
     findFirst: () => Promise.resolve(),
     upsert: () => Promise.resolve(),
+    findMany: () => Promise.resolve(),
+    delete: () => Promise.resolve(),
   }
   almacen = {
     findMany: () => Promise.resolve(),
@@ -23,6 +25,7 @@ class PrismaClient {
   codigoAlmacen = {
     findUnique: () => Promise.resolve(),
     update: () => Promise.resolve(),
+    create: () => Promise.resolve(),
   }
   material = {
     findMany: () => Promise.resolve(),


### PR DESCRIPTION
## Summary
- extend share modal with role selection and real-time user list
- store role when generating share codes
- emit events to update access lists
- add `/api/almacenes/[id]/usuarios` endpoint
- hook `useAlmacenUsuarios` for SSE updates and revoking
- cover new API logic with vitest

## Testing
- `npm test`
- `npm run build` *(fails: Prisma connection error, JWT secret missing)*

------
