### PR TITLE
Add version column check for auditoria init

### DIFF
--- a/tests/auditoriaInit.test.ts
+++ b/tests/auditoriaInit.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+describe('ensureAuditoriaTables', () => {
+  it('crea tablas con columna version', async () => {
+    const query = vi.fn().mockResolvedValue([{ exists: false }])
+    const exec = vi.fn()
+    const prismaMock = { $queryRaw: query, $executeRawUnsafe: exec }
+    vi.doMock('../lib/prisma', () => ({ default: prismaMock }))
+    const { ensureAuditoriaTables } = await import('../lib/auditoriaInit')
+
+    await ensureAuditoriaTables()
+
+    expect(exec).toHaveBeenCalledWith(
+      expect.stringContaining('"version" INTEGER NOT NULL DEFAULT 1')
+    )
+    vi.unmock('../lib/prisma')
+  })
+})


### PR DESCRIPTION
## Summary
- create `version` column in `Auditoria` tables by default
- patch `ensureAuditoriaTables` to add the column if missing
- cover initialization logic with a new test

## Testing
- `pnpm test`
- `pnpm run build` *(fails: Failed to collect page data)*

------
https://chatgpt.com/codex/tasks/task_e_68881af5aab08328b4da74553ceb7440