### PR TITLE
0.0.1

### DIFF
--- a/src/app/dashboard/almacenes/[id]/UnidadesPanel.tsx
+++ b/src/app/dashboard/almacenes/[id]/UnidadesPanel.tsx
@@ -48,7 +48,10 @@ export default function UnidadesPanel({
 
   const remove = async (id: number) => {
     const ok = await toast.confirm('¿Eliminar unidad?')
-    if (ok) await eliminar(id)
+    if (!ok) return
+    const res = await eliminar(id)
+    if (res.success) toast.show('Unidad eliminada', 'success')
+    else if (res.error) toast.show(res.error, 'error')
   };
 
   const filtrados = useMemo(

--- a/src/app/dashboard/almacenes/components/MaterialList.tsx
+++ b/src/app/dashboard/almacenes/components/MaterialList.tsx
@@ -156,7 +156,7 @@ export default function MaterialList({
                   type="button"
                   onClick={(e) => {
                     e.stopPropagation();
-                    const id = parseId(m.id);
+                    const id = parseId(m.dbId);
                     if (!id) {
                       toast.show('ID inválido', 'error');
                       return;

--- a/src/hooks/useMateriales.ts
+++ b/src/hooks/useMateriales.ts
@@ -140,10 +140,11 @@ export default function useMateriales(almacenId?: number | string) {
         if (data?.auditoria?.id) {
           window.dispatchEvent(new CustomEvent(AUDIT_PREVIEW_EVENT, { detail: true }))
         }
+        return { success: true, auditoria: data?.auditoria }
       }
-      return data
+      return { success: false, error: data?.error || 'Error' }
     } catch {
-      return { error: 'Error de red' }
+      return { success: false, error: 'Error de red' }
     }
   }
 

--- a/src/hooks/useUnidades.ts
+++ b/src/hooks/useUnidades.ts
@@ -179,9 +179,9 @@ export default function useUnidades(materialId?: number | string) {
   }
 
   const eliminar = async (unidadId: number) => {
-    if (Number.isNaN(id) || id <= 0) return { error: 'ID inválido' }
+    if (Number.isNaN(id) || id <= 0) return { success: false, error: 'ID inválido' }
     if (Number.isNaN(unidadId) || unidadId <= 0)
-      return { error: 'ID de unidad inválido' }
+      return { success: false, error: 'ID de unidad inválido' }
     try {
       const res = await apiFetch(`/api/materiales/${id}/unidades/${unidadId}`, {
         method: 'DELETE',
@@ -193,10 +193,11 @@ export default function useUnidades(materialId?: number | string) {
         if (result?.auditoria?.id) {
           window.dispatchEvent(new CustomEvent(AUDIT_PREVIEW_EVENT, { detail: true }))
         }
+        return { success: true, auditoria: result?.auditoria }
       }
-      return result
+      return { success: false, error: result?.error || 'Error' }
     } catch {
-      return { error: 'Error de red' }
+      return { success: false, error: 'Error de red' }
     }
   }
 

--- a/tests/useMateriales.test.ts
+++ b/tests/useMateriales.test.ts
@@ -87,4 +87,37 @@ describe('useMateriales', () => {
     expect(form.get('fechaCaducidad')).toBe('2024-01-01')
     vi.resetModules()
   })
+
+  it('eliminar notifica exito', async () => {
+    const mutate = vi.fn()
+    const swr = useSWR as unknown as ReturnType<typeof vi.fn>
+    swr.mockReturnValue({ data: null, error: null, isLoading: false, mutate })
+    const apiFetch = vi.fn().mockResolvedValue(
+      new Response('{"success":true}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+    )
+    vi.doMock('../lib/api', () => ({ apiFetch, apiPath: (p: string) => p }))
+    const { default: useMats } = await import('../src/hooks/useMateriales')
+    const { eliminar } = useMats(1)
+    const res = await eliminar(2)
+    expect(res.success).toBe(true)
+    expect(mutate).toHaveBeenCalled()
+    vi.resetModules()
+  })
+
+  it('eliminar devuelve error', async () => {
+    const mutate = vi.fn()
+    const swr = useSWR as unknown as ReturnType<typeof vi.fn>
+    swr.mockReturnValue({ data: null, error: null, isLoading: false, mutate })
+    const apiFetch = vi.fn().mockResolvedValue(
+      new Response('{"error":"fail"}', { status: 400, headers: { 'Content-Type': 'application/json' } })
+    )
+    vi.doMock('../lib/api', () => ({ apiFetch, apiPath: (p: string) => p }))
+    const { default: useMats } = await import('../src/hooks/useMateriales')
+    const { eliminar } = useMats(1)
+    const res = await eliminar(2)
+    expect(res.success).toBe(false)
+    expect(res.error).toBe('fail')
+    expect(mutate).not.toHaveBeenCalled()
+    vi.resetModules()
+  })
 })

--- a/tests/useUnidades.test.ts
+++ b/tests/useUnidades.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import useUnidades from '../src/hooks/useUnidades'
+import useSWR from 'swr'
+
+vi.mock('swr', () => ({ default: vi.fn() }))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+describe('useUnidades', () => {
+  it('eliminar notifica exito', async () => {
+    const mutate = vi.fn()
+    const swr = useSWR as unknown as ReturnType<typeof vi.fn>
+    swr.mockReturnValue({ data: { unidades: [] }, error: null, isLoading: false, mutate })
+    const apiFetch = vi.fn().mockResolvedValue(
+      new Response('{"success":true}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+    )
+    vi.doMock('../lib/api', () => ({ apiFetch, apiPath: (p: string) => p }))
+    const { default: useUnidadesHook } = await import('../src/hooks/useUnidades')
+    const { eliminar } = useUnidadesHook(1)
+    const res = await eliminar(2)
+    expect(res.success).toBe(true)
+    expect(mutate).toHaveBeenCalled()
+    vi.resetModules()
+  })
+
+  it('eliminar devuelve error', async () => {
+    const mutate = vi.fn()
+    const swr = useSWR as unknown as ReturnType<typeof vi.fn>
+    swr.mockReturnValue({ data: { unidades: [] }, error: null, isLoading: false, mutate })
+    const apiFetch = vi.fn().mockResolvedValue(
+      new Response('{"error":"fail"}', { status: 400, headers: { 'Content-Type': 'application/json' } })
+    )
+    vi.doMock('../lib/api', () => ({ apiFetch, apiPath: (p: string) => p }))
+    const { default: useUnidadesHook } = await import('../src/hooks/useUnidades')
+    const { eliminar } = useUnidadesHook(1)
+    const res = await eliminar(2)
+    expect(res.success).toBe(false)
+    expect(res.error).toBe('fail')
+    expect(mutate).not.toHaveBeenCalled()
+    vi.resetModules()
+  })
+})


### PR DESCRIPTION
## Summary
- validamos IDs numéricos al eliminar materiales
- reportamos resultado de eliminación de unidades con toast
- devolvemos flags de éxito en hooks de materiales y unidades
- cubrimos eliminaciones exitosas y fallidas con Vitest

## Testing
- `npm run build` *(fails: InvalidDatasourceError, SMTP_USER/PASS faltantes)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882dfbd75f88328a8ca51e06c8b3520