### PR TITLE
0.8.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@
 ## 0.8.20
 - Añadimos margen superior en `AuditoriasPanel` y `UnidadesPanel` para separar secciones.
 
+## 0.8.21
+- Registramos auditoría al duplicar materiales y almacenes.
+
 ## 0.8.5
 - Registramos auditorías también al escanear códigos.
 - Mejoramos el manejo de errores al crear reportes y auditorías.

--- a/src/app/api/almacenes/[id]/duplicar/route.ts
+++ b/src/app/api/almacenes/[id]/duplicar/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@lib/prisma';
 import { getUsuarioFromSession } from '@lib/auth';
 import { hasManagePerms } from '@lib/permisos';
+import { registrarAuditoria } from '@lib/reporter';
 import crypto from 'node:crypto';
 import * as logger from '@lib/logger';
 
@@ -49,7 +50,15 @@ export async function POST(req: NextRequest) {
       select: { id: true, nombre: true },
     });
 
-    return NextResponse.json({ almacen: nuevo });
+    const { auditoria, error: auditError } = await registrarAuditoria(
+      req,
+      'almacen',
+      id,
+      'duplicacion',
+      nuevo,
+    );
+
+    return NextResponse.json({ almacen: nuevo, auditoria, auditError });
   } catch (err) {
     logger.error('POST /api/almacenes/[id]/duplicar', err);
     return NextResponse.json({ error: 'Error al duplicar' }, { status: 500 });

--- a/src/app/api/materiales/[id]/duplicar/route.ts
+++ b/src/app/api/materiales/[id]/duplicar/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@lib/prisma'
 import { getUsuarioFromSession } from '@lib/auth'
 import { hasManagePerms } from '@lib/permisos'
+import { registrarAuditoria } from '@lib/reporter'
 import crypto from 'node:crypto'
 import * as logger from '@lib/logger'
 
@@ -88,7 +89,15 @@ export async function POST(req: NextRequest) {
       return creado
     })
 
-    return NextResponse.json({ material: nuevo })
+    const { auditoria, error: auditError } = await registrarAuditoria(
+      req,
+      'material',
+      id,
+      'duplicacion',
+      nuevo,
+    )
+
+    return NextResponse.json({ material: nuevo, auditoria, auditError })
   } catch (err) {
     logger.error('POST /api/materiales/[id]/duplicar', err)
     return NextResponse.json({ error: 'Error al duplicar' }, { status: 500 })

--- a/tests/almacenDuplicarAuditoria.test.ts
+++ b/tests/almacenDuplicarAuditoria.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import * as auth from '../lib/auth'
+import * as permisos from '../lib/permisos'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+describe('POST /api/almacenes/[id]/duplicar', () => {
+  it('retorna auditoria al duplicar', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ id: 1 } as any)
+    vi.spyOn(permisos, 'hasManagePerms').mockReturnValue(true)
+    const almacen = {
+      nombre: 'A',
+      descripcion: '',
+      funciones: '',
+      permisosPredeterminados: '',
+      imagenUrl: null,
+      imagenNombre: null,
+      imagen: null,
+      entidadId: 2,
+    }
+    const prismaMock = {
+      almacen: {
+        findUnique: vi.fn().mockResolvedValue(almacen),
+        create: vi.fn().mockResolvedValue({ id: 6, nombre: 'A copia' }),
+      },
+    }
+    vi.doMock('../lib/prisma', () => ({ default: prismaMock }))
+    const registrarAuditoria = vi.fn().mockResolvedValue({ auditoria: { id: 9 } })
+    vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
+    const { POST } = await import('../src/app/api/almacenes/[id]/duplicar/route')
+    const req = new NextRequest('http://localhost/api/almacenes/5/duplicar', {
+      method: 'POST',
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.auditoria).toEqual({ id: 9 })
+    expect(registrarAuditoria).toHaveBeenCalled()
+  })
+})

--- a/tests/materialDuplicarAuditoria.test.ts
+++ b/tests/materialDuplicarAuditoria.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import * as auth from '../lib/auth'
+import * as permisos from '../lib/permisos'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+describe('POST /api/materiales/[id]/duplicar', () => {
+  it('retorna auditoria al duplicar', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ id: 1 } as any)
+    vi.spyOn(permisos, 'hasManagePerms').mockReturnValue(true)
+    const material = {
+      nombre: 'mat',
+      descripcion: '',
+      miniatura: null,
+      miniaturaNombre: null,
+      cantidad: 1,
+      unidad: 'u',
+      lote: null,
+      fechaCaducidad: null,
+      ubicacion: null,
+      proveedor: null,
+      estado: null,
+      observaciones: null,
+      codigoBarra: null,
+      codigoQR: null,
+      minimo: null,
+      maximo: null,
+      reorderLevel: null,
+      almacenId: 2,
+      archivos: [] as any[],
+    }
+    const tx = {
+      material: { create: vi.fn().mockResolvedValue({ id: 6, nombre: 'm copia' }) },
+      archivoMaterial: { create: vi.fn() },
+    }
+    const prismaMock = {
+      material: { findUnique: vi.fn().mockResolvedValue(material) },
+      usuarioAlmacen: { findFirst: vi.fn().mockResolvedValue({ id: 1 }) },
+      $transaction: vi.fn().mockImplementation(async (cb: any) => cb(tx)),
+    }
+    vi.doMock('../lib/prisma', () => ({ default: prismaMock }))
+    const registrarAuditoria = vi.fn().mockResolvedValue({ auditoria: { id: 9 } })
+    vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
+    const { POST } = await import('../src/app/api/materiales/[id]/duplicar/route')
+    const req = new NextRequest('http://localhost/api/materiales/5/duplicar', {
+      method: 'POST',
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.auditoria).toEqual({ id: 9 })
+    expect(registrarAuditoria).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- registramos auditoría al duplicar materiales y almacenes
- devolvemos los datos de auditoría en ambas rutas
- añadimos tests para comprobar la auditoría al duplicar
- actualizamos CHANGELOG

## Testing
- `npm run build` *(fails: InvalidDatasourceError / JWT_SECRET no definido)*
- `npm test`

------
