### PR TITLE
0.4.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Entender que este repositorio solo cuenta "Funcional" la base del proyecto, no s
 
 Para ver mensajes detallados de la aplicación establece `LOG_LEVEL=debug` antes de ejecutar los comandos de desarrollo o producción.
 
+### Límites de archivos adjuntos
+
+Por omisión se permiten hasta diez archivos en los formularios de materiales y unidades. Estos valores se definen en `src/lib/constants.ts` mediante las constantes `MAX_ARCHIVOS_MATERIAL` y `MAX_ARCHIVOS_UNIDAD`. Si necesitas un límite distinto basta con modificar dichas constantes y recompilar la aplicación.
+
 ### Generación de APK
 
 La sección **App** del panel permite descargar la versión móvil. Para que el APK se genere correctamente es necesario definir las variables `GITHUB_REPO` y `GITHUB_TOKEN` en el entorno del servidor. Al enviar una petición `POST` al endpoint `/api/build-mobile` se activa el workflow de GitHub que compila la aplicación Android y actualiza `lib/app-info.json` con la nueva versión y su hash.

--- a/src/app/dashboard/almacenes/components/MaterialForm.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialForm.tsx
@@ -10,6 +10,7 @@ import MaterialCodes from "./MaterialCodes";
 import { generarUUID } from "@/lib/uuid";
 import useUnidades from "@/hooks/useUnidades";
 import useArchivosMaterial from "@/hooks/useArchivosMaterial";
+import { MAX_ARCHIVOS_MATERIAL } from "@/lib/constants";
 
 function FileThumb({ file, onClick }: { file: File; onClick: (url: string) => void }) {
   const url = useObjectUrl(file);
@@ -335,7 +336,9 @@ export default function MaterialForm({
               </button>
             </div>
           ))}
-          {!readOnly && (!material.archivos || material.archivos.length < 10) && (
+          {!readOnly &&
+            (!material.archivos ||
+              material.archivos.length < MAX_ARCHIVOS_MATERIAL) && (
             <input
               type="file"
               data-index={material.archivos?.length || 0}

--- a/src/app/dashboard/almacenes/components/UnidadForm.tsx
+++ b/src/app/dashboard/almacenes/components/UnidadForm.tsx
@@ -5,6 +5,7 @@ import { generarUUID } from "@/lib/uuid";
 import type { UnidadDetalle } from "@/types/unidad-detalle";
 import useArchivosUnidad from "@/hooks/useArchivosUnidad";
 import useObjectUrl from "@/hooks/useObjectUrl";
+import { MAX_ARCHIVOS_UNIDAD } from "@/lib/constants";
 
 interface Props {
   unidad: UnidadDetalle | null;
@@ -466,7 +467,8 @@ export default function UnidadForm({ unidad, onChange, onGuardar, onCancelar }: 
                 </button>
               </div>
             ))}
-            {(!unidad.archivos || unidad.archivos.length < 10) && (
+            {(!unidad.archivos ||
+              unidad.archivos.length < MAX_ARCHIVOS_UNIDAD) && (
               <input
                 type="file"
                 data-index={unidad.archivos?.length || 0}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,3 @@
+export const MAX_ARCHIVOS_MATERIAL = 10
+export const MAX_ARCHIVOS_UNIDAD = 10
+


### PR DESCRIPTION
## Summary
- definimos limites MAX_ARCHIVOS_MATERIAL y MAX_ARCHIVOS_UNIDAD
- aplicamos los nuevos limites en MaterialForm y UnidadForm
- añadimos sección de documentación con la forma de modificar esos valores

## Testing
- `pnpm run build` *(fails: Failed to collect page data for /api/login)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688195ec67cc8328a483f937d89061fa