### PR TITLE
Add auditoria_new event and hook

### DIFF
--- a/src/app/api/auditorias/route.ts
+++ b/src/app/api/auditorias/route.ts
@@ -6,6 +6,7 @@ import { Prisma } from '@prisma/client'
 import { getUsuarioFromSession } from '@lib/auth'
 import * as logger from '@lib/logger'
 import { ensureAuditoriaTables } from '@lib/auditoriaInit'
+import { emitEvent } from '@/lib/events'
 
 export async function GET(req: NextRequest) {
   try {
@@ -143,6 +144,7 @@ export async function POST(req: NextRequest) {
         })
       )
     }
+    emitEvent({ type: 'auditoria_new', payload: { id: auditoria.id } })
 
     return NextResponse.json({ auditoria })
   } catch (err) {

--- a/src/app/dashboard/almacenes/[id]/AuditoriasPanel.tsx
+++ b/src/app/dashboard/almacenes/[id]/AuditoriasPanel.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import useAuditorias from "@/hooks/useAuditorias";
+import useAuditoriasUpdates from "@/hooks/useAuditoriasUpdates";
 
 interface Props {
   material: { dbId: number; nombre: string } | null;
@@ -17,7 +18,8 @@ export default function AuditoriasPanel({ material, almacenId, unidadId, onSelec
   if (tipo === 'material') opts.materialId = material?.dbId
   else if (tipo === 'unidad') opts.unidadId = unidadId
   else opts.almacenId = almacenId
-  const { auditorias } = useAuditorias(opts)
+  const { auditorias, mutate } = useAuditorias(opts)
+  useAuditoriasUpdates(mutate)
   const [activo, setActivo] = useState<number | null>(null);
   const router = useRouter();
 

--- a/src/app/dashboard/auditorias/page.tsx
+++ b/src/app/dashboard/auditorias/page.tsx
@@ -4,6 +4,7 @@ import { FixedSizeList as VList } from "react-window";
 import { useRouter } from "next/navigation";
 import Spinner from "@/components/Spinner";
 import useAuditorias from "@/hooks/useAuditorias";
+import useAuditoriasUpdates from "@/hooks/useAuditoriasUpdates";
 import useAdminUsuarios from "@/hooks/useAdminUsuarios";
 import { apiFetch } from "@lib/api";
 
@@ -16,7 +17,7 @@ export default function AuditoriasPage() {
   const [hasta, setHasta] = useState('');
   const [usuarioId, setUsuarioId] = useState('todos');
   const { usuarios } = useAdminUsuarios();
-  const { auditorias, loading } = useAuditorias({
+  const { auditorias, loading, mutate } = useAuditorias({
     tipo,
     categoria,
     q: busqueda,
@@ -24,6 +25,7 @@ export default function AuditoriasPage() {
     hasta,
     usuarioId: usuarioId !== 'todos' ? Number(usuarioId) : undefined,
   });
+  useAuditoriasUpdates(mutate)
   const [detalle, setDetalle] = useState<any | null>(null);
   const [activo, setActivo] = useState<number | null>(null);
 

--- a/src/hooks/useAuditoriasUpdates.ts
+++ b/src/hooks/useAuditoriasUpdates.ts
@@ -1,0 +1,48 @@
+import { useEffect } from 'react'
+import { API_EVENTS } from '@lib/apiPaths'
+
+export function startAuditoriasUpdates(
+  onUpdate: () => void,
+  maxRetries = 5,
+) {
+  let es: EventSource
+  let retry = 1
+  let attempts = 0
+  const connect = () => {
+    es = new EventSource(API_EVENTS)
+    es.addEventListener('open', () => {
+      retry = 1
+      attempts = 0
+    })
+    es.onmessage = (e) => {
+      try {
+        const ev = JSON.parse(e.data)
+        if (ev.type === 'auditoria_new') {
+          onUpdate()
+        }
+      } catch {}
+    }
+    es.onerror = async () => {
+      es.close()
+      attempts += 1
+      try {
+        const r = await fetch(API_EVENTS, { method: 'HEAD' })
+        if (r.status === 401) return
+      } catch {}
+      if (attempts <= maxRetries) {
+        setTimeout(connect, retry * 1000)
+        retry = Math.min(retry * 2, 30)
+      }
+    }
+  }
+  connect()
+  return () => es.close()
+}
+
+export default function useAuditoriasUpdates(onUpdate: () => void) {
+  useEffect(() => {
+    if (!onUpdate) return
+    const stop = startAuditoriasUpdates(onUpdate)
+    return stop
+  }, [onUpdate])
+}

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,5 +1,9 @@
 import { EventEmitter } from 'events'
 
+// Tipos de evento emitidos por la aplicación.
+// - 'usuarios_update': cambios en los usuarios de un almacén.
+// - 'alertas_update': se generó o modificó una alerta.
+// - 'auditoria_new': creación de una auditoría.
 export type AppEvent = { type: string; payload?: any }
 
 export const events = new EventEmitter()

--- a/tests/useAuditoriasUpdates.test.ts
+++ b/tests/useAuditoriasUpdates.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { startAuditoriasUpdates } from '../src/hooks/useAuditoriasUpdates'
+
+class MockES {
+  static instances: MockES[] = []
+  onmessage?: (e: { data: string }) => void
+  constructor(public url: string) { MockES.instances.push(this) }
+  addEventListener() {}
+  close() {}
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  MockES.instances = []
+})
+
+describe('auditorias updates', () => {
+  it('invoca mutate cuando llega auditoria_new', () => {
+    // @ts-ignore
+    global.EventSource = MockES
+    const mutate = vi.fn()
+    startAuditoriasUpdates(mutate)
+    const msg = JSON.stringify({ type: 'auditoria_new', payload: { id: 1 } })
+    MockES.instances[0].onmessage?.({ data: msg } as any)
+    expect(mutate).toHaveBeenCalled()
+  })
+
+  it('ignora otros eventos', () => {
+    // @ts-ignore
+    global.EventSource = MockES
+    const mutate = vi.fn()
+    startAuditoriasUpdates(mutate)
+    const msg = JSON.stringify({ type: 'otro' })
+    MockES.instances[0].onmessage?.({ data: msg } as any)
+    expect(mutate).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- document new `auditoria_new` event type
- emit `auditoria_new` when an auditoria is created
- add `useAuditoriasUpdates` hook to refresh data from SSE
- refresh auditorias panel and page using the new hook
- test event handling for the new hook

## Testing
- `pnpm run build` *(fails: Command failed with exit code 1)*
- `pnpm test`

------
