### PR TITLE
0.2.3

### DIFF
--- a/src/app/dashboard/almacenes/components/AlmacenesList.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenesList.tsx
@@ -168,7 +168,7 @@ const SortableAlmacen = memo(function SortableAlmacen({
         </span>
         <ul className="text-sm mt-1 space-y-1 list-disc list-inside">
           <li>Materiales: {almacen.inventario ?? 0}</li>
-          <li>Unidades: {(almacen.entradas ?? 0) - (almacen.salidas ?? 0)}</li>
+          <li>Unidades: {almacen.unidades ?? 0}</li>
         </ul>
         {almacen.descripcion && (
           <p className="text-xs text-[var(--dashboard-muted)] mt-1">

--- a/src/hooks/useAlmacenes.ts
+++ b/src/hooks/useAlmacenes.ts
@@ -11,6 +11,7 @@ export interface Almacen {
   entradas?: number
   salidas?: number
   inventario?: number
+  unidades?: number
   encargado?: string | null
   correo?: string | null
   notificaciones?: number


### PR DESCRIPTION
## Summary
- computamos unidades totales en la ruta de almacenes
- agregamos `unidades` al hook `useAlmacenes`
- mostramos unidades en el listado de almacenes
- cubrimos el nuevo campo con una prueba

## Testing
- `npm test`
- `npm run build` *(falla: InvalidDatasourceError y variables faltantes)*

------
