### PR TITLE
fix: registra auditoria en movimientos

### DIFF
--- a/src/app/api/almacenes/[id]/movimientos/route.ts
+++ b/src/app/api/almacenes/[id]/movimientos/route.ts
@@ -5,6 +5,7 @@ import prisma from '@lib/prisma';
 import { getUsuarioFromSession } from '@lib/auth';
 import { hasManagePerms, hasPermission } from '@lib/permisos';
 import { logAudit } from '@/lib/audit';
+import { registrarAuditoria } from '@lib/reporter';
 import * as logger from '@lib/logger'
 
 function getAlmacenIdFromRequest(req: NextRequest): number | null {
@@ -62,7 +63,15 @@ export async function POST(req: NextRequest) {
       })
     })
 
-    return NextResponse.json({ success: true });
+    const { auditoria, error: auditError } = await registrarAuditoria(
+      req,
+      'almacen',
+      id,
+      'movimiento',
+      { tipo, cantidad: n, descripcion, contexto },
+    )
+
+    return NextResponse.json({ success: true, auditoria, auditError });
   } catch (err) {
     logger.error('POST /api/almacenes/[id]/movimientos', err);
     return NextResponse.json({ error: 'Error al registrar' }, { status: 500 });

--- a/tests/movimientosAuditoria.test.ts
+++ b/tests/movimientosAuditoria.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+describe('POST /api/almacenes/[id]/movimientos', () => {
+  it('retorna auditoria al registrar movimiento', async () => {
+    vi.doMock('../lib/auth', () => ({ getUsuarioFromSession: vi.fn().mockResolvedValue({ id: 1 }) }))
+    vi.doMock('../lib/permisos', () => ({
+      hasManagePerms: vi.fn().mockReturnValue(true),
+      hasPermission: vi.fn().mockReturnValue(true),
+    }))
+    const create = vi.fn()
+    const tx = { movimiento: { create } }
+    const prismaMock = {
+      usuarioAlmacen: { findFirst: vi.fn().mockResolvedValue({ id: 1 }) },
+      $transaction: vi.fn().mockImplementation(async (cb: any) => cb(tx)),
+    }
+    vi.doMock('../lib/prisma', () => ({ default: prismaMock }))
+    vi.doMock('../src/lib/audit', () => ({ logAudit: vi.fn() }))
+    const registrarAuditoria = vi.fn().mockResolvedValue({ auditoria: { id: 9 } })
+    vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
+    const { POST } = await import('../src/app/api/almacenes/[id]/movimientos/route')
+    const req = new NextRequest('http://localhost/api/almacenes/5/movimientos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tipo: 'entrada', cantidad: 2 }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.auditoria).toEqual({ id: 9 })
+    expect(registrarAuditoria).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- registra auditoria al crear movimientos de almacén
- agrega prueba para verificar el registro de auditorías en movimientos

## Testing
- `pnpm run build` *(fails: InvalidDatasourceError P6001, SMTP_USER/SMTP_PASS missing)*
- `pnpm test`

------
