### PR TITLE
Estado del sistema con API y tests

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,15 @@
+# Endpoint de Estado del Sistema
+
+`GET /api/status`
+
+Retorna un JSON indicando si todos los servicios están operativos.
+
+```json
+{ "status": "ok" }
+```
+
+En caso de fallo de alguna dependencia, la respuesta es:
+
+```json
+{ "status": "maintenance" }
+```

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -1,0 +1,25 @@
+export const runtime = 'nodejs'
+
+import { NextResponse } from 'next/server'
+import prisma from '@lib/prisma'
+import * as logger from '@lib/logger'
+
+const EXTERNAL_URL = process.env.STATUS_SERVICE_URL || 'https://example.com'
+
+export async function GET() {
+  try {
+    await prisma.$queryRaw`SELECT 1`
+    const res = await fetch(EXTERNAL_URL, { method: 'HEAD' })
+    if (!res.ok) throw new Error('external')
+    return NextResponse.json(
+      { status: 'ok' },
+      { headers: { 'Cache-Control': 'no-store' } },
+    )
+  } catch (err) {
+    logger.error('[STATUS_ERROR]', err)
+    return NextResponse.json(
+      { status: 'maintenance' },
+      { status: 503, headers: { 'Cache-Control': 'no-store' } },
+    )
+  }
+}

--- a/src/app/estado/page.tsx
+++ b/src/app/estado/page.tsx
@@ -1,22 +1,32 @@
 // src/app/estado/page.tsx
-export default function EstadoPage() {
+import { apiPath } from '@lib/api'
+
+interface EstadoData {
+  status: 'ok' | 'maintenance'
+}
+
+export default async function EstadoPage() {
+  const res = await fetch(apiPath('/api/status'), { cache: 'no-store' })
+  const data = (await res.json()) as EstadoData
+  const now = new Date().toLocaleString()
+  const ok = data.status === 'ok'
   return (
-    <main className="max-w-3xl mx-auto p-8" data-oid="55r6f68">
-      <h1 className="text-3xl font-bold mb-2 text-amber-700" data-oid="6:ostpz">
-        Estado del sistema
-      </h1>
-      <p className="text-zinc-600 mb-4" data-oid="os1kij2">
+    <main className="max-w-3xl mx-auto p-8">
+      <h1 className="text-3xl font-bold mb-2 text-amber-700">Estado del sistema</h1>
+      <p className="text-zinc-600 mb-4">
         Consulta aquí el estado actual de los servicios y funcionalidades de
         HoneyLabs. Si algún servicio presenta problemas, aparecerá una
         notificación en esta sección.
       </p>
-      <div
-        className="p-4 bg-green-50 rounded-lg border border-green-200 text-green-700 font-semibold"
-        data-oid="3n303nl"
-      >
-        Todos los sistemas funcionan normalmente. Última actualización:{" "}
-        {new Date().toLocaleString()}
-      </div>
+      {ok ? (
+        <div className="p-4 bg-green-50 rounded-lg border border-green-200 text-green-700 font-semibold">
+          Todos los sistemas funcionan normalmente. Última actualización: {now}
+        </div>
+      ) : (
+        <div className="p-4 bg-orange-50 rounded-lg border border-orange-200 text-orange-700 font-semibold">
+          El sistema se encuentra en mantenimiento. Última actualización: {now}
+        </div>
+      )}
     </main>
-  );
+  )
 }

--- a/tests/estadoPage.test.tsx
+++ b/tests/estadoPage.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import React from 'react'
+import { render } from '@testing-library/react'
+
+;(global as any).React = React
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+describe('EstadoPage', () => {
+  it('muestra sistemas ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response('{"status":"ok"}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+    ))
+    const { default: EstadoPage } = await import('../src/app/estado/page')
+    const ui = await EstadoPage()
+    const { getByText } = render(ui)
+    expect(getByText(/funcionan normalmente/i)).toBeTruthy()
+  })
+
+  it('muestra mantenimiento', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response('{"status":"maintenance"}', { status: 503, headers: { 'Content-Type': 'application/json' } })
+    ))
+    const { default: EstadoPage } = await import('../src/app/estado/page')
+    const ui = await EstadoPage()
+    const { getByText } = render(ui)
+    expect(getByText(/mantenimiento/i)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- implementar `api/status` con verificación de BD y servicio externo
- consumir este API en la página `/estado`
- documentar el formato de respuesta
- añadir pruebas de renderizado según estado

## Testing
- `pnpm run build` *(fails: Failed to collect page data)*
- `pnpm test`

------
