### PR TITLE
Fix auditoria error messages

### DIFF
--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -33,11 +33,15 @@ export async function registrarAuditoria(
       logger.error(req, 'Error de red al crear reporte', err)
       return { error: 'Error de red al crear reporte' }
     }
+    const data1 = await res
+      .json()
+      .catch(() => ({ error: 'No se pudo crear reporte' }))
     if (!res.ok) {
-      logger.error(req, 'Fallo al crear reporte', res.status)
-      return { error: 'No se pudo crear reporte' }
+      const msg = data1?.error || 'No se pudo crear reporte'
+      logger.error(req, 'Fallo al crear reporte', msg)
+      return { error: msg }
     }
-    const { reporte } = await res.json()
+    const { reporte } = data1 as any
 
     let res2: Response
     try {
@@ -53,11 +57,15 @@ export async function registrarAuditoria(
       logger.error(req, 'Error de red al crear auditoría', err)
       return { error: 'Error de red al crear auditoría' }
     }
+    const data2 = await res2
+      .json()
+      .catch(() => ({ error: 'No se pudo crear auditoría' }))
     if (!res2.ok) {
-      logger.error(req, 'Fallo al crear auditoría', res2.status)
-      return { error: 'No se pudo crear auditoría' }
+      const msg = data2?.error || 'No se pudo crear auditoría'
+      logger.error(req, 'Fallo al crear auditoría', msg)
+      return { error: msg }
     }
-    const { auditoria } = await res2.json()
+    const { auditoria } = data2 as any
     return { auditoria }
   } catch (err) {
     logger.error(req, 'Error inesperado en registrarAuditoria', err)

--- a/tests/almacenesAuditoria.test.ts
+++ b/tests/almacenesAuditoria.test.ts
@@ -32,6 +32,31 @@ describe('POST /api/almacenes', () => {
     expect(data.auditoria).toEqual({ id: 9 })
     expect(registrarAuditoria).toHaveBeenCalled()
   })
+
+  it('propaga error de auditoria al crear', async () => {
+    vi.doMock('../lib/auth', () => ({ getUsuarioFromSession: vi.fn().mockResolvedValue({ id: 1, entidadId: 2, tipoCuenta: 'admin', nombre: 'u' }) }))
+    vi.doMock('../lib/permisos', () => ({ hasManagePerms: vi.fn().mockReturnValue(true) }))
+    const create = vi.fn().mockResolvedValue({ id: 5, nombre: 'A', descripcion: '', imagenNombre: null, imagenUrl: null, codigoUnico: 'c' })
+    const findUnique = vi.fn().mockResolvedValue(null)
+    const hist = vi.fn().mockResolvedValue({})
+    const tx = { almacen: { create, findUnique }, historialAlmacen: { create: hist } }
+    const prismaMock = { $transaction: vi.fn().mockImplementation(async (cb:any)=> cb(tx)) }
+    vi.doMock('../lib/prisma', () => ({ default: prismaMock }))
+    vi.doMock('../src/lib/audit', () => ({ logAudit: vi.fn() }))
+    const registrarAuditoria = vi.fn().mockResolvedValue({ error: 'fallo' })
+    vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
+    const { POST } = await import('../src/app/api/almacenes/route')
+    const body = JSON.stringify({ nombre: 'A', descripcion: '', funciones: '', permisosPredeterminados: '' })
+    const req = new NextRequest('http://localhost/api/almacenes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    })
+    const res = await POST(req)
+    const data = await res.json()
+    expect(data.auditError).toBe('fallo')
+    expect(data.auditoria).toBeUndefined()
+  })
 })
 
 describe('PUT /api/almacenes/[id]', () => {
@@ -58,6 +83,30 @@ describe('PUT /api/almacenes/[id]', () => {
     const data = await res.json()
     expect(data.auditoria).toEqual({ id: 9 })
     expect(registrarAuditoria).toHaveBeenCalled()
+  })
+
+  it('propaga error de auditoria al actualizar', async () => {
+    vi.doMock('../lib/auth', () => ({ getUsuarioFromSession: vi.fn().mockResolvedValue({ id: 1 }) }))
+    vi.doMock('../lib/permisos', () => ({ hasManagePerms: vi.fn().mockReturnValue(true) }))
+    const update = vi.fn().mockResolvedValue({ id: 5, nombre: 'A', descripcion: '', imagenNombre: null, imagenUrl: null })
+    const findUnique = vi.fn().mockResolvedValue(null)
+    const hist = vi.fn().mockResolvedValue({})
+    const tx = { almacen: { update, findUnique }, historialAlmacen: { create: hist } }
+    const prismaMock = { usuarioAlmacen: { findFirst: vi.fn().mockResolvedValue({ id: 1 }) }, $transaction: vi.fn().mockImplementation(async (cb:any)=> cb(tx)) }
+    vi.doMock('../lib/prisma', () => ({ default: prismaMock }))
+    vi.doMock('../src/lib/audit', () => ({ logAudit: vi.fn() }))
+    const registrarAuditoria = vi.fn().mockResolvedValue({ error: 'fallo' })
+    vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
+    const { PUT } = await import('../src/app/api/almacenes/[id]/route')
+    const req = new NextRequest('http://localhost/api/almacenes/5', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nombre: 'x' }),
+    })
+    const res = await PUT(req)
+    const data = await res.json()
+    expect(data.auditError).toBe('fallo')
+    expect(data.auditoria).toBeUndefined()
   })
 })
 
