### PR TITLE
Handle missing status env

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -4,6 +4,9 @@
 
 Retorna un JSON indicando si todos los servicios están operativos.
 
+Si la variable de entorno `STATUS_SERVICE_URL` no está definida, se omite la
+verificación externa y solo se comprueba la conexión a la base de datos.
+
 ```json
 { "status": "ok" }
 ```

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -4,13 +4,17 @@ import { NextResponse } from 'next/server'
 import prisma from '@lib/prisma'
 import * as logger from '@lib/logger'
 
-const EXTERNAL_URL = process.env.STATUS_SERVICE_URL || 'https://example.com'
+const EXTERNAL_URL = process.env.STATUS_SERVICE_URL
 
 export async function GET() {
   try {
     await prisma.$queryRaw`SELECT 1`
-    const res = await fetch(EXTERNAL_URL, { method: 'HEAD' })
-    if (!res.ok) throw new Error('external')
+
+    if (EXTERNAL_URL) {
+      const res = await fetch(EXTERNAL_URL, { method: 'HEAD' })
+      if (!res.ok) throw new Error('external')
+    }
+
     return NextResponse.json(
       { status: 'ok' },
       { headers: { 'Cache-Control': 'no-store' } },


### PR DESCRIPTION
## Summary
- skip external check when `STATUS_SERVICE_URL` is unset
- document behaviour of status route when env var is missing

## Testing
- `pnpm run build` *(fails: Failed to collect page data)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688421b554008328ba8833f8a9ad19eb