### PR TITLE
fix: ensure auditoria tables

### DIFF
--- a/lib/auditoriaInit.ts
+++ b/lib/auditoriaInit.ts
@@ -1,0 +1,50 @@
+import prisma from './prisma'
+import * as logger from './logger'
+
+let checked = false
+
+export async function ensureAuditoriaTables() {
+  if (checked) return
+  try {
+    const r = await prisma.$queryRaw<{ exists: boolean }[]>`
+      SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema='public' AND table_name='Auditoria'
+      ) as "exists"
+    `
+    if (!r[0]?.exists) {
+      await prisma.$executeRawUnsafe(`CREATE TABLE "Auditoria" (
+        "id" SERIAL NOT NULL,
+        "tipo" TEXT NOT NULL,
+        "almacenId" INTEGER,
+        "materialId" INTEGER,
+        "unidadId" INTEGER,
+        "observaciones" TEXT,
+        "categoria" TEXT,
+        "fecha" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        "usuarioId" INTEGER,
+        CONSTRAINT "Auditoria_pkey" PRIMARY KEY ("id")
+      )`)
+      await prisma.$executeRawUnsafe(`CREATE TABLE "ArchivoAuditoria" (
+        "id" SERIAL NOT NULL,
+        "nombre" TEXT NOT NULL,
+        "archivo" BYTEA,
+        "archivoNombre" TEXT,
+        "fecha" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        "auditoriaId" INTEGER NOT NULL,
+        "subidoPorId" INTEGER,
+        CONSTRAINT "ArchivoAuditoria_pkey" PRIMARY KEY ("id")
+      )`)
+      await prisma.$executeRawUnsafe(`ALTER TABLE "Auditoria" ADD CONSTRAINT "Auditoria_usuarioId_fkey" FOREIGN KEY ("usuarioId") REFERENCES "Usuario"("id") ON DELETE SET NULL ON UPDATE CASCADE`)
+      await prisma.$executeRawUnsafe(`ALTER TABLE "Auditoria" ADD CONSTRAINT "Auditoria_almacenId_fkey" FOREIGN KEY ("almacenId") REFERENCES "Almacen"("id") ON DELETE SET NULL ON UPDATE CASCADE`)
+      await prisma.$executeRawUnsafe(`ALTER TABLE "Auditoria" ADD CONSTRAINT "Auditoria_materialId_fkey" FOREIGN KEY ("materialId") REFERENCES "Material"("id") ON DELETE SET NULL ON UPDATE CASCADE`)
+      await prisma.$executeRawUnsafe(`ALTER TABLE "Auditoria" ADD CONSTRAINT "Auditoria_unidadId_fkey" FOREIGN KEY ("unidadId") REFERENCES "MaterialUnidad"("id") ON DELETE SET NULL ON UPDATE CASCADE`)
+      await prisma.$executeRawUnsafe(`ALTER TABLE "ArchivoAuditoria" ADD CONSTRAINT "ArchivoAuditoria_auditoriaId_fkey" FOREIGN KEY ("auditoriaId") REFERENCES "Auditoria"("id") ON DELETE CASCADE ON UPDATE CASCADE`)
+      await prisma.$executeRawUnsafe(`ALTER TABLE "ArchivoAuditoria" ADD CONSTRAINT "ArchivoAuditoria_subidoPorId_fkey" FOREIGN KEY ("subidoPorId") REFERENCES "Usuario"("id") ON DELETE SET NULL ON UPDATE CASCADE`)
+    }
+    checked = true
+  } catch (err) {
+    logger.error('ensureAuditoriaTables', err)
+    throw err
+  }
+}

--- a/src/app/api/auditorias/route.ts
+++ b/src/app/api/auditorias/route.ts
@@ -5,9 +5,11 @@ import prisma from '@lib/prisma'
 import { Prisma } from '@prisma/client'
 import { getUsuarioFromSession } from '@lib/auth'
 import * as logger from '@lib/logger'
+import { ensureAuditoriaTables } from '@lib/auditoriaInit'
 
 export async function GET(req: NextRequest) {
   try {
+    await ensureAuditoriaTables()
     const tipo = req.nextUrl.searchParams.get('tipo') || undefined
     const categoria = req.nextUrl.searchParams.get('categoria') || undefined
     const almacenId = req.nextUrl.searchParams.get('almacenId') || undefined
@@ -69,6 +71,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
+    await ensureAuditoriaTables()
     const usuario = await getUsuarioFromSession(req)
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
 


### PR DESCRIPTION
## Summary
- create utility to auto-create Auditoria tables if absent
- call new setup from auditoria API

## Testing
- `pnpm run build` *(fails: Error collecting page data)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6887c8fa0d5483288dcc8610ef57e806