### PR TITLE
Add tooltips to material actions

### DIFF
--- a/src/app/dashboard/almacenes/components/MaterialList.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialList.tsx
@@ -127,40 +127,46 @@ export default function MaterialList({
       </ul>
       <p className="text-xs text-right">Total stock: {totalStock}</p>
       <div className="flex gap-2">
-        <button
-          type="button"
-          onClick={async () => {
-            const res = await onNuevo();
-            if (res?.error) toast.show(res.error, 'error');
-            else toast.show('Material creado', 'success');
-          }}
-          className="flex-1 py-1 rounded-md bg-[var(--dashboard-accent)] text-black text-sm hover:bg-[var(--dashboard-accent-hover)]"
-        >
-          Nuevo Material
-        </button>
-        <button
-          type="button"
-          onClick={onDuplicar}
-          disabled={selectedId === null}
-          className="flex-1 py-1 rounded-md bg-white/10 text-white text-sm disabled:opacity-50"
-        >
-          Duplicar
-        </button>
-        <button
-          type="button"
-          onClick={() => {
-            const id = parseId(selectedId);
-            if (!id) {
-              toast.show('ID inválido', 'error');
-              return;
-            }
-            onEliminar(id);
-          }}
-          disabled={selectedId === null}
-          className="flex-1 py-1 rounded-md bg-red-600 text-white text-sm disabled:opacity-50"
-        >
-          Eliminar
-        </button>
+        <span title="Crear un material nuevo" className="flex-1">
+          <button
+            type="button"
+            onClick={async () => {
+              const res = await onNuevo();
+              if (res?.error) toast.show(res.error, 'error');
+              else toast.show('Material creado', 'success');
+            }}
+            className="w-full py-1 rounded-md bg-[var(--dashboard-accent)] text-black text-sm hover:bg-[var(--dashboard-accent-hover)]"
+          >
+            Nuevo Material
+          </button>
+        </span>
+        <span title="Duplicar material seleccionado" className="flex-1">
+          <button
+            type="button"
+            onClick={onDuplicar}
+            disabled={selectedId === null}
+            className="w-full py-1 rounded-md bg-white/10 text-white text-sm disabled:opacity-50"
+          >
+            Duplicar
+          </button>
+        </span>
+        <span title="Eliminar material seleccionado" className="flex-1">
+          <button
+            type="button"
+            onClick={() => {
+              const id = parseId(selectedId);
+              if (!id) {
+                toast.show('ID inválido', 'error');
+                return;
+              }
+              onEliminar(id);
+            }}
+            disabled={selectedId === null}
+            className="w-full py-1 rounded-md bg-red-600 text-white text-sm disabled:opacity-50"
+          >
+            Eliminar
+          </button>
+        </span>
       </div>
       {preview && (
         <ImageModal src={preview} onClose={() => setPreview(null)} />

--- a/src/app/dashboard/paneles/components/ChatPanel.tsx
+++ b/src/app/dashboard/paneles/components/ChatPanel.tsx
@@ -70,12 +70,16 @@ export default function ChatPanel({ canalId }: { canalId: number }) {
           className="w-full mt-3 p-2 bg-white/10 rounded text-sm"
           rows={3}
         />
-        <button onClick={enviar} className="mt-2 px-3 py-1 bg-white/10 rounded w-full text-sm">
-          Enviar
-        </button>
-        <button onClick={() => setMostrarChat(() => {})} className="mt-2 px-3 py-1 bg-white/10 rounded w-full text-sm">
-          Cerrar
-        </button>
+        <span title="Enviar mensaje">
+          <button onClick={enviar} className="mt-2 px-3 py-1 bg-white/10 rounded w-full text-sm">
+            Enviar
+          </button>
+        </span>
+        <span title="Cerrar panel">
+          <button onClick={() => setMostrarChat(() => {})} className="mt-2 px-3 py-1 bg-white/10 rounded w-full text-sm">
+            Cerrar
+          </button>
+        </span>
       </div>
     </div>
   );

--- a/src/app/dashboard/paneles/components/CommentsPanel.tsx
+++ b/src/app/dashboard/paneles/components/CommentsPanel.tsx
@@ -74,20 +74,24 @@ export default function CommentsPanel({ comentarios, onAdd, widgetId }: { coment
           className="w-full mt-3 p-2 bg-white/10 rounded text-sm"
           rows={3}
         />
-        <button
-          onClick={() => {
-            if (texto.trim()) {
-              onAdd(texto.trim(), widgetId);
-              setTexto("");
-            }
-          }}
-          className="mt-2 px-3 py-1 bg-white/10 rounded w-full text-sm"
-        >
-          Agregar
-        </button>
-        <button onClick={() => setMostrarComentarios(() => {})} className="mt-3 px-3 py-1 bg-white/10 rounded w-full text-sm">
-          Cerrar
-        </button>
+        <span title="Agregar comentario">
+          <button
+            onClick={() => {
+              if (texto.trim()) {
+                onAdd(texto.trim(), widgetId);
+                setTexto("");
+              }
+            }}
+            className="mt-2 px-3 py-1 bg-white/10 rounded w-full text-sm"
+          >
+            Agregar
+          </button>
+        </span>
+        <span title="Cerrar panel">
+          <button onClick={() => setMostrarComentarios(() => {})} className="mt-3 px-3 py-1 bg-white/10 rounded w-full text-sm">
+            Cerrar
+          </button>
+        </span>
       </div>
     </div>
   );

--- a/src/app/dashboard/paneles/components/GalleryPanel.tsx
+++ b/src/app/dashboard/paneles/components/GalleryPanel.tsx
@@ -13,7 +13,9 @@ export default function GalleryPanel({ images, onSelect, onClose }:{ images:stri
             </button>
           ))}
         </div>
-        <button onClick={onClose} className="mt-3 px-3 py-1 bg-white/10 rounded w-full text-sm">Cerrar</button>
+        <span title="Cerrar galería">
+          <button onClick={onClose} className="mt-3 px-3 py-1 bg-white/10 rounded w-full text-sm">Cerrar</button>
+        </span>
       </div>
     </div>
   );

--- a/src/app/dashboard/paneles/components/HistorySidebar.tsx
+++ b/src/app/dashboard/paneles/components/HistorySidebar.tsx
@@ -20,7 +20,9 @@ export default function HistorySidebar({ open, historial, onClose, restore }: {
           ))}
           {!historial.length && <li className="text-gray-400">Sin historial</li>}
         </ul>
-        <button onClick={onClose} className="mt-3 px-3 py-1 bg-white/10 rounded w-full text-sm">Cerrar</button>
+        <span title="Cerrar historial">
+          <button onClick={onClose} className="mt-3 px-3 py-1 bg-white/10 rounded w-full text-sm">Cerrar</button>
+        </span>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- wrap MaterialList action buttons in `<span title>` for quick hints
- add similar hints in ChatPanel, CommentsPanel, GalleryPanel and HistorySidebar

## Testing
- `npx vitest run`
- `npm run build` *(fails: InvalidDatasourceError)*

------
