### PR TITLE
Fix auditorias panel warehouse id

### DIFF
--- a/src/app/dashboard/almacenes/components/WarehouseBoard.tsx
+++ b/src/app/dashboard/almacenes/components/WarehouseBoard.tsx
@@ -6,6 +6,7 @@ import AuditoriasPanel from '../[id]/AuditoriasPanel';
 import MaterialForm from './MaterialForm';
 import UnidadForm from './UnidadForm';
 import { useBoard } from '../board/BoardProvider';
+import { useParams } from 'next/navigation';
 import useUnidades from '@/hooks/useUnidades';
 import { useToast } from '@/components/Toast';
 import { generarUUID } from '@/lib/uuid';
@@ -27,6 +28,8 @@ export default function WarehouseBoard() {
     duplicar,
     mutate,
   } = useBoard();
+  const { id } = useParams();
+  const almacenId = parseId(id);
   const toast = useToast();
 
   const material = materiales.find(m => m.id === selectedId) || null;
@@ -168,7 +171,7 @@ export default function WarehouseBoard() {
         <MaterialesTab />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <UnidadesPanel material={material} onChange={() => {}} onSelect={openUnidad} />
-          <AuditoriasPanel material={material} almacenId={0} onSelectHistorial={openAuditoria} />
+          <AuditoriasPanel material={material} almacenId={almacenId ?? undefined} onSelectHistorial={openAuditoria} />
         </div>
       </div>
     </div>

--- a/tests/warehouseBoardAuditorias.test.tsx
+++ b/tests/warehouseBoardAuditorias.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+;(global as any).React = React
+
+describe('WarehouseBoard auditorias', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('pasa almacenId desde params a AuditoriasPanel', async () => {
+    vi.doMock('next/navigation', () => ({ useParams: () => ({ id: '7' }) }))
+    vi.doMock('../src/components/Toast', () => ({ useToast: () => ({ show: vi.fn(), confirm: vi.fn() }) }))
+    vi.doMock('../src/app/dashboard/almacenes/board/BoardProvider', () => ({
+      useBoard: () => ({
+        materiales: [],
+        selectedId: null,
+        setSelectedId: vi.fn(),
+        unidadSel: null,
+        setUnidadSel: vi.fn(),
+        setAuditoriaSel: vi.fn(),
+        eliminar: vi.fn(),
+        crear: vi.fn(),
+        actualizar: vi.fn(),
+        duplicar: vi.fn(),
+        mutate: vi.fn(),
+      }),
+    }))
+    let props: any
+    vi.doMock('../src/app/dashboard/almacenes/[id]/AuditoriasPanel', () => ({
+      __esModule: true,
+      default: (p: any) => {
+        props = p
+        return null
+      },
+    }))
+
+    const WarehouseBoard = (await import('../src/app/dashboard/almacenes/components/WarehouseBoard')).default
+    renderToStaticMarkup(<WarehouseBoard />)
+    expect(props.almacenId).toBe(7)
+  })
+})


### PR DESCRIPTION
## Summary
- wire up the warehouse id in `WarehouseBoard`
- test that the ID is passed to `AuditoriasPanel`

## Testing
- `pnpm run build` *(fails: Error validating datasource, SMTP user missing)*
- `pnpm test` *(fails: buildMobile.test.ts SyntaxError)*

------
