### PR TITLE
Handle missing Auditoria table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@
 - Reorganizamos la información con totales y ubicación.
 - Reemplazamos los iconos por botones de texto en la lista.
 
+## 0.8.28
+- Manejamos el error `P2021` en las rutas de auditorías para indicar que la base
+  de datos requiere migraciones.
+
 ## 0.8.5
 - Registramos auditorías también al escanear códigos.
 - Mejoramos el manejo de errores al crear reportes y auditorías.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ DATABASE_URL=$DIRECT_DB_URL pnpm prisma migrate deploy
 vercel --prod
 ```
 
-Si Prisma arroja el error `P2021` indicando que la tabla `Usuario` no existe,
+Si Prisma arroja el error `P2021` indicando que la tabla `Usuario` o `Auditoria` no existe,
 asegúrate de aplicar todas las migraciones con:
 
 ```sh

--- a/src/app/api/auditorias/[id]/restore/route.ts
+++ b/src/app/api/auditorias/[id]/restore/route.ts
@@ -2,6 +2,7 @@ export const runtime = 'nodejs'
 
 import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@lib/prisma'
+import { Prisma } from '@prisma/client'
 import { getUsuarioFromSession } from '@lib/auth'
 import * as logger from '@lib/logger'
 import { registrarAuditoria } from '@lib/reporter'
@@ -46,6 +47,16 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ success: true, auditoria: nuevaAuditoria, auditError })
   } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === 'P2021'
+    ) {
+      logger.error('POST /api/auditorias/[id]/restore', err)
+      return NextResponse.json(
+        { error: 'Base de datos no inicializada.' },
+        { status: 500 },
+      )
+    }
     logger.error('POST /api/auditorias/[id]/restore', err)
     return NextResponse.json({ error: 'Error' }, { status: 500 })
   }

--- a/src/app/api/auditorias/[id]/route.ts
+++ b/src/app/api/auditorias/[id]/route.ts
@@ -2,6 +2,7 @@ export const runtime = 'nodejs'
 
 import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@lib/prisma'
+import { Prisma } from '@prisma/client'
 import { getUsuarioFromSession } from '@lib/auth'
 import * as logger from '@lib/logger'
 
@@ -31,6 +32,16 @@ export async function GET(req: NextRequest) {
     if (!auditoria) return NextResponse.json({ error: 'No encontrado' }, { status: 404 })
     return NextResponse.json({ auditoria })
   } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === 'P2021'
+    ) {
+      logger.error('GET /api/auditorias/[id]', err)
+      return NextResponse.json(
+        { error: 'Base de datos no inicializada.' },
+        { status: 500 },
+      )
+    }
     logger.error('GET /api/auditorias/[id]', err)
     return NextResponse.json({ error: 'Error' }, { status: 500 })
   }

--- a/src/app/api/auditorias/route.ts
+++ b/src/app/api/auditorias/route.ts
@@ -2,6 +2,7 @@ export const runtime = 'nodejs'
 
 import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@lib/prisma'
+import { Prisma } from '@prisma/client'
 import { getUsuarioFromSession } from '@lib/auth'
 import * as logger from '@lib/logger'
 
@@ -51,6 +52,16 @@ export async function GET(req: NextRequest) {
     })
     return NextResponse.json({ auditorias })
   } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === 'P2021'
+    ) {
+      logger.error('GET /api/auditorias', err)
+      return NextResponse.json(
+        { error: 'Base de datos no inicializada.' },
+        { status: 500 },
+      )
+    }
     logger.error('GET /api/auditorias', err)
     return NextResponse.json({ error: 'Error' }, { status: 500 })
   }
@@ -110,6 +121,16 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ auditoria })
   } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === 'P2021'
+    ) {
+      logger.error('POST /api/auditorias', err)
+      return NextResponse.json(
+        { error: 'Base de datos no inicializada.' },
+        { status: 500 },
+      )
+    }
     logger.error('POST /api/auditorias', err)
     return NextResponse.json({ error: 'Error' }, { status: 500 })
   }


### PR DESCRIPTION
## Summary
- catch Prisma `P2021` errors in auditorias API routes
- clarify migration instructions when table `Auditoria` is missing
- document fix in the changelog

## Testing
- `pnpm run build`
- `pnpm test`


------
