### PR TITLE
0.4.7

### DIFF
--- a/src/app/dashboard/almacenes/components/MaterialList.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialList.tsx
@@ -15,7 +15,7 @@ interface Props {
   orden: "nombre" | "cantidad";
   setOrden: (v: "nombre" | "cantidad") => void;
   onNuevo: () => Promise<any>;
-  onDuplicar: () => void;
+  onDuplicar: (id: string) => void;
   onEliminar: (id: number) => Promise<any>;
 }
 
@@ -105,7 +105,7 @@ export default function MaterialList({
       </div>
       <ul className="space-y-2 overflow-y-auto max-h-[calc(100vh-12rem)]">
         {filtrados.map((m) => (
-          <li key={m.id}>
+          <li key={m.id} className="relative group">
             <button
               type="button"
               onClick={() => onSeleccion(m.id)}
@@ -114,14 +114,37 @@ export default function MaterialList({
               {(m.miniatura || m.miniaturaUrl) && <Miniatura m={m} />}
               <div className="flex flex-col flex-1">
                 <span className="font-semibold">{m.nombre}</span>
-                <span className="text-xs">
-                  Stock: {m.numUnidades ?? 0}
-                </span>
-                {m.lote && (
-                  <span className="text-xs">Lote: {m.lote}</span>
-                )}
+                <span className="text-xs">Stock: {m.numUnidades ?? 0}</span>
+                {m.lote && <span className="text-xs">Lote: {m.lote}</span>}
               </div>
             </button>
+            <div className="absolute right-2 top-2 flex gap-1 opacity-0 group-hover:opacity-100">
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDuplicar(m.id);
+                }}
+                className="px-1 py-0.5 text-xs rounded bg-white/10"
+              >
+                Duplicar
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const id = parseId(m.id);
+                  if (!id) {
+                    toast.show('ID inválido', 'error');
+                    return;
+                  }
+                  onEliminar(id);
+                }}
+                className="px-1 py-0.5 text-xs rounded bg-red-600 text-white"
+              >
+                Eliminar
+              </button>
+            </div>
           </li>
         ))}
       </ul>
@@ -138,33 +161,6 @@ export default function MaterialList({
             className="w-full py-1 rounded-md bg-[var(--dashboard-accent)] text-black text-sm hover:bg-[var(--dashboard-accent-hover)]"
           >
             Nuevo Material
-          </button>
-        </span>
-        <span title="Duplicar material seleccionado" className="flex-1">
-          <button
-            type="button"
-            onClick={onDuplicar}
-            disabled={selectedId === null}
-            className="w-full py-1 rounded-md bg-white/10 text-white text-sm disabled:opacity-50"
-          >
-            Duplicar
-          </button>
-        </span>
-        <span title="Eliminar material seleccionado" className="flex-1">
-          <button
-            type="button"
-            onClick={() => {
-              const id = parseId(selectedId);
-              if (!id) {
-                toast.show('ID inválido', 'error');
-                return;
-              }
-              onEliminar(id);
-            }}
-            disabled={selectedId === null}
-            className="w-full py-1 rounded-md bg-red-600 text-white text-sm disabled:opacity-50"
-          >
-            Eliminar
           </button>
         </span>
       </div>

--- a/src/app/dashboard/almacenes/components/tabs/MaterialesTab.tsx
+++ b/src/app/dashboard/almacenes/components/tabs/MaterialesTab.tsx
@@ -86,8 +86,8 @@ export default function MaterialesTab() {
         if (mid) openMaterial(String(mid))
         return res
       }}
-      onDuplicar={async () => {
-        const id = parseId(selectedId)
+      onDuplicar={async (mid) => {
+        const id = parseId(mid)
         if (!id) {
           toast.show('ID inválido', 'error')
           return

--- a/tests/materialListDeletion.test.tsx
+++ b/tests/materialListDeletion.test.tsx
@@ -9,7 +9,7 @@ vi.mock('../src/components/Toast', () => ({ useToast: () => toast }))
 
 const toast = { show: vi.fn() }
 
-function renderList(selectedId: string | null, onEliminar: any) {
+function renderList(id: string, onEliminar: any) {
   const elems: any[] = []
   const orig = React.createElement
   const spy = vi
@@ -22,8 +22,8 @@ function renderList(selectedId: string | null, onEliminar: any) {
 
   renderToStaticMarkup(
     <MaterialList
-      materiales={[]}
-      selectedId={selectedId}
+      materiales={[{ id, nombre: 'x', cantidad: 0, lote: '' } as any]}
+      selectedId={null}
       onSeleccion={() => {}}
       busqueda=""
       setBusqueda={() => {}}
@@ -44,7 +44,7 @@ describe('MaterialList', () => {
     const remove = vi.fn()
     const click = renderList('abc', remove)
     expect(click).toBeTypeOf('function')
-    click()
+    click({ stopPropagation() {} })
     expect(remove).not.toHaveBeenCalled()
     expect(toast.show).toHaveBeenCalledWith('ID inválido', 'error')
   })


### PR DESCRIPTION
## Summary
- movemos botones de Duplicar/Eliminar dentro de cada elemento en `MaterialList`
- ajustamos `MaterialesTab` para recibir el id al duplicar
- actualizamos prueba de eliminación de MaterialList

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68818ae979648328844de07c4cbe1008