### PR TITLE
0.9.0

### DIFF
--- a/src/app/dashboard/almacenes/components/ShareAlmacenModal.tsx
+++ b/src/app/dashboard/almacenes/components/ShareAlmacenModal.tsx
@@ -74,14 +74,21 @@ export default function ShareAlmacenModal({ id, nombre, onClose }: Props) {
     }
     setGuardando(true);
     try {
+      const lista = correos
+        .split(',')
+        .map((c) => c.trim())
+        .filter(Boolean);
       const res = await apiFetch("/api/almacenes/compartir", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ codigo }),
+        body: JSON.stringify({ codigo, correos: lista }),
       });
-      if (res.ok) {
-        toast.show("Configuración guardada", "success");
+      const data = await jsonOrNull(res);
+      if (res.ok && data?.enviado) {
+        toast.show("Invitación enviada", "success");
         onClose();
+      } else if (res.ok) {
+        toast.show("Error al enviar", "error");
       } else {
         toast.show("Error al guardar", "error");
       }

--- a/src/lib/email/enviarInvitacionAlmacen.ts
+++ b/src/lib/email/enviarInvitacionAlmacen.ts
@@ -1,0 +1,41 @@
+import nodemailer from 'nodemailer';
+import { plantillaInvitacionAlmacenHTML } from '@/templates/email/invitacionAlmacen.html';
+import * as logger from '@lib/logger';
+
+const SMTP_USER = process.env.SMTP_USER;
+const SMTP_PASS = process.env.SMTP_PASS;
+
+if (!SMTP_USER || !SMTP_PASS) {
+  throw new Error('SMTP_USER o SMTP_PASS faltantes');
+}
+
+export async function enviarInvitacionAlmacen({
+  correos,
+  enlace,
+}: {
+  correos: string[];
+  enlace: string;
+}) {
+  try {
+    const transporter = nodemailer.createTransport({
+      host: 'smtp.gmail.com',
+      port: 465,
+      secure: true,
+      auth: { user: SMTP_USER, pass: SMTP_PASS },
+    });
+
+    const html = plantillaInvitacionAlmacenHTML({ enlace });
+    const info = await transporter.sendMail({
+      from: `"HoneyLabs" <${SMTP_USER}>`,
+      to: correos.join(', '),
+      subject: 'Invitación a almacén',
+      html,
+    });
+
+    logger.info('[EMAIL_INVITACION_ENVIADO]', info.messageId);
+    return { enviado: true };
+  } catch (error: any) {
+    logger.error('[ERROR_EMAIL_INVITACION]', error);
+    return { enviado: false, error: error.message };
+  }
+}

--- a/src/templates/email/invitacionAlmacen.html.ts
+++ b/src/templates/email/invitacionAlmacen.html.ts
@@ -1,0 +1,12 @@
+export function plantillaInvitacionAlmacenHTML({ enlace }: { enlace: string }) {
+  return `
+    <div style="font-family: Arial, sans-serif; color: #333; padding: 1rem; max-width: 600px;">
+      <h2 style="color: #a16f3d;">🔗 Invitación a colaborar en <strong>HoneyLabs</strong></h2>
+      <p>Haz clic en el siguiente enlace para acceder al almacén compartido:</p>
+      <p>
+        <a href="${enlace}" style="display:inline-block;padding:8px 16px;background:#a16f3d;color:#fff;text-decoration:none;border-radius:4px;">Abrir invitación</a>
+      </p>
+      <p style="font-size:0.9rem;color:#777;">Si no esperabas esta invitación puedes ignorar este mensaje.</p>
+    </div>
+  `;
+}


### PR DESCRIPTION
## Summary
- enviar invitaciones por correo
- usar la nueva funcion en la ruta compartir y exponer el resultado en el modal
- test unitario para verificar el envio

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688199e1323483288ee1c62263973a8d