### PR TITLE
Adjust badge padding in Almacenes components

### DIFF
--- a/src/app/dashboard/almacenes/components/AlmacenesGrid.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenesGrid.tsx
@@ -48,7 +48,7 @@ export default function AlmacenesGrid({
               <h3 className="font-semibold text-base">{a.nombre}</h3>
               <span
                 className={cn(
-                  'px-2 py-0.5 rounded-full text-xs font-semibold',
+                  'px-1 py-0.5 rounded-full text-xs font-semibold',
                   (a.inventario ?? 0) > 0 ? 'bg-yellow-400 text-black' : 'bg-gray-500 text-white',
                 )}
               >
@@ -81,7 +81,7 @@ export default function AlmacenesGrid({
               <span className="font-semibold text-lg">📦 {a.inventario ?? 0}</span>
               <span
                 className={cn(
-                  'px-2 py-0.5 rounded-full text-xs',
+                  'px-1 py-0.5 rounded-full text-xs',
                   (a.inventario ?? 0) > 0
                     ? 'bg-emerald-600 text-white'
                     : 'bg-red-600 text-white',
@@ -98,7 +98,7 @@ export default function AlmacenesGrid({
               {a.notificaciones && a.notificaciones > 0 && (
                 <span
                   title={`${a.notificaciones} notificaciones sin leer`}
-                  className="text-xs px-2 py-0.5 rounded-full bg-[var(--dashboard-accent)] text-[#101014] font-semibold"
+                  className="text-xs px-1 py-0.5 rounded-full bg-[var(--dashboard-accent)] text-[#101014] font-semibold"
                 >
                   {a.notificaciones}
                 </span>

--- a/src/app/dashboard/almacenes/components/AlmacenesList.tsx
+++ b/src/app/dashboard/almacenes/components/AlmacenesList.tsx
@@ -158,7 +158,7 @@ const SortableAlmacen = memo(function SortableAlmacen({
         <h3 className="font-semibold text-base">{almacen.nombre}</h3>
         <span
           className={cn(
-            "px-1 py-px rounded text-[9px]",
+            "px-1 py-0.5 rounded text-[9px]",
             (almacen.inventario ?? 0) > 0
               ? "bg-emerald-600 text-white"
               : "bg-red-600 text-white",


### PR DESCRIPTION
## Summary
- reduce horizontal padding on inventory and status badges in `AlmacenesGrid`
- match padding on abbreviated status badge in `AlmacenesList`

## Testing
- `pnpm run build` *(fails: Error validating datasource & missing SMTP_USER/SMTP_PASS)*
- `pnpm test`

------
