### PR TITLE
Separate auditorias from reportes

### DIFF
--- a/docs/auditorias.md
+++ b/docs/auditorias.md
@@ -1,5 +1,11 @@
 # Endpoints de Auditorías
 
+## POST /api/auditorias
+Crea una nueva entrada de auditoría. Puede enviar datos en `multipart/form-data` o JSON.
+
+- **Campos:** `tipo` (`almacen`|`material`|`unidad`), `objetoId`, `categoria`, `observaciones` (JSON) y opcionalmente `archivos`.
+- **Respuesta:** `{ auditoria: { id } }`.
+
 ## POST /api/auditorias/[id]/restore
 Restaura el elemento asociado a la auditoría indicada.
 

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -25,48 +25,24 @@ export async function registrarAuditoria(
 
     let res: Response
     try {
-      res = await fetch(new URL(apiPath('/api/reportes'), req.url), {
+      res = await fetch(new URL(apiPath('/api/auditorias'), req.url), {
         method: 'POST',
         headers: { cookie: req.headers.get('cookie') ?? '' },
         body: form,
       })
     } catch (err) {
-      logger.error(req, 'Error de red al crear reporte', err)
-      return { error: 'Error de red al crear reporte' }
-    }
-    const data1 = await res
-      .json()
-      .catch(() => ({ error: 'No se pudo crear reporte' }))
-    if (!res.ok) {
-      const msg = data1?.error || 'No se pudo crear reporte'
-      logger.error(req, 'Fallo al crear reporte', msg)
-      return { error: msg }
-    }
-    const { reporte } = data1 as any
-
-    let res2: Response
-    try {
-      res2 = await fetch(new URL(apiPath('/api/auditorias'), req.url), {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          cookie: req.headers.get('cookie') ?? '',
-        },
-        body: JSON.stringify({ reporteId: reporte.id }),
-      })
-    } catch (err) {
       logger.error(req, 'Error de red al crear auditoría', err)
       return { error: 'Error de red al crear auditoría' }
     }
-    const data2 = await res2
+    const data = await res
       .json()
       .catch(() => ({ error: 'No se pudo crear auditoría' }))
-    if (!res2.ok) {
-      const msg = data2?.error || 'No se pudo crear auditoría'
+    if (!res.ok) {
+      const msg = data?.error || 'No se pudo crear auditoría'
       logger.error(req, 'Fallo al crear auditoría', msg)
       return { error: msg }
     }
-    const { auditoria } = data2 as any
+    const { auditoria } = data as any
     return { auditoria }
   } catch (err) {
     logger.error(req, 'Error inesperado en registrarAuditoria', err)

--- a/prisma/migrations/20250728073536_create_auditoria/migration.sql
+++ b/prisma/migrations/20250728073536_create_auditoria/migration.sql
@@ -1,0 +1,33 @@
+-- CreateTable
+CREATE TABLE "Auditoria" (
+    "id" SERIAL NOT NULL,
+    "tipo" TEXT NOT NULL,
+    "almacenId" INTEGER,
+    "materialId" INTEGER,
+    "unidadId" INTEGER,
+    "observaciones" TEXT,
+    "categoria" TEXT,
+    "fecha" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "usuarioId" INTEGER,
+    CONSTRAINT "Auditoria_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ArchivoAuditoria" (
+    "id" SERIAL NOT NULL,
+    "nombre" TEXT NOT NULL,
+    "archivo" BYTEA,
+    "archivoNombre" TEXT,
+    "fecha" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "auditoriaId" INTEGER NOT NULL,
+    "subidoPorId" INTEGER,
+    CONSTRAINT "ArchivoAuditoria_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Auditoria" ADD CONSTRAINT "Auditoria_usuarioId_fkey" FOREIGN KEY ("usuarioId") REFERENCES "Usuario"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Auditoria" ADD CONSTRAINT "Auditoria_almacenId_fkey" FOREIGN KEY ("almacenId") REFERENCES "Almacen"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Auditoria" ADD CONSTRAINT "Auditoria_materialId_fkey" FOREIGN KEY ("materialId") REFERENCES "Material"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Auditoria" ADD CONSTRAINT "Auditoria_unidadId_fkey" FOREIGN KEY ("unidadId") REFERENCES "MaterialUnidad"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "ArchivoAuditoria" ADD CONSTRAINT "ArchivoAuditoria_auditoriaId_fkey" FOREIGN KEY ("auditoriaId") REFERENCES "Auditoria"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ArchivoAuditoria" ADD CONSTRAINT "ArchivoAuditoria_subidoPorId_fkey" FOREIGN KEY ("subidoPorId") REFERENCES "Usuario"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,7 +100,9 @@ model Usuario {
   facturas             Factura[]
   tickets              Ticket[]
   reportes             Reporte[]       @relation("ReporteUsuario")
+  auditorias           Auditoria[]     @relation("AuditoriaUsuario")
   archivosReportes     ArchivoReporte[] @relation("ArchivoReporteSubidoPor")
+  archivosAuditorias   ArchivoAuditoria[] @relation("ArchivoAuditoriaSubidoPor")
   entidad              Entidad?               @relation(fields: [entidadId], references: [id])
   plan                 Plan?                  @relation(fields: [planId], references: [id])
   almacenes            UsuarioAlmacen[]
@@ -161,6 +163,7 @@ model Almacen {
   novedades               NovedadAlmacen[]
   usuarios                UsuarioAlmacen[]
   reportes               Reporte[]          @relation("ReporteAlmacen")
+  auditorias             Auditoria[]        @relation("AuditoriaAlmacen")
 }
 
 model UsuarioAlmacen {
@@ -321,6 +324,7 @@ model Material {
   movimientosMaterial MovimientoMaterial[]
   facturaItems        FacturaItem[]
   reportes            Reporte[]          @relation("ReporteMaterial")
+  auditorias          Auditoria[]        @relation("AuditoriaMaterial")
 }
 
 model ArchivoMaterial {
@@ -412,6 +416,7 @@ model MaterialUnidad {
   historial          HistorialUnidad[]
   facturaItems       FacturaItem[]
   reportes           Reporte[]          @relation("ReporteUnidad")
+  auditorias         Auditoria[]        @relation("AuditoriaUnidad")
   material           Material          @relation(fields: [materialId], references: [id])
 
   @@unique([materialId, nombre])
@@ -634,4 +639,35 @@ model ArchivoReporte {
   reporte       Reporte  @relation("ArchivoDeReporte", fields: [reporteId], references: [id])
   subidoPorId   Int?
   subidoPor     Usuario? @relation("ArchivoReporteSubidoPor", fields: [subidoPorId], references: [id])
+}
+
+model Auditoria {
+  id            Int      @id @default(autoincrement())
+  tipo          String   // 'almacen', 'material', 'unidad'
+  almacenId     Int?
+  materialId    Int?
+  unidadId      Int?
+  observaciones String?
+  categoria     String?
+  fecha         DateTime @default(now())
+  usuarioId     Int?
+
+  usuario   Usuario?        @relation("AuditoriaUsuario", fields: [usuarioId], references: [id])
+  almacen   Almacen?        @relation("AuditoriaAlmacen", fields: [almacenId], references: [id])
+  material  Material?       @relation("AuditoriaMaterial", fields: [materialId], references: [id])
+  unidad    MaterialUnidad? @relation("AuditoriaUnidad", fields: [unidadId], references: [id])
+
+  archivos  ArchivoAuditoria[] @relation("ArchivoDeAuditoria")
+}
+
+model ArchivoAuditoria {
+  id            Int      @id @default(autoincrement())
+  nombre        String
+  archivo       Bytes?
+  archivoNombre String?
+  fecha         DateTime @default(now())
+  auditoriaId   Int
+  auditoria     Auditoria @relation("ArchivoDeAuditoria", fields: [auditoriaId], references: [id])
+  subidoPorId   Int?
+  subidoPor     Usuario?  @relation("ArchivoAuditoriaSubidoPor", fields: [subidoPorId], references: [id])
 }

--- a/src/app/api/auditorias/[id]/restore/route.ts
+++ b/src/app/api/auditorias/[id]/restore/route.ts
@@ -20,7 +20,7 @@ export async function POST(req: NextRequest) {
     const id = getAuditoriaId(req)
     if (!id) return NextResponse.json({ error: 'ID inválido' }, { status: 400 })
 
-    const auditoria = await prisma.reporte.findUnique({ where: { id } })
+    const auditoria = await prisma.auditoria.findUnique({ where: { id } })
     if (!auditoria) return NextResponse.json({ error: 'No encontrado' }, { status: 404 })
 
     const datos = auditoria.observaciones ? JSON.parse(auditoria.observaciones) : {}

--- a/src/app/api/auditorias/[id]/route.ts
+++ b/src/app/api/auditorias/[id]/route.ts
@@ -18,7 +18,7 @@ export async function GET(req: NextRequest) {
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     const id = getAuditoriaId(req)
     if (!id) return NextResponse.json({ error: 'ID inválido' }, { status: 400 })
-    const auditoria = await prisma.reporte.findUnique({
+    const auditoria = await prisma.auditoria.findUnique({
       where: { id },
       include: {
         usuario: { select: { nombre: true } },

--- a/tests/auditLog.test.ts
+++ b/tests/auditLog.test.ts
@@ -23,7 +23,7 @@ describe('logAudit', () => {
     const { NextRequest } = await import('next/server')
     const req = new NextRequest('http://localhost/api/test')
     const result = await registrarAuditoria(req, 'almacen', 1, 'creacion', {})
-    expect(result).toEqual({ error: 'Error de red al crear reporte' })
+    expect(result).toEqual({ error: 'Error de red al crear auditoría' })
     vi.unstubAllGlobals()
   })
 })

--- a/tests/auditoriaRestore.test.ts
+++ b/tests/auditoriaRestore.test.ts
@@ -10,7 +10,7 @@ describe('POST /api/auditorias/[id]/restore', () => {
   it('restaura y registra auditoria', async () => {
     const auditoria = { id: 5, tipo: 'material', observaciones: '{"nombre":"m"}' }
     const prismaMock = {
-      reporte: { findUnique: vi.fn().mockResolvedValue(auditoria) },
+      auditoria: { findUnique: vi.fn().mockResolvedValue(auditoria) },
       material: { create: vi.fn().mockResolvedValue({ id: 8 }) },
     }
     vi.doMock('../lib/prisma', () => ({ default: prismaMock }))

--- a/tests/materialesValidation.test.ts
+++ b/tests/materialesValidation.test.ts
@@ -1,11 +1,16 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { POST } from '../src/app/api/almacenes/[id]/materiales/route'
+import * as reporter from '../lib/reporter'
 import { NextRequest } from 'next/server'
 import prisma from '../lib/prisma'
 import * as auth from '../lib/auth'
 import * as permisos from '../lib/permisos'
 
 afterEach(() => vi.restoreAllMocks())
+
+beforeEach(() => {
+  vi.spyOn(reporter, 'registrarAuditoria').mockResolvedValue({})
+})
 
 describe('validaciones de materiales', () => {
   const baseReq = {

--- a/tests/materialsOrderRelation.test.ts
+++ b/tests/materialsOrderRelation.test.ts
@@ -1,12 +1,17 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { GET as GET_MATERIALES } from '../src/app/api/materiales/route'
 import { POST as POST_MATERIAL } from '../src/app/api/almacenes/[id]/materiales/route'
 import { NextRequest } from 'next/server'
 import prisma from '../lib/prisma'
 import * as auth from '../lib/auth'
 import * as permisos from '../lib/permisos'
+import * as reporter from '../lib/reporter'
 
 afterEach(() => vi.restoreAllMocks())
+
+beforeEach(() => {
+  vi.spyOn(reporter, 'registrarAuditoria').mockResolvedValue({})
+})
 
 describe('materiales orden y asociacion', () => {
   it('GET ordena por id desc', async () => {


### PR DESCRIPTION
## Summary
- add Auditoria models and migration
- detach reporter from reportes
- implement new /api/auditorias API
- adjust restore endpoint
- update docs and tests

## Testing
- `pnpm run build` *(fails: Prisma connection error)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68872744558083289b7b5e113bfd8f8e