### PR TITLE
0.8.22

### DIFF
--- a/src/app/dashboard/almacenes/components/MaterialForm.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialForm.tsx
@@ -18,7 +18,7 @@ function FileThumb({ file, onClick }: { file: File; onClick: (url: string) => vo
     <img
       src={url}
       alt="preview"
-      className="w-12 h-12 object-cover rounded cursor-pointer"
+      className="w-12 h-12 object-contain rounded cursor-pointer"
       onClick={() => onClick(url)}
     />
   );
@@ -293,7 +293,7 @@ export default function MaterialForm({
             <img
               src={miniaturaSrc}
               alt="miniatura"
-              className="w-32 h-32 object-cover rounded cursor-pointer"
+              className="w-32 h-32 object-contain rounded cursor-pointer"
               onClick={() => setPreview(miniaturaSrc)}
             />
             <button
@@ -353,7 +353,7 @@ export default function MaterialForm({
                     <img
                       src={`data:image/*;base64,${(a as any).archivo}`}
                       alt={a.nombre}
-                      className="w-12 h-12 object-cover rounded cursor-pointer"
+                      className="w-12 h-12 object-contain rounded cursor-pointer"
                       onClick={() =>
                         setPreview(`data:image/*;base64,${(a as any).archivo}`)
                       }
@@ -363,7 +363,7 @@ export default function MaterialForm({
                   <img
                     src={`/api/materiales/${material.dbId}/archivos/${a.id}`}
                     alt={a.nombre}
-                    className="w-12 h-12 object-cover rounded cursor-pointer"
+                    className="w-12 h-12 object-contain rounded cursor-pointer"
                     onClick={() =>
                       setPreview(
                         `/api/materiales/${material.dbId}/archivos/${a.id}`

--- a/src/app/dashboard/almacenes/components/MaterialList.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialList.tsx
@@ -64,7 +64,7 @@ export default function MaterialList({
     return (
       <img
         src={src}
-        className="w-32 h-32 object-cover rounded cursor-pointer"
+        className="w-32 h-32 object-contain rounded cursor-pointer"
         alt="miniatura"
         onClick={(e) => {
           e.stopPropagation();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -445,7 +445,7 @@ function PartnersSection() {
 // =============== EXPORT DE LA PAGINA PRINCIPAL ===============
 export default function Page() {
   return (
-    <main className="relative min-h-screen w-full font-sans overflow-x-hidden">
+    <main className="relative min-h-screen w-full font-sans overflow-x-hidden mt-6">
       <HeroSection />
       <FeaturesSection />
       <DemoSection />


### PR DESCRIPTION
## Summary
- add margin before landing sections
- ensure material thumbnails scale for png/jpg/gif

## Testing
- `npm run build` *(fails: JWT_SECRET not defined)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68815d41e18c8328b7180c2138017f83