### PR TITLE
Add mass deletion alert and SSE refresh

### DIFF
--- a/src/app/api/almacenes/[id]/materiales/route.ts
+++ b/src/app/api/almacenes/[id]/materiales/route.ts
@@ -11,6 +11,7 @@ import * as logger from '@lib/logger'
 import { logAudit } from '@/lib/audit'
 import { registrarAuditoria } from '@lib/reporter'
 import { snapshotMaterial } from '@/lib/snapshot'
+import { emitEvent } from '@/lib/events'
 
 
 function getAlmacenIdFromRequest(req: NextRequest): number | null {
@@ -242,6 +243,17 @@ export async function DELETE(req: NextRequest) {
       'eliminacion',
       { accion: 'vaciar_materiales' },
     )
+
+    await prisma.alerta.create({
+      data: {
+        titulo: 'Eliminación masiva de materiales',
+        mensaje: 'Se eliminaron todos los materiales del almacén',
+        prioridad: 'ALTA',
+        tipo: 'eliminacion_masiva',
+        almacenId,
+      },
+    })
+    emitEvent({ type: 'alertas_update', payload: { almacenId } })
 
     return NextResponse.json({ success: true, auditoria, auditError })
   } catch (err) {

--- a/src/hooks/useAlertasUpdates.ts
+++ b/src/hooks/useAlertasUpdates.ts
@@ -1,0 +1,37 @@
+export function startAlertasUpdates(
+  onUpdate: () => void,
+  maxRetries = 5,
+) {
+  let es: EventSource
+  let retry = 1
+  let attempts = 0
+  const connect = () => {
+    es = new EventSource('/api/events')
+    es.addEventListener('open', () => {
+      retry = 1
+      attempts = 0
+    })
+    es.onmessage = (e) => {
+      try {
+        const ev = JSON.parse(e.data)
+        if (ev.type === 'alertas_update') {
+          onUpdate()
+        }
+      } catch {}
+    }
+    es.onerror = async () => {
+      es.close()
+      attempts += 1
+      try {
+        const r = await fetch('/api/events', { method: 'HEAD' })
+        if (r.status === 401) return
+      } catch {}
+      if (attempts <= maxRetries) {
+        setTimeout(connect, retry * 1000)
+        retry = Math.min(retry * 2, 30)
+      }
+    }
+  }
+  connect()
+  return () => es.close()
+}


### PR DESCRIPTION
## Summary
- trigger alert creation on DELETE /api/almacenes/[id]/materiales
- emit `alertas_update` SSE event
- listen for SSE in `AlertasWidget`
- provide helper to subscribe to alert updates

## Testing
- `pnpm run build` *(fails: SMTP_USER o SMTP_PASS faltantes)*
- `pnpm test`

------
