### PR TITLE
feat: navbar detalle auditoria

### DIFF
--- a/src/app/dashboard/auditorias/[id]/page.tsx
+++ b/src/app/dashboard/auditorias/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Spinner from "@/components/Spinner";
 import { apiFetch } from "@lib/api";
 import { jsonOrNull } from "@lib/http";
+import AuditoriaDetailNavbar from "../components/AuditoriaDetailNavbar";
 
 export default function AuditoriaPage() {
   const params = useParams<{ id: string }>();
@@ -48,37 +49,32 @@ export default function AuditoriaPage() {
     return (
       <div className="p-4 space-y-2">
         <p className="text-red-500">No encontrado</p>
-        <button onClick={goBack} className="underline text-sm">
-          Volver
-        </button>
+        <button onClick={goBack} className="underline text-sm">Volver</button>
       </div>
     );
 
   return (
-    <div className="p-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Auditoría {data.id}</h1>
-        <button onClick={goBack} className="underline text-sm">
-          Volver
-        </button>
+    <>
+      <AuditoriaDetailNavbar />
+      <div className="p-4 space-y-4" style={{ paddingTop: 'calc(var(--navbar-height) * 2)' }}>
+        <div className="dashboard-card text-xs space-y-1">
+          <div>Tipo: {data.tipo}</div>
+          {data.unidad?.nombre && <div>Unidad: {data.unidad.nombre}</div>}
+          {data.material?.nombre && <div>Material: {data.material.nombre}</div>}
+          {data.almacen?.nombre && <div>Almacén: {data.almacen.nombre}</div>}
+          {data.observaciones && <div>{data.observaciones}</div>}
+          <div>{new Date(data.fecha).toLocaleString()}</div>
+          <pre className="overflow-auto bg-black/20 p-2 rounded">
+            {JSON.stringify(data, null, 2)}
+          </pre>
+          <button
+            onClick={() => navigator.clipboard.writeText(JSON.stringify(data))}
+            className="px-2 py-1 rounded bg-white/10 text-xs"
+          >
+            Copiar
+          </button>
+        </div>
       </div>
-      <div className="dashboard-card text-xs space-y-1">
-        <div>Tipo: {data.tipo}</div>
-        {data.unidad?.nombre && <div>Unidad: {data.unidad.nombre}</div>}
-        {data.material?.nombre && <div>Material: {data.material.nombre}</div>}
-        {data.almacen?.nombre && <div>Almacén: {data.almacen.nombre}</div>}
-        {data.observaciones && <div>{data.observaciones}</div>}
-        <div>{new Date(data.fecha).toLocaleString()}</div>
-        <pre className="overflow-auto bg-black/20 p-2 rounded">
-          {JSON.stringify(data, null, 2)}
-        </pre>
-        <button
-          onClick={() => navigator.clipboard.writeText(JSON.stringify(data))}
-          className="px-2 py-1 rounded bg-white/10 text-xs"
-        >
-          Copiar
-        </button>
-      </div>
-    </div>
+    </>
   );
 }

--- a/src/app/dashboard/auditorias/components/AuditoriaDetailNavbar.tsx
+++ b/src/app/dashboard/auditorias/components/AuditoriaDetailNavbar.tsx
@@ -1,0 +1,115 @@
+"use client";
+import { ArrowLeft, Download, FileText, RotateCcw } from "lucide-react";
+import Image from "next/image";
+import { useRouter, useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { apiFetch } from "@lib/api";
+import { jsonOrNull } from "@lib/http";
+import { useToast } from "@/components/Toast";
+import { NAVBAR_HEIGHT } from "../../constants";
+
+export default function AuditoriaDetailNavbar() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const id = Array.isArray(params?.id) ? params.id[0] : params?.id;
+  const toast = useToast();
+  const [title, setTitle] = useState<string>("Auditoría");
+  const [openExport, setOpenExport] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    apiFetch(`/api/auditorias/${id}`)
+      .then(jsonOrNull)
+      .then((d) => {
+        if (d?.auditoria?.id) {
+          setTitle(`Auditoría ${d.auditoria.id}`);
+        }
+      })
+      .catch(() => {});
+  }, [id]);
+
+  const volver = () => router.back();
+
+  const exportar = (formato: "pdf" | "excel") => {
+    window.open(`/api/auditorias/${id}/export?format=${formato}`, "_blank");
+  };
+
+  const respaldar = async () => {
+    if (!id) return;
+    const res = await apiFetch(`/api/auditorias/${id}`);
+    const data = await jsonOrNull(res);
+    if (!data?.auditoria) {
+      toast.show("Error al respaldar", "error");
+      return;
+    }
+    const blob = new Blob([JSON.stringify(data.auditoria, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `auditoria_${id}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const restaurar = async () => {
+    if (!id) return;
+    const ok = await toast.confirm("¿Restaurar elemento?");
+    if (!ok) return;
+    const res = await apiFetch(`/api/auditorias/${id}/restore`, { method: "POST" });
+    if (res.ok) toast.show("Restaurado", "success");
+    else toast.show("Error al restaurar", "error");
+  };
+
+  return (
+    <header
+      className="flex items-center justify-between h-[3.5rem] min-h-[3.5rem] px-3 md:px-4 border-b border-[var(--dashboard-border)] bg-[var(--dashboard-navbar)] fixed left-0 right-0 z-30"
+      style={{ top: NAVBAR_HEIGHT }}
+    >
+      <div className="flex items-center gap-3">
+        <button onClick={volver} className="p-2 text-gray-400 hover:bg-white/10 rounded-lg" title="Regresar">
+          <ArrowLeft className="w-5 h-5" />
+        </button>
+        <Image src="/logo-honeylabs.png" alt="HoneyLabs" width={28} height={28} className="rounded" />
+        <span className="font-semibold text-sm">HoneyLabs</span>
+      </div>
+      <span className="flex-1 mx-4 text-center text-white text-lg font-semibold truncate">
+        {title}
+      </span>
+      <div className="flex items-center gap-2 relative">
+        <div className="relative" onClick={(e) => e.stopPropagation()}>
+          <button
+            onClick={() => setOpenExport((o) => !o)}
+            className="p-2 hover:bg-white/10 rounded-lg"
+            title="Exportar"
+          >
+            <Download className="w-5 h-5" />
+          </button>
+          {openExport && (
+            <div className="absolute right-0 mt-2 bg-[var(--dashboard-sidebar)] border border-[var(--dashboard-border)] rounded shadow-md z-10">
+              {(["pdf", "excel"] as const).map((f) => (
+                <button
+                  key={f}
+                  onClick={() => {
+                    exportar(f);
+                    setOpenExport(false);
+                  }}
+                  className="block px-3 py-1 text-sm text-left hover:bg-white/5 w-full"
+                >
+                  {f.toUpperCase()}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <button onClick={respaldar} className="p-2 hover:bg-white/10 rounded-lg" title="Respaldar">
+          <FileText className="w-5 h-5" />
+        </button>
+        <button onClick={restaurar} className="p-2 hover:bg-white/10 rounded-lg" title="Restaurar">
+          <RotateCcw className="w-5 h-5" />
+        </button>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add `AuditoriaDetailNavbar` component with export, backup and restore actions
- integrate navbar into auditoria detail page

## Testing
- `pnpm run lint` *(fails: Unexpected any and other existing lint errors)*
- `pnpm run build` *(fails: Prisma datasource URL not set)*
- `pnpm test`

------
