### PR TITLE
0.4.27

### DIFF
--- a/src/app/dashboard/almacenes/components/MaterialCodes.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialCodes.tsx
@@ -20,6 +20,9 @@ export default function MaterialCodes({
   const qrData =
     typeof value === 'object' && tipo ? buildQRPayload(tipo, value) : value;
   const qrValue = typeof qrData === 'string' ? qrData : encodeQR(qrData);
+  const MAX_QR_LEN = 2000;
+  const tooLong = qrValue.length > MAX_QR_LEN;
+  const displayValue = tooLong ? qrValue.slice(0, MAX_QR_LEN) : qrValue;
 
   const barValue = codigo ??
     (typeof value === 'object' ? (value as any).codigoQR ?? (value as any).codigoUnico : value);
@@ -34,7 +37,12 @@ export default function MaterialCodes({
 
   return (
     <div className="flex flex-col items-start gap-2">
-      <QRCodeSVG value={qrValue} size={128} />
+      {tooLong && (
+        <p className="text-red-500 text-xs">
+          Datos demasiado extensos para código QR, se usa versión resumida.
+        </p>
+      )}
+      <QRCodeSVG value={displayValue} size={128} />
       <svg ref={barRef} className="w-32 h-16" />
       {onRegenerate && (
         <button

--- a/tests/materialCodes.test.tsx
+++ b/tests/materialCodes.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import MaterialCodes from '../src/app/dashboard/almacenes/components/MaterialCodes'
+
+;(global as any).React = React
+
+describe('MaterialCodes', () => {
+  it('avisa cuando el payload supera el límite', () => {
+    const value = 'x'.repeat(2100)
+    const html = renderToStaticMarkup(<MaterialCodes value={value} />)
+    expect(html).toContain('versión resumida')
+  })
+
+  it('omite aviso con datos cortos', () => {
+    const value = 'y'.repeat(100)
+    const html = renderToStaticMarkup(<MaterialCodes value={value} />)
+    expect(html).not.toContain('versión resumida')
+  })
+})


### PR DESCRIPTION
## Summary
- validamos largo del payload antes de generar QR en `MaterialCodes`
- avisamos si se usa versión resumida cuando se exceden 2000 caracteres
- añadimos pruebas de esta lógica con datos extensos

## Testing
- `npm test --silent`
- `npm run build --silent` *(falla: InvalidDatasourceError y falta de JWT_SECRET)*

------
