### PR TITLE
Add auditoria export endpoint and download utils

### DIFF
--- a/src/app/api/auditorias/[id]/export/route.ts
+++ b/src/app/api/auditorias/[id]/export/route.ts
@@ -1,0 +1,108 @@
+export const runtime = 'nodejs'
+
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@lib/prisma'
+import { getUsuarioFromSession } from '@lib/auth'
+import PDFDocument from 'pdfkit'
+import ExcelJS from 'exceljs'
+import * as logger from '@lib/logger'
+
+function getAuditoriaId(req: NextRequest): number | null {
+  const parts = req.nextUrl.pathname.split('/')
+  const idx = parts.findIndex(p => p === 'auditorias')
+  const id = idx !== -1 && parts.length > idx + 1 ? Number(parts[idx + 1]) : null
+  return id && !Number.isNaN(id) ? id : null
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const usuario = await getUsuarioFromSession(req)
+    if (!usuario) return new NextResponse('No autenticado', { status: 401 })
+    const id = getAuditoriaId(req)
+    if (!id) return new NextResponse('ID inválido', { status: 400 })
+    const auditoria = await prisma.auditoria.findUnique({
+      where: { id },
+      include: {
+        usuario: { select: { nombre: true } },
+        almacen: { select: { nombre: true } },
+        material: { select: { nombre: true } },
+        unidad: { select: { nombre: true } },
+        archivos: { select: { nombre: true } },
+      },
+    })
+    if (!auditoria) return new NextResponse('No encontrado', { status: 404 })
+    const url = new URL(req.url)
+    const format = (url.searchParams.get('format') || 'json').toLowerCase()
+    const baseData: any = {
+      tipo: auditoria.tipo,
+      version: auditoria.version,
+      categoria: auditoria.categoria,
+      fecha: auditoria.fecha,
+      observaciones: auditoria.observaciones,
+      usuario: auditoria.usuario?.nombre,
+      almacen: auditoria.almacen?.nombre,
+      material: auditoria.material?.nombre,
+      unidad: auditoria.unidad?.nombre,
+      archivos: auditoria.archivos.map(a => a.nombre),
+    }
+
+    if (format === 'pdf') {
+      const doc = new PDFDocument()
+      const chunks: Buffer[] = []
+      doc.fontSize(16).text(`Auditor\xeda ${id}`)
+      doc.moveDown()
+      Object.entries(baseData).forEach(([k, v]) => {
+        if (Array.isArray(v)) return
+        if (v != null) doc.fontSize(12).text(`${k}: ${String(v)}`)
+      })
+      doc.end()
+      for await (const c of doc) chunks.push(c as Buffer)
+      const buffer = Buffer.concat(chunks)
+      return new NextResponse(buffer, {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/pdf',
+          'Content-Disposition': `attachment; filename=auditoria_${id}.pdf`,
+        },
+      })
+    }
+
+    if (format === 'excel') {
+      const wb = new ExcelJS.Workbook()
+      const ws = wb.addWorksheet('Auditoria')
+      ws.addRow(['Campo', 'Valor'])
+      Object.entries(baseData).forEach(([k, v]) => {
+        if (Array.isArray(v)) return
+        ws.addRow([k, v as any])
+      })
+      const buffer = await wb.xlsx.writeBuffer()
+      return new NextResponse(buffer, {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          'Content-Disposition': `attachment; filename=auditoria_${id}.xlsx`,
+        },
+      })
+    }
+
+    if (format === 'csv') {
+      const csv = Object.entries(baseData)
+        .filter(([, v]) => !Array.isArray(v))
+        .map(([k, v]) => `${k},"${String(v ?? '').replace(/\"/g, '""')}"`)
+        .join('\n')
+      return new NextResponse(csv, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/csv',
+          'Content-Disposition': `attachment; filename=auditoria_${id}.csv`,
+        },
+      })
+    }
+
+    // json por defecto
+    return NextResponse.json(baseData)
+  } catch (err) {
+    logger.error('GET /api/auditorias/[id]/export', err)
+    return new NextResponse('Error', { status: 500 })
+  }
+}

--- a/src/app/dashboard/auditorias/components/AuditoriaDetailNavbar.tsx
+++ b/src/app/dashboard/auditorias/components/AuditoriaDetailNavbar.tsx
@@ -5,6 +5,7 @@ import { useRouter, useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { apiFetch } from "@lib/api";
 import { jsonOrNull } from "@lib/http";
+import { fetchAuditoriaExport } from "@/app/dashboard/utils/auditoriaExport";
 import { useToast } from "@/components/Toast";
 import { NAVBAR_HEIGHT } from "../../constants";
 
@@ -30,8 +31,13 @@ export default function AuditoriaDetailNavbar() {
 
   const volver = () => router.back();
 
-  const exportar = (formato: "pdf" | "excel") => {
-    window.open(`/api/auditorias/${id}/export?format=${formato}`, "_blank");
+  const exportar = async (formato: "pdf" | "excel" | "csv" | "json") => {
+    if (!id) return;
+    try {
+      await fetchAuditoriaExport(id, formato);
+    } catch {
+      toast.show("Error al exportar", "error");
+    }
   };
 
   const respaldar = async () => {
@@ -88,7 +94,7 @@ export default function AuditoriaDetailNavbar() {
           </button>
           {openExport && (
             <div className="absolute right-0 mt-2 bg-[var(--dashboard-sidebar)] border border-[var(--dashboard-border)] rounded shadow-md z-10">
-              {(["pdf", "excel"] as const).map((f) => (
+              {(["pdf", "excel", "csv", "json"] as const).map((f) => (
                 <button
                   key={f}
                   onClick={() => {

--- a/src/app/dashboard/utils/auditoriaExport.ts
+++ b/src/app/dashboard/utils/auditoriaExport.ts
@@ -1,0 +1,23 @@
+"use client"
+
+import { apiFetch } from '@lib/api'
+
+export const triggerDownload = (blob: Blob, filename: string) => {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+export const fetchAuditoriaExport = async (
+  id: string | number,
+  formato: 'pdf' | 'excel' | 'csv' | 'json'
+) => {
+  const res = await apiFetch(`/api/auditorias/${id}/export?format=${formato}`)
+  if (!res.ok) throw new Error('Export failed')
+  const blob = await res.blob()
+  const ext = formato === 'excel' ? 'xlsx' : formato
+  triggerDownload(blob, `auditoria_${id}.${ext}`)
+}


### PR DESCRIPTION
## Summary
- export auditoria data in several formats
- helper to download exported auditoria files
- integrate export menu in auditoria detail navbar

## Testing
- `pnpm run build` *(fails: InvalidDatasourceError, SMTP env vars missing)*
- `pnpm test`

------
