### PR TITLE
fix auditoria compat without version

### DIFF
--- a/src/app/api/auditorias/[id]/export/route.ts
+++ b/src/app/api/auditorias/[id]/export/route.ts
@@ -35,7 +35,8 @@ export async function GET(req: NextRequest) {
     const format = (url.searchParams.get('format') || 'json').toLowerCase()
     const baseData: any = {
       tipo: auditoria.tipo,
-      version: auditoria.version,
+      // "version" puede no estar disponible según la versión del cliente
+      version: auditoria.version ?? 1,
       categoria: auditoria.categoria,
       fecha: auditoria.fecha,
       observaciones: auditoria.observaciones,

--- a/src/app/api/auditorias/route.ts
+++ b/src/app/api/auditorias/route.ts
@@ -42,10 +42,10 @@ export async function GET(req: NextRequest) {
       take: 50,
       orderBy: { fecha: 'desc' },
       where,
+      // "version" se excluye para compatibilidad con clientes antiguos
       select: {
         id: true,
         tipo: true,
-        version: true,
         categoria: true,
         fecha: true,
         observaciones: true,

--- a/src/app/dashboard/almacenes/[id]/AuditoriasPanel.tsx
+++ b/src/app/dashboard/almacenes/[id]/AuditoriasPanel.tsx
@@ -51,7 +51,9 @@ export default function AuditoriasPanel({ material, almacenId, unidadId, onSelec
             </div>
           <div className="text-xs">
               <span className="mr-2 font-semibold">{a.categoria || a.tipo}</span>
-              <span className="mr-2">v{a.version}</span>
+              {a.version != null && (
+                <span className="mr-2">v{a.version}</span>
+              )}
               {a.observaciones && <span>{a.observaciones}</span>}
             </div>
           </li>

--- a/src/app/dashboard/almacenes/components/AuditoriaForm.tsx
+++ b/src/app/dashboard/almacenes/components/AuditoriaForm.tsx
@@ -24,7 +24,7 @@ export default function AuditoriaForm({ auditoriaId, onClose }: Props) {
   return (
     <div className="space-y-2 text-sm p-2 overflow-y-auto max-h-[calc(100vh-8rem)]">
       <div>Tipo: {auditoria.tipo}</div>
-      <div>Versión: {auditoria.version}</div>
+      {auditoria.version != null && <div>Versión: {auditoria.version}</div>}
       {auditoria.categoria && <div>Categoría: {auditoria.categoria}</div>}
       {auditoria.almacen?.nombre && <div>Almacén: {auditoria.almacen.nombre}</div>}
       {auditoria.material?.nombre && <div>Material: {auditoria.material.nombre}</div>}

--- a/src/app/dashboard/auditorias/[id]/page.tsx
+++ b/src/app/dashboard/auditorias/[id]/page.tsx
@@ -101,7 +101,7 @@ export default function AuditoriaPage() {
       <div className="p-4 space-y-4" style={{ paddingTop: 'calc(var(--navbar-height) * 2)' }}>
         <div className="dashboard-card text-xs space-y-1">
           <div>Tipo: {data.tipo}</div>
-          <div>Versión: {data.version}</div>
+          {data.version != null && <div>Versión: {data.version}</div>}
           {data.unidad?.nombre && <div>Unidad: {data.unidad.nombre}</div>}
           {data.material?.nombre && <div>Material: {data.material.nombre}</div>}
           {data.almacen?.nombre && <div>Almacén: {data.almacen.nombre}</div>}

--- a/src/app/dashboard/auditorias/page.tsx
+++ b/src/app/dashboard/auditorias/page.tsx
@@ -166,7 +166,9 @@ export default function AuditoriasPage() {
               </div>
               <div className="text-xs">
                 <span className="font-semibold mr-2">{a.categoria || a.tipo}</span>
-                <span className="mr-2">v{a.version}</span>
+                {a.version != null && (
+                  <span className="mr-2">v{a.version}</span>
+                )}
                 {a.observaciones && <span className="mr-2">{a.observaciones}</span>}
                 {a.usuario?.nombre && <span className="mr-2">{a.usuario.nombre}</span>}
               </div>
@@ -177,7 +179,7 @@ export default function AuditoriasPage() {
       {detalle && (
         <div className="dashboard-card text-xs space-y-1">
           <div>Tipo: {detalle.tipo}</div>
-          <div>Versión: {detalle.version}</div>
+          {detalle.version != null && <div>Versión: {detalle.version}</div>}
           {detalle.unidad?.nombre && <div>Unidad: {detalle.unidad.nombre}</div>}
           {detalle.material?.nombre && <div>Material: {detalle.material.nombre}</div>}
           {detalle.almacen?.nombre && <div>Almacén: {detalle.almacen.nombre}</div>}

--- a/src/app/dashboard/timeline/page.tsx
+++ b/src/app/dashboard/timeline/page.tsx
@@ -7,7 +7,7 @@ interface Evento {
   id: number;
   fecha: string;
   observaciones: string | null;
-  version: number;
+  version?: number;
   usuario?: { nombre: string } | null;
   almacen?: { nombre: string } | null;
   material?: { nombre: string } | null;
@@ -57,7 +57,7 @@ export default function TimelinePage() {
             {activo === e.id && (
               <div className="mt-1 text-xs space-y-1">
                 {e.observaciones && <div>{e.observaciones}</div>}
-                <div>Versión: {e.version}</div>
+                {e.version != null && <div>Versión: {e.version}</div>}
                 {e.usuario?.nombre && <div>Usuario: {e.usuario.nombre}</div>}
               </div>
             )}

--- a/src/hooks/useAuditorias.ts
+++ b/src/hooks/useAuditorias.ts
@@ -4,7 +4,7 @@ import fetcher from '@lib/swrFetcher'
 export interface Auditoria {
   id: number
   tipo: string
-  version: number
+  version?: number
   categoria?: string | null
   fecha: string
   observaciones?: string | null


### PR DESCRIPTION
## Summary
- omit `version` from auditorias query to avoid Prisma mismatch
- make auditoria `version` optional in hooks
- handle optional version in dashboard views
- fallback when exporting an auditoria

## Testing
- `pnpm run build` *(fails: InvalidDatasourceError)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6888092c46fc83288d3909879c0dd970