### PR TITLE
Add usuario filter to auditorias

### DIFF
--- a/src/app/api/auditorias/route.ts
+++ b/src/app/api/auditorias/route.ts
@@ -15,6 +15,7 @@ export async function GET(req: NextRequest) {
     const almacenId = req.nextUrl.searchParams.get('almacenId') || undefined
     const materialId = req.nextUrl.searchParams.get('materialId') || undefined
     const unidadId = req.nextUrl.searchParams.get('unidadId') || undefined
+    const usuarioId = req.nextUrl.searchParams.get('usuarioId') || undefined
     const q = req.nextUrl.searchParams.get('q')?.toLowerCase() || undefined
     const desde = req.nextUrl.searchParams.get('desde') || undefined
     const hasta = req.nextUrl.searchParams.get('hasta') || undefined
@@ -23,6 +24,7 @@ export async function GET(req: NextRequest) {
     if (almacenId) where.almacenId = Number(almacenId)
     if (materialId) where.materialId = Number(materialId)
     if (unidadId) where.unidadId = Number(unidadId)
+    if (usuarioId) where.usuarioId = Number(usuarioId)
     if (categoria) where.categoria = categoria
     if (q) {
       where.OR = [

--- a/src/app/dashboard/auditorias/page.tsx
+++ b/src/app/dashboard/auditorias/page.tsx
@@ -4,6 +4,7 @@ import { FixedSizeList as VList } from "react-window";
 import { useRouter } from "next/navigation";
 import Spinner from "@/components/Spinner";
 import useAuditorias from "@/hooks/useAuditorias";
+import useAdminUsuarios from "@/hooks/useAdminUsuarios";
 import { apiFetch } from "@lib/api";
 
 export default function AuditoriasPage() {
@@ -13,7 +14,16 @@ export default function AuditoriasPage() {
   const [busqueda, setBusqueda] = useState("");
   const [desde, setDesde] = useState('');
   const [hasta, setHasta] = useState('');
-  const { auditorias, loading } = useAuditorias({ tipo, categoria, q: busqueda, desde, hasta });
+  const [usuarioId, setUsuarioId] = useState('todos');
+  const { usuarios } = useAdminUsuarios();
+  const { auditorias, loading } = useAuditorias({
+    tipo,
+    categoria,
+    q: busqueda,
+    desde,
+    hasta,
+    usuarioId: usuarioId !== 'todos' ? Number(usuarioId) : undefined,
+  });
   const [detalle, setDetalle] = useState<any | null>(null);
   const [activo, setActivo] = useState<number | null>(null);
 
@@ -95,6 +105,16 @@ export default function AuditoriasPage() {
           <option value="actualizacion">Actualizaciones</option>
           <option value="duplicacion">Duplicaciones</option>
         </select>
+        <select
+          value={usuarioId}
+          onChange={(e) => setUsuarioId(e.target.value)}
+          className="dashboard-input"
+        >
+          <option value="todos">Todos</option>
+          {usuarios.map((u) => (
+            <option key={u.id} value={u.id}>{u.nombre}</option>
+          ))}
+        </select>
         <button
           onClick={() => {
             setBusqueda('');
@@ -102,6 +122,7 @@ export default function AuditoriasPage() {
             setCategoria('todas');
             setDesde('');
             setHasta('');
+            setUsuarioId('todos');
           }}
           className="px-3 py-1 rounded bg-white/10 text-sm"
         >

--- a/src/hooks/useAuditorias.ts
+++ b/src/hooks/useAuditorias.ts
@@ -13,7 +13,7 @@ export interface Auditoria {
   unidad?: { nombre: string }
 }
 
-export default function useAuditorias(opts?: { tipo?: string, categoria?: string, q?: string, desde?: string, hasta?: string, almacenId?: number, materialId?: number, unidadId?: number }) {
+export default function useAuditorias(opts?: { tipo?: string, categoria?: string, q?: string, desde?: string, hasta?: string, almacenId?: number, materialId?: number, unidadId?: number, usuarioId?: number }) {
   const params = new URLSearchParams()
   if (opts?.tipo && opts.tipo !== 'todos') params.set('tipo', opts.tipo)
   if (opts?.categoria && opts.categoria !== 'todas') params.set('categoria', opts.categoria)
@@ -23,6 +23,7 @@ export default function useAuditorias(opts?: { tipo?: string, categoria?: string
   if (opts?.almacenId) params.set('almacenId', String(opts.almacenId))
   if (opts?.materialId) params.set('materialId', String(opts.materialId))
   if (opts?.unidadId) params.set('unidadId', String(opts.unidadId))
+  if (opts?.usuarioId) params.set('usuarioId', String(opts.usuarioId))
   const url = `/api/auditorias${params.toString() ? `?${params.toString()}` : ''}`
 
   const { data, error, isLoading, mutate } = useSWR(url, fetcher, {

--- a/tests/useAuditorias.test.ts
+++ b/tests/useAuditorias.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import useAuditorias from '../src/hooks/useAuditorias'
+import useSWR from 'swr'
+
+vi.mock('swr', () => ({ default: vi.fn() }))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+describe('useAuditorias', () => {
+  it('agrega usuarioId en la url', async () => {
+    const swr = useSWR as unknown as ReturnType<typeof vi.fn>
+    swr.mockReturnValue({ data: { auditorias: [] }, error: null, isLoading: false })
+    const { default: useAud } = await import('../src/hooks/useAuditorias')
+    useAud({ usuarioId: 5 })
+    expect(swr).toHaveBeenCalledWith('/api/auditorias?usuarioId=5', expect.any(Function), expect.any(Object))
+  })
+})


### PR DESCRIPTION
## Summary
- allow filtering auditorias by usuarioId in API and hook
- add usuario selector in auditorias dashboard page
- cover new hook behaviour with test

## Testing
- `pnpm test`
- `pnpm run build` *(fails: Error validating datasource `db` and SMTP env missing)*

------
