### PR TITLE
Fix Prisma generate step and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Configura las variables de entorno copiando `.env.example` a `.env`.
 Debes definir `DATABASE_URL` con la URL de Prisma Accelerate y
 `DIRECT_DB_URL` con la conexión directa usada en las migraciones.
 
+Tras modificar `prisma/schema.prisma` ejecuta `pnpm install` o
+`pnpm prisma generate` para actualizar el cliente de Prisma.
+
 ---
 
 ## Uso

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "gen:dev": "node scripts/gen-dev.js",
     "prisma:gen:prod": "prisma generate --data-proxy",
     "dev": "pnpm gen:dev && next dev",
-    "postinstall": "prisma generate",
+    "postinstall": "pnpm gen:dev",
     "build": "pnpm prisma:gen:prod && next build",
     "start": "next start",
     "lint": "next lint",

--- a/tests/prismaTypes.test.ts
+++ b/tests/prismaTypes.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+
+describe('prisma types', () => {
+  it('AuditoriaCreateInput tiene propiedad version', () => {
+    const input: import('@prisma/client').Prisma.AuditoriaCreateInput = {
+      tipo: 'almacen',
+      version: 1,
+    }
+    expect(input).toHaveProperty('version')
+  })
+})


### PR DESCRIPTION
## Summary
- run Prisma generate in `postinstall` via `gen:dev`
- clarify when to regenerate Prisma client
- check Prisma types for `version` field

## Testing
- `pnpm run build` *(fails: Invalid datasource; missing SMTP creds)*
- `pnpm test`

------
