### PR TITLE
0.2.3

### DIFF
--- a/src/hooks/useMateriales.ts
+++ b/src/hooks/useMateriales.ts
@@ -3,7 +3,7 @@ import fetcher from '@lib/swrFetcher'
 import { jsonOrNull } from '@lib/http'
 import { useMemo } from 'react'
 import { generarUUID } from '@/lib/uuid'
-import { apiFetch } from '@lib/api'
+import { apiFetch, apiPath } from '@lib/api'
 import { parseId } from '@/lib/parseId'
 import { AUDIT_PREVIEW_EVENT } from '@/lib/ui-events'
 import type { Material } from '@/app/dashboard/almacenes/components/MaterialRow'
@@ -170,7 +170,7 @@ export default function useMateriales(almacenId?: number | string) {
         numUnidades: m._count?.unidades ?? 0,
         fechaCaducidad: m.fechaCaducidad?.slice(0, 10) ?? '',
         miniaturaUrl: m.miniaturaNombre
-          ? `/api/materiales/archivo?nombre=${encodeURIComponent(m.miniaturaNombre)}`
+          ? apiPath(`/api/materiales/archivo?nombre=${encodeURIComponent(m.miniaturaNombre)}`)
           : null,
       })) as Material[] | undefined,
     [data],

--- a/tests/useMateriales.test.ts
+++ b/tests/useMateriales.test.ts
@@ -120,4 +120,24 @@ describe('useMateriales', () => {
     expect(mutate).not.toHaveBeenCalled()
     vi.resetModules()
   })
+
+  it('incluye apiPath en miniaturaUrl', async () => {
+    const swr = useSWR as unknown as ReturnType<typeof vi.fn>
+    swr.mockReturnValue({
+      data: { materiales: [{ nombre: 'm1', miniaturaNombre: 'img.png' }] },
+      error: null,
+      isLoading: false,
+      mutate: vi.fn(),
+    })
+    vi.doMock('../lib/api', () => ({
+      apiFetch: vi.fn(),
+      apiPath: (p: string) => '/base' + p,
+    }))
+    const { default: useMats } = await import('../src/hooks/useMateriales')
+    const { materiales } = useMats(1)
+    expect(materiales[0].miniaturaUrl).toBe(
+      '/base/api/materiales/archivo?nombre=img.png',
+    )
+    vi.resetModules()
+  })
 })


### PR DESCRIPTION
## Summary
- usamos `apiPath` para construir las rutas de miniaturas en `useMateriales`
- cubrimos con un test que verifica el prefijo retornado por `apiPath`

## Testing
- `npm run build` *(falla: SMTP_USER o SMTP_PASS faltantes)*
- `npm test`

------
