### PR TITLE
feat(docs): subsección Descargas

### DIFF
--- a/docs/inventory-utilities.md
+++ b/docs/inventory-utilities.md
@@ -6,3 +6,5 @@ Este documento resume operaciones útiles disponibles en la sección de Almacene
 - **Actualizaciones masivas**: envía varias modificaciones de stock en una sola acción utilizando `/api/materiales/[id]/ajuste`.
 - **Alertas de bajo stock**: consulta `/api/alertas` para mostrar materiales con existencias por debajo del mínimo configurado.
 - **Generación de códigos QR por lote**: crea varios códigos de acceso con `/api/codigos/generar` para identificación rápida.
+- **Manuales en PDF**: descarga el [Manual de Usuario](../public/manuales/manual-usuario.pdf) y la [Referencia Técnica](../public/manuales/referencia-tecnica.pdf) para consulta offline.
+

--- a/public/manuales/manual-usuario.pdf
+++ b/public/manuales/manual-usuario.pdf
@@ -1,0 +1,7 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog >>
+endobj
+trailer
+<<>>
+%%EOF

--- a/public/manuales/referencia-tecnica.pdf
+++ b/public/manuales/referencia-tecnica.pdf
@@ -1,0 +1,7 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog >>
+endobj
+trailer
+<<>>
+%%EOF

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -129,8 +129,33 @@ export default function DocumentosPage() {
           className="text-zinc-600 dark:text-zinc-300 text-sm"
           data-oid="67v_5ex"
         >
-          Consejos y atajos para aprovechar al máximo todas las funciones.
+        Consejos y atajos para aprovechar al máximo todas las funciones.
+      </p>
+      </section>
+      <section
+        className="rounded-lg bg-white/70 dark:bg-[#22223b]/80 p-4 shadow"
+        data-oid="descargas"
+      >
+        <h2 className="text-lg font-bold text-amber-700 mb-1">Descargas</h2>
+        <p className="text-zinc-600 dark:text-zinc-300 text-sm">
+          Manuales disponibles para consulta sin conexión.
         </p>
+        <div className="grid sm:grid-cols-2 gap-4 mt-4">
+          <a
+            href="/manuales/manual-usuario.pdf"
+            className="block rounded-md bg-white/70 dark:bg-[#22223b]/60 p-4 shadow hover:shadow-md transition"
+            data-oid="download-manual"
+          >
+            Manual de Usuario
+          </a>
+          <a
+            href="/manuales/referencia-tecnica.pdf"
+            className="block rounded-md bg-white/70 dark:bg-[#22223b]/60 p-4 shadow hover:shadow-md transition"
+            data-oid="download-tecnica"
+          >
+            Referencia Técnica
+          </a>
+        </div>
       </section>
       <section
         className="rounded-lg bg-white/70 dark:bg-[#22223b]/80 p-4 shadow"

--- a/tests/docsDownloads.test.tsx
+++ b/tests/docsDownloads.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import DocumentosPage from '../src/app/docs/page'
+
+;(global as any).React = React
+
+describe('DocumentosPage descargas', () => {
+  it('renderiza enlaces a manuales', () => {
+    const html = renderToStaticMarkup(<DocumentosPage />)
+    expect(html).toContain('/manuales/manual-usuario.pdf')
+    expect(html).toContain('/manuales/referencia-tecnica.pdf')
+  })
+})


### PR DESCRIPTION
## Summary
- add PDF placeholders under `public/manuales`
- reference new manuals in docs
- extend `src/app/docs/page.tsx` with Descargas section
- cover download cards with a rendering test

## Testing
- `pnpm run build` *(fails: InvalidDatasourceError / SMTP_USER missing)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688416b9e7448328840db83b9b0ecd91