### PR TITLE
Add version tracking to auditorías

### DIFF
--- a/prisma/migrations/20250801000000_auditoria_version/migration.sql
+++ b/prisma/migrations/20250801000000_auditoria_version/migration.sql
@@ -1,0 +1,2 @@
+-- Agrega columna version para auditorias
+ALTER TABLE "Auditoria" ADD COLUMN "version" INTEGER NOT NULL DEFAULT 1;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -647,6 +647,7 @@ model Auditoria {
   almacenId     Int?
   materialId    Int?
   unidadId      Int?
+  version       Int      @default(1)
   observaciones String?
   categoria     String?
   fecha         DateTime @default(now())

--- a/src/app/api/auditorias/route.ts
+++ b/src/app/api/auditorias/route.ts
@@ -45,6 +45,7 @@ export async function GET(req: NextRequest) {
       select: {
         id: true,
         tipo: true,
+        version: true,
         categoria: true,
         fecha: true,
         observaciones: true,
@@ -106,6 +107,13 @@ export async function POST(req: NextRequest) {
     if (tipo === 'almacen') data.almacenId = Number(objetoId)
     if (tipo === 'material') data.materialId = Number(objetoId)
     if (tipo === 'unidad') data.unidadId = Number(objetoId)
+
+    const where: any = { tipo }
+    if (data.almacenId) where.almacenId = data.almacenId
+    if (data.materialId) where.materialId = data.materialId
+    if (data.unidadId) where.unidadId = data.unidadId
+    const count = await prisma.auditoria.count({ where })
+    data.version = count + 1
 
     const auditoria = await prisma.auditoria.create({ data, select: { id: true } })
 

--- a/src/app/dashboard/almacenes/[id]/AuditoriasPanel.tsx
+++ b/src/app/dashboard/almacenes/[id]/AuditoriasPanel.tsx
@@ -45,8 +45,9 @@ export default function AuditoriasPanel({ material, almacenId, unidadId, onSelec
               </span>
               <span className="text-xs">{new Date(a.fecha).toLocaleString()}</span>
             </div>
-            <div className="text-xs">
+          <div className="text-xs">
               <span className="mr-2 font-semibold">{a.categoria || a.tipo}</span>
+              <span className="mr-2">v{a.version}</span>
               {a.observaciones && <span>{a.observaciones}</span>}
             </div>
           </li>

--- a/src/app/dashboard/almacenes/components/AuditoriaForm.tsx
+++ b/src/app/dashboard/almacenes/components/AuditoriaForm.tsx
@@ -24,6 +24,7 @@ export default function AuditoriaForm({ auditoriaId, onClose }: Props) {
   return (
     <div className="space-y-2 text-sm p-2 overflow-y-auto max-h-[calc(100vh-8rem)]">
       <div>Tipo: {auditoria.tipo}</div>
+      <div>Versión: {auditoria.version}</div>
       {auditoria.categoria && <div>Categoría: {auditoria.categoria}</div>}
       {auditoria.almacen?.nombre && <div>Almacén: {auditoria.almacen.nombre}</div>}
       {auditoria.material?.nombre && <div>Material: {auditoria.material.nombre}</div>}

--- a/src/app/dashboard/auditorias/[id]/page.tsx
+++ b/src/app/dashboard/auditorias/[id]/page.tsx
@@ -59,6 +59,7 @@ export default function AuditoriaPage() {
       <div className="p-4 space-y-4" style={{ paddingTop: 'calc(var(--navbar-height) * 2)' }}>
         <div className="dashboard-card text-xs space-y-1">
           <div>Tipo: {data.tipo}</div>
+          <div>Versión: {data.version}</div>
           {data.unidad?.nombre && <div>Unidad: {data.unidad.nombre}</div>}
           {data.material?.nombre && <div>Material: {data.material.nombre}</div>}
           {data.almacen?.nombre && <div>Almacén: {data.almacen.nombre}</div>}

--- a/src/app/dashboard/auditorias/page.tsx
+++ b/src/app/dashboard/auditorias/page.tsx
@@ -166,6 +166,7 @@ export default function AuditoriasPage() {
               </div>
               <div className="text-xs">
                 <span className="font-semibold mr-2">{a.categoria || a.tipo}</span>
+                <span className="mr-2">v{a.version}</span>
                 {a.observaciones && <span className="mr-2">{a.observaciones}</span>}
                 {a.usuario?.nombre && <span className="mr-2">{a.usuario.nombre}</span>}
               </div>
@@ -176,6 +177,7 @@ export default function AuditoriasPage() {
       {detalle && (
         <div className="dashboard-card text-xs space-y-1">
           <div>Tipo: {detalle.tipo}</div>
+          <div>Versión: {detalle.version}</div>
           {detalle.unidad?.nombre && <div>Unidad: {detalle.unidad.nombre}</div>}
           {detalle.material?.nombre && <div>Material: {detalle.material.nombre}</div>}
           {detalle.almacen?.nombre && <div>Almacén: {detalle.almacen.nombre}</div>}

--- a/src/app/dashboard/timeline/page.tsx
+++ b/src/app/dashboard/timeline/page.tsx
@@ -7,6 +7,7 @@ interface Evento {
   id: number;
   fecha: string;
   observaciones: string | null;
+  version: number;
   usuario?: { nombre: string } | null;
   almacen?: { nombre: string } | null;
   material?: { nombre: string } | null;
@@ -56,6 +57,7 @@ export default function TimelinePage() {
             {activo === e.id && (
               <div className="mt-1 text-xs space-y-1">
                 {e.observaciones && <div>{e.observaciones}</div>}
+                <div>Versión: {e.version}</div>
                 {e.usuario?.nombre && <div>Usuario: {e.usuario.nombre}</div>}
               </div>
             )}

--- a/src/hooks/useAuditorias.ts
+++ b/src/hooks/useAuditorias.ts
@@ -4,6 +4,7 @@ import fetcher from '@lib/swrFetcher'
 export interface Auditoria {
   id: number
   tipo: string
+  version: number
   categoria?: string | null
   fecha: string
   observaciones?: string | null


### PR DESCRIPTION
## Summary
- keep versioning of auditorías in Prisma schema and new migration
- calculate version when creating auditoría
- expose `version` in API and React hook
- show version in dashboard UI

## Testing
- `pnpm run build` *(fails: InvalidDatasourceError)*
- `pnpm test`

------
