### PR TITLE
Fix miniaturaUrl with BASE_PATH

### DIFF
--- a/src/hooks/useMateriales.ts
+++ b/src/hooks/useMateriales.ts
@@ -3,7 +3,7 @@ import fetcher from '@lib/swrFetcher'
 import { jsonOrNull } from '@lib/http'
 import { useMemo } from 'react'
 import { generarUUID } from '@/lib/uuid'
-import { apiFetch } from '@lib/api'
+import { apiFetch, apiPath } from '@lib/api'
 import { parseId } from '@/lib/parseId'
 import { AUDIT_PREVIEW_EVENT } from '@/lib/ui-events'
 import type { Material } from '@/app/dashboard/almacenes/components/MaterialRow'
@@ -170,7 +170,7 @@ export default function useMateriales(almacenId?: number | string) {
         numUnidades: m._count?.unidades ?? 0,
         fechaCaducidad: m.fechaCaducidad?.slice(0, 10) ?? '',
         miniaturaUrl: m.miniaturaNombre
-          ? `/api/materiales/archivo?nombre=${encodeURIComponent(m.miniaturaNombre)}`
+          ? apiPath(`/api/materiales/archivo?nombre=${encodeURIComponent(m.miniaturaNombre)}`)
           : null,
       })) as Material[] | undefined,
     [data],

--- a/tests/useMateriales.test.ts
+++ b/tests/useMateriales.test.ts
@@ -58,6 +58,25 @@ describe('useMateriales', () => {
     Object.defineProperty(globalThis, 'crypto', { value: originalCrypto, configurable: true })
   })
 
+  it('construye miniaturaUrl con BASE_PATH', async () => {
+    const swr = useSWR as unknown as ReturnType<typeof vi.fn>
+    swr.mockReturnValue({
+      data: { materiales: [{ nombre: 'm1', miniaturaNombre: 'img 1.png' }] },
+      error: null,
+      isLoading: false,
+      mutate: vi.fn(),
+    })
+    const original = process.env.NEXT_PUBLIC_BASE_PATH
+    process.env.NEXT_PUBLIC_BASE_PATH = '/base'
+    const { default: useMats } = await import('../src/hooks/useMateriales')
+    const { materiales } = useMats(1)
+    expect(materiales[0].miniaturaUrl).toBe(
+      '/base/api/materiales/archivo?nombre=img%201.png',
+    )
+    process.env.NEXT_PUBLIC_BASE_PATH = original
+    vi.resetModules()
+  })
+
   it('crear genera FormData valida', async () => {
     const swr = useSWR as unknown as ReturnType<typeof vi.fn>
     swr.mockReturnValue({ data: null, error: null, isLoading: false, mutate: vi.fn() })


### PR DESCRIPTION
## Summary
- use `apiPath` in `useMateriales` when building `miniaturaUrl`
- test that `BASE_PATH` is respected when generating `miniaturaUrl`

## Testing
- `pnpm run build`
- `pnpm test`


------
