### PR TITLE
feat: motivo obligatorio al eliminar objetos

### DIFF
--- a/src/app/api/almacenes/[id]/route.ts
+++ b/src/app/api/almacenes/[id]/route.ts
@@ -149,6 +149,12 @@ export async function DELETE(req: NextRequest) {
   if (!pertenece && !hasManagePerms(usuario)) {
       return NextResponse.json({ error: 'Sin permisos' }, { status: 403 });
     }
+  let motivo = ''
+  try {
+    const body = await req.json()
+    motivo = String(body?.motivo ?? '').trim()
+  } catch {}
+
   await prisma.$transaction(async tx => {
       await snapshotAlmacen(tx, id, usuario.id, 'Eliminación')
       await tx.usuarioAlmacen.deleteMany({ where: { almacenId: id } })
@@ -174,7 +180,7 @@ export async function DELETE(req: NextRequest) {
     'almacen',
     id,
     'eliminacion',
-    {},
+    { motivo },
   )
     return NextResponse.json({ success: true, auditoria, auditError });
   } catch (err) {

--- a/src/app/api/materiales/[id]/route.ts
+++ b/src/app/api/materiales/[id]/route.ts
@@ -164,6 +164,12 @@ export async function DELETE(req: NextRequest) {
     if (!pertenece && !hasManagePerms(usuario)) {
       return NextResponse.json({ error: 'Sin permisos' }, { status: 403 })
     }
+    let motivo = ''
+    try {
+      const body = await req.json()
+      motivo = String(body?.motivo ?? '').trim()
+    } catch {}
+
     await prisma.$transaction(async (tx) => {
       await snapshotMaterial(tx, id, usuario.id, 'Eliminación')
       await tx.historialLote.deleteMany({ where: { materialId: id } })
@@ -177,7 +183,7 @@ export async function DELETE(req: NextRequest) {
       'material',
       id,
       'eliminacion',
-      {},
+      { motivo },
     )
     return NextResponse.json({ success: true, auditoria, auditError })
   } catch (err) {

--- a/src/app/api/materiales/[id]/unidades/[unidadId]/route.ts
+++ b/src/app/api/materiales/[id]/unidades/[unidadId]/route.ts
@@ -192,6 +192,11 @@ export async function DELETE(req: NextRequest) {
     if (!pertenece && !hasManagePerms(usuario)) {
       return NextResponse.json({ error: 'Sin permisos' }, { status: 403 })
     }
+    let motivo = ''
+    try {
+      const body = await req.json()
+      motivo = String(body?.motivo ?? '').trim()
+    } catch {}
     await snapshotUnidad(prisma, unidadId, usuario.id, 'Eliminación')
     await prisma.materialUnidad.delete({ where: { id: unidadId } })
     await logAudit(usuario.id, 'eliminacion_unidad', 'material', { materialId, unidadId })
@@ -201,7 +206,7 @@ export async function DELETE(req: NextRequest) {
       'unidad',
       unidadId,
       'eliminacion',
-      {},
+      { motivo },
     )
 
     return NextResponse.json({ success: true, auditoria, auditError })

--- a/src/app/dashboard/almacenes/[id]/UnidadesPanel.tsx
+++ b/src/app/dashboard/almacenes/[id]/UnidadesPanel.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react";
 import type { Material } from "../components/MaterialRow";
 import useUnidades, { type Unidad as UnidadAPI } from "@/hooks/useUnidades";
 import { useToast } from "@/components/Toast";
+import { usePrompt } from "@/hooks/usePrompt";
 import useObjectUrl from "@/hooks/useObjectUrl";
 import { apiPath } from "@lib/api";
 
@@ -23,6 +24,7 @@ export default function UnidadesPanel({
   const [busqueda, setBusqueda] = useState("");
   const { unidades, crear, eliminar } = useUnidades(material?.dbId);
   const toast = useToast();
+  const prompt = usePrompt();
 
   const add = async () => {
     const v = value.trim()
@@ -47,9 +49,9 @@ export default function UnidadesPanel({
   };
 
   const remove = async (id: number) => {
-    const ok = await toast.confirm('¿Eliminar unidad?')
-    if (!ok) return
-    const res = await eliminar(id)
+    const motivo = await prompt('Motivo de eliminación')
+    if (!motivo) return
+    const res = await eliminar(id, motivo)
     if (res.success) toast.show('Unidad eliminada', 'success')
     else if (res.error) toast.show(res.error, 'error')
   };

--- a/src/app/dashboard/almacenes/board/BoardProvider.tsx
+++ b/src/app/dashboard/almacenes/board/BoardProvider.tsx
@@ -17,7 +17,7 @@ interface BoardState {
   error: any;
   crear: (m: Material) => Promise<any>;
   actualizar: (m: Material) => Promise<any>;
-  eliminar: (id: number) => Promise<any>;
+  eliminar: (id: number, motivo?: string) => Promise<any>;
   duplicar: (id: number) => Promise<any>;
   mutate: () => void;
 }

--- a/src/app/dashboard/almacenes/components/tabs/MaterialFormTab.tsx
+++ b/src/app/dashboard/almacenes/components/tabs/MaterialFormTab.tsx
@@ -6,12 +6,14 @@ import { useCallback, useEffect, useState } from 'react'
 import { generarUUID } from '@/lib/uuid'
 import { useToast } from '@/components/Toast'
 import { parseId } from '@/lib/parseId'
+import { usePrompt } from '@/hooks/usePrompt'
 
 export default function MaterialFormTab({ tabId }: { tabId: string }) {
   const { selectedId, materiales, setSelectedId, eliminar, mutate, crear, actualizar } = useBoard()
   const baseMat = materiales.find(m => m.id === selectedId) || null
   const { close } = useTabStore()
   const toast = useToast()
+  const prompt = usePrompt()
   const [draft, setDraft] = useState(baseMat)
 
   useEffect(() => {
@@ -24,9 +26,9 @@ export default function MaterialFormTab({ tabId }: { tabId: string }) {
       toast.show('ID inválido', 'error')
       return
     }
-    const ok = await toast.confirm('¿Eliminar material?')
-    if (!ok) return
-    const res = await eliminar(id)
+    const motivo = await prompt('Motivo de eliminación')
+    if (!motivo) return
+    const res = await eliminar(id, motivo)
     if (res?.error) toast.show(res.error, 'error')
     else toast.show('Material eliminado', 'success')
     mutate()

--- a/src/hooks/useAlmacenesLogic.ts
+++ b/src/hooks/useAlmacenesLogic.ts
@@ -3,6 +3,7 @@ import { jsonOrNull } from '@lib/http'
 import { apiFetch } from '@lib/api'
 import { DragStartEvent, DragOverEvent, DragEndEvent } from '@dnd-kit/core'
 import { useToast } from '@/components/Toast'
+import { usePrompt } from '@/hooks/usePrompt'
 import useSession from '@/hooks/useSession'
 import useAlmacenes, { Almacen } from '@/hooks/useAlmacenes'
 import { getMainRole, normalizeTipoCuenta } from '@lib/permisos'
@@ -20,6 +21,7 @@ export default function useAlmacenesLogic() {
   const { usuario, loading: loadingUsuario } = useSession()
   const { filter, registerCreate } = useAlmacenesUI()
   const toast = useToast()
+  const prompt = usePrompt()
 
   const [almacenes, setAlmacenes] = useState<Almacen[]>([])
   const [error, setError] = useState('')
@@ -101,9 +103,13 @@ export default function useAlmacenesLogic() {
 
   const eliminar = useCallback(
     async (id: number) => {
-      const ok = await toast.confirm('¿Eliminar almacén?')
-      if (!ok) return
-      const res = await apiFetch(`/api/almacenes/${id}`, { method: 'DELETE' })
+      const motivo = await prompt('Motivo de eliminación')
+      if (!motivo) return
+      const res = await apiFetch(`/api/almacenes/${id}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ motivo }),
+      })
       if (res.ok) {
         mutate()
         toast.show('Almacén eliminado', 'success')

--- a/src/hooks/useMateriales.ts
+++ b/src/hooks/useMateriales.ts
@@ -131,9 +131,14 @@ export default function useMateriales(almacenId?: number | string) {
     }
   }
 
-  const eliminar = async (materialId: number) => {
+  const eliminar = async (materialId: number, motivo?: string) => {
     try {
-      const res = await apiFetch(`/api/materiales/${materialId}`, { method: 'DELETE' })
+      const options: any = { method: 'DELETE' }
+      if (motivo) {
+        options.headers = { 'Content-Type': 'application/json' }
+        options.body = JSON.stringify({ motivo })
+      }
+      const res = await apiFetch(`/api/materiales/${materialId}`, options)
       const data = await jsonOrNull(res)
       if (res.ok) {
         mutate()

--- a/src/hooks/useUnidades.ts
+++ b/src/hooks/useUnidades.ts
@@ -178,14 +178,17 @@ export default function useUnidades(materialId?: number | string) {
     }
   }
 
-  const eliminar = async (unidadId: number) => {
+  const eliminar = async (unidadId: number, motivo?: string) => {
     if (Number.isNaN(id) || id <= 0) return { success: false, error: 'ID inválido' }
     if (Number.isNaN(unidadId) || unidadId <= 0)
       return { success: false, error: 'ID de unidad inválido' }
     try {
-      const res = await apiFetch(`/api/materiales/${id}/unidades/${unidadId}`, {
-        method: 'DELETE',
-      })
+      const options: any = { method: 'DELETE' }
+      if (motivo) {
+        options.headers = { 'Content-Type': 'application/json' }
+        options.body = JSON.stringify({ motivo })
+      }
+      const res = await apiFetch(`/api/materiales/${id}/unidades/${unidadId}`, options)
       const result = await jsonOrNull(res)
       if (res.ok) {
         mutate()

--- a/tests/almacenesAuditoria.test.ts
+++ b/tests/almacenesAuditoria.test.ts
@@ -140,12 +140,19 @@ describe('DELETE /api/almacenes/[id]', () => {
     const registrarAuditoria = vi.fn().mockResolvedValue({ auditoria: { id: 9 } })
     vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
     const { DELETE } = await import('../src/app/api/almacenes/[id]/route')
-    const req = new NextRequest('http://localhost/api/almacenes/5', { method: 'DELETE' })
+    const body = JSON.stringify({ motivo: 'test' })
+    const req = new NextRequest('http://localhost/api/almacenes/5', { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body })
     const res = await DELETE(req)
     expect(res.status).toBe(200)
     const data = await res.json()
     expect(data.auditoria).toEqual({ id: 9 })
-    expect(registrarAuditoria).toHaveBeenCalled()
+    expect(registrarAuditoria).toHaveBeenCalledWith(
+      expect.any(NextRequest),
+      'almacen',
+      5,
+      'eliminacion',
+      { motivo: 'test' },
+    )
   })
 
   it('propaga error de auditoria al eliminar', async () => {
@@ -177,7 +184,8 @@ describe('DELETE /api/almacenes/[id]', () => {
     const registrarAuditoria = vi.fn().mockResolvedValue({ error: 'fallo' })
     vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
     const { DELETE } = await import('../src/app/api/almacenes/[id]/route')
-    const req = new NextRequest('http://localhost/api/almacenes/5', { method: 'DELETE' })
+    const body = JSON.stringify({ motivo: 'test' })
+    const req = new NextRequest('http://localhost/api/almacenes/5', { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body })
     const res = await DELETE(req)
     const data = await res.json()
     expect(data.auditError).toBe('fallo')

--- a/tests/materialDeleteAuditoria.test.ts
+++ b/tests/materialDeleteAuditoria.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import * as auth from '../lib/auth'
+import * as permisos from '../lib/permisos'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+describe('DELETE /api/materiales/[id]', () => {
+  it('pasa motivo a registrarAuditoria', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ id: 1 } as any)
+    vi.spyOn(permisos, 'hasManagePerms').mockReturnValue(true)
+    const tx = {
+      historialLote: { deleteMany: vi.fn() },
+      materialUnidad: { deleteMany: vi.fn() },
+      archivoMaterial: { deleteMany: vi.fn() },
+      material: { delete: vi.fn() },
+    }
+    const prismaMock = {
+      material: { findUnique: vi.fn().mockResolvedValue({ almacenId: 2 }) },
+      usuarioAlmacen: { findFirst: vi.fn().mockResolvedValue({ id: 1 }) },
+      $transaction: vi.fn().mockImplementation(async (cb:any)=> cb(tx))
+    }
+    vi.doMock('../lib/prisma', () => ({ default: prismaMock }))
+    vi.doMock('../src/lib/snapshot', () => ({ snapshotMaterial: vi.fn() }))
+    vi.doMock('../src/lib/audit', () => ({ logAudit: vi.fn() }))
+    const registrarAuditoria = vi.fn().mockResolvedValue({ auditoria: { id: 9 } })
+    vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
+    const { DELETE } = await import('../src/app/api/materiales/[id]/route')
+    const body = JSON.stringify({ motivo: 'razon' })
+    const req = new NextRequest('http://localhost/api/materiales/5', { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body })
+    const res = await DELETE(req)
+    expect(res.status).toBe(200)
+    expect(registrarAuditoria).toHaveBeenCalledWith(
+      expect.any(NextRequest),
+      'material',
+      5,
+      'eliminacion',
+      { motivo: 'razon' },
+    )
+  })
+})

--- a/tests/unidadDeleteAuditoria.test.ts
+++ b/tests/unidadDeleteAuditoria.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import * as auth from '../lib/auth'
+import * as permisos from '../lib/permisos'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+describe('DELETE /api/materiales/[id]/unidades/[unidadId]', () => {
+  it('pasa motivo a registrarAuditoria', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ id: 1 } as any)
+    vi.spyOn(permisos, 'hasManagePerms').mockReturnValue(true)
+    const prismaMock = {
+      material: { findUnique: vi.fn().mockResolvedValue({ almacenId: 2 }) },
+      usuarioAlmacen: { findFirst: vi.fn().mockResolvedValue({ id: 1 }) },
+      materialUnidad: { delete: vi.fn() },
+    }
+    vi.doMock('../lib/prisma', () => ({ default: prismaMock }))
+    vi.doMock('../src/lib/snapshot', () => ({ snapshotUnidad: vi.fn() }))
+    vi.doMock('../src/lib/audit', () => ({ logAudit: vi.fn() }))
+    const registrarAuditoria = vi.fn().mockResolvedValue({ auditoria: { id: 9 } })
+    vi.doMock('../lib/reporter', () => ({ registrarAuditoria }))
+    const { DELETE } = await import('../src/app/api/materiales/[id]/unidades/[unidadId]/route')
+    const body = JSON.stringify({ motivo: 'mot' })
+    const req = new NextRequest('http://localhost/api/materiales/5/unidades/3', { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body })
+    const res = await DELETE(req)
+    expect(res.status).toBe(200)
+    expect(registrarAuditoria).toHaveBeenCalledWith(
+      expect.any(NextRequest),
+      'unidad',
+      3,
+      'eliminacion',
+      { motivo: 'mot' },
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- ask for a reason before deleting warehouses, materials or units
- include reason when calling DELETE APIs
- propagate motive to registrarAuditoria in API routes
- show reason in audit history
- test new API behaviour

## Testing
- `pnpm run build` *(fails: Prisma connection error)*
- `pnpm test`

------