@@ -98,4 +147,41 @@ describe('DELETE /api/almacenes/[id]', () => {
     expect(data.auditoria).toEqual({ id: 9 })
     expect(registrarAuditoria).toHaveBeenCalled()
   })
+
+  it('propaga error de auditoria al eliminar', async () => {
+    vi.doMock('../lib/auth', () => ({ getUsuarioFromSession: vi.fn().mockResolvedValue({ id: 1 }) }))
+    vi.doMock('../lib/permisos', () => ({ hasManagePerms: vi.fn().mockReturnValue(true) }))
+    const tx = {
+      almacen: { delete: vi.fn(), findUnique: vi.fn() },
+      usuarioAlmacen: { deleteMany: vi.fn() },
+      codigoAlmacen: { deleteMany: vi.fn() },
+      movimiento: { deleteMany: vi.fn() },
+      eventoAlmacen: { deleteMany: vi.fn() },
+      novedadAlmacen: { deleteMany: vi.fn() },
+      documentoAlmacen: { deleteMany: vi.fn() },
+      incidencia: { deleteMany: vi.fn() },
+      notificacion: { deleteMany: vi.fn() },
+      alerta: { deleteMany: vi.fn() },
+      historialLote: { deleteMany: vi.fn() },
+      materialUnidad: { deleteMany: vi.fn() },
+      archivoMaterial: { deleteMany: vi.fn() },
+      material: { deleteMany: vi.fn() },
+      historialAlmacen: { create: vi.fn() },
+    }
+    const prismaMock = {
+      usuarioAlmacen: { findFirst: vi.fn().mockResolvedValue({ id: 1 }) },
+      $transaction: vi.fn().mockImplementation(async (cb:any)=> cb(tx))
+    }
+    vi.doMock('../lib/prisma', () => ({ default: prismaMock }))
+    vi.doMock('../src/lib/audit', () => ({ logAudit: vi.fn() }))
+    const registrarAuditoria = vi.fn().mockResolvedValue({ error: 'fallo' })
+    vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
+    const { DELETE } = await import('../src/app/api/almacenes/[id]/route')
+    const req = new NextRequest('http://localhost/api/almacenes/5', { method: 'DELETE' })
+    const res = await DELETE(req)
+    const data = await res.json()
+    expect(data.auditError).toBe('fallo')
+    expect(data.auditoria).toBeUndefined()
+  })
 })
+


### PR DESCRIPTION
## Summary
- forward error messages from the auditoria/report creation to callers
- test POST/PUT/DELETE almacenes when reporter fails

## Testing
- `pnpm run build` *(fails: InvalidDatasourceError & missing SMTP credentials)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688421ba08c8832889648e1b36c513db