### PR TITLE
fix auditorias panel for almacen

### DIFF
--- a/src/app/dashboard/almacenes/components/tabs/AuditoriasTab.tsx
+++ b/src/app/dashboard/almacenes/components/tabs/AuditoriasTab.tsx
@@ -2,11 +2,15 @@
 import AuditoriasPanel from '../../[id]/AuditoriasPanel'
 import { useBoard } from '../../board/BoardProvider'
 import { useTabHelpers } from '@/hooks/useTabHelpers'
+import { useParams } from 'next/navigation'
+import { parseId } from '@/lib/parseId'
 
 export default function AuditoriasTab() {
   const { materiales, selectedId, setAuditoriaSel } = useBoard()
   const material = materiales.find(m => m.id === selectedId) || null
   const { ensureTab } = useTabHelpers()
+  const { id } = useParams()
+  const almacenId = parseId(id)
 
   const openAuditoria = (entry: any) => {
     if (!entry?.id) return
@@ -15,6 +19,10 @@ export default function AuditoriasTab() {
   }
 
   return (
-    <AuditoriasPanel material={material} almacenId={0} onSelectHistorial={openAuditoria} />
+    <AuditoriasPanel
+      material={material}
+      almacenId={almacenId ?? undefined}
+      onSelectHistorial={openAuditoria}
+    />
   )
 }


### PR DESCRIPTION
## Summary
- use current almacen id when showing audit history within tab panels

## Testing
- `pnpm run build` *(fails: InvalidDatasourceError and missing SMTP variables)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6888f1df65348328b4b048e025d8c9f2