### PR TITLE
0.2.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1042,6 +1042,10 @@
 
 - Sidebar de almacenes simplificado con las nuevas categorías principales.
 
+## 0.2.31
+
+- Nuevo endpoint `POST /api/auditorias/[id]/restore` para revivir elementos desde auditorías.
+
 ## 0.2.29
 
 - Se añadieron placeholders para inventario, operaciones, reportes, archivos, configuracion y ayuda.

--- a/docs/auditorias.md
+++ b/docs/auditorias.md
@@ -1,0 +1,7 @@
+# Endpoints de Auditorías
+
+## POST /api/auditorias/[id]/restore
+Restaura el elemento asociado a la auditoría indicada.
+
+- **Parámetros:** ninguno en el cuerpo. El ID se toma de la URL.
+- **Respuesta:** `{ success: true, auditoria: { id }, auditError?: string }`.

--- a/src/app/api/auditorias/[id]/restore/route.ts
+++ b/src/app/api/auditorias/[id]/restore/route.ts
@@ -1,0 +1,52 @@
+export const runtime = 'nodejs'
+
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@lib/prisma'
+import { getUsuarioFromSession } from '@lib/auth'
+import * as logger from '@lib/logger'
+import { registrarAuditoria } from '@lib/reporter'
+
+function getAuditoriaId(req: NextRequest): number | null {
+  const parts = req.nextUrl.pathname.split('/')
+  const idx = parts.findIndex(p => p === 'auditorias')
+  const id = idx !== -1 && parts.length > idx + 1 ? Number(parts[idx + 1]) : null
+  return id && !Number.isNaN(id) ? id : null
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const usuario = await getUsuarioFromSession(req)
+    if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
+    const id = getAuditoriaId(req)
+    if (!id) return NextResponse.json({ error: 'ID inválido' }, { status: 400 })
+
+    const auditoria = await prisma.reporte.findUnique({ where: { id } })
+    if (!auditoria) return NextResponse.json({ error: 'No encontrado' }, { status: 404 })
+
+    const datos = auditoria.observaciones ? JSON.parse(auditoria.observaciones) : {}
+    let creado: any
+
+    if (auditoria.tipo === 'almacen') {
+      creado = await prisma.almacen.create({ data: datos, select: { id: true } })
+    } else if (auditoria.tipo === 'material') {
+      creado = await prisma.material.create({ data: datos, select: { id: true } })
+    } else if (auditoria.tipo === 'unidad') {
+      creado = await prisma.materialUnidad.create({ data: datos, select: { id: true } })
+    } else {
+      return NextResponse.json({ error: 'Tipo desconocido' }, { status: 400 })
+    }
+
+    const { auditoria: nuevaAuditoria, error: auditError } = await registrarAuditoria(
+      req,
+      auditoria.tipo as any,
+      creado.id,
+      'restauracion',
+      datos,
+    )
+
+    return NextResponse.json({ success: true, auditoria: nuevaAuditoria, auditError })
+  } catch (err) {
+    logger.error('POST /api/auditorias/[id]/restore', err)
+    return NextResponse.json({ error: 'Error' }, { status: 500 })
+  }
+}

--- a/src/app/dashboard/almacenes/components/AuditoriaForm.tsx
+++ b/src/app/dashboard/almacenes/components/AuditoriaForm.tsx
@@ -14,6 +14,13 @@ export default function AuditoriaForm({ auditoriaId, onClose }: Props) {
   if (!auditoriaId) return <p className="text-sm p-2">Selecciona una auditoría.</p>;
   if (!auditoria) return <p className="text-sm p-2">Cargando...</p>;
 
+  const restore = async () => {
+    if (!auditoriaId) return;
+    try {
+      await fetch(`/api/auditorias/${auditoriaId}/restore`, { method: 'POST' });
+    } catch {}
+  };
+
   return (
     <div className="space-y-2 text-sm p-2 overflow-y-auto max-h-[calc(100vh-8rem)]">
       <div>Tipo: {auditoria.tipo}</div>
@@ -24,6 +31,12 @@ export default function AuditoriaForm({ auditoriaId, onClose }: Props) {
       {auditoria.observaciones && <div>{auditoria.observaciones}</div>}
       {auditoria.usuario?.nombre && <div>Usuario: {auditoria.usuario.nombre}</div>}
       <div>{new Date(auditoria.fecha).toLocaleString()}</div>
+      <button
+        onClick={restore}
+        className="no-drag px-2 py-1 rounded bg-white/10 text-xs"
+      >
+        Restaurar
+      </button>
       <button onClick={onClose} className="no-drag px-2 py-1 rounded bg-white/10 text-xs">
         Cerrar
       </button>

--- a/tests/auditoriaRestore.test.ts
+++ b/tests/auditoriaRestore.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+describe('POST /api/auditorias/[id]/restore', () => {
+  it('restaura y registra auditoria', async () => {
+    const auditoria = { id: 5, tipo: 'material', observaciones: '{"nombre":"m"}' }
+    const prismaMock = {
+      reporte: { findUnique: vi.fn().mockResolvedValue(auditoria) },
+      material: { create: vi.fn().mockResolvedValue({ id: 8 }) },
+    }
+    vi.doMock('../lib/prisma', () => ({ default: prismaMock }))
+    vi.doMock('../lib/auth', () => ({ getUsuarioFromSession: vi.fn().mockResolvedValue({ id: 1 }) }))
+    const registrarAuditoria = vi.fn().mockResolvedValue({ auditoria: { id: 9 } })
+    vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
+
+    const { POST } = await import('../src/app/api/auditorias/[id]/restore/route')
+    const req = new NextRequest('http://localhost/api/auditorias/5/restore', { method: 'POST' })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.auditoria).toEqual({ id: 9 })
+    expect(prismaMock.material.create).toHaveBeenCalled()
+    expect(registrarAuditoria).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- create `/api/auditorias/[id]/restore` to restore deleted records
- add restore button in `AuditoriaForm`
- document auditoria restore endpoint
- test new API route

## Testing
- `npx vitest run`
- `pnpm run build` *(fails: JWT_SECRET not defined)*

------
