### PR TITLE
Add inventory QR scanner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 
 # production
 /build
+node-compile-cache
 
 # misc
 .DS_Store

--- a/src/app/dashboard/components/Sidebar.tsx
+++ b/src/app/dashboard/components/Sidebar.tsx
@@ -9,6 +9,7 @@ import Spinner from "@/components/Spinner";
 import {
   Home,
   Boxes,
+  Box,
   Bell,
   Network,
   FileText,
@@ -48,6 +49,13 @@ const sidebarMenu = [
     label: "Almacenes",
     icon: <Boxes className="dashboard-sidebar-icon" data-oid="fhr-clw" />,
     path: "/dashboard/almacenes",
+    allowed: ["admin", "administrador", "institucional", "empresarial", "individual"],
+  },
+  {
+    key: "inventario",
+    label: "Inventario",
+    icon: <Box className="dashboard-sidebar-icon" />,
+    path: "/dashboard/inventario",
     allowed: ["admin", "administrador", "institucional", "empresarial", "individual"],
   },
   {

--- a/src/app/dashboard/inventario/ScanInfo.tsx
+++ b/src/app/dashboard/inventario/ScanInfo.tsx
@@ -1,0 +1,27 @@
+"use client";
+import React from "react";
+
+interface Props {
+  info: any | null;
+}
+
+export default function ScanInfo({ info }: Props) {
+  if (!info) return <p>No hay información.</p>;
+  const obj = info[info.tipo] ?? {};
+  const title =
+    info.tipo === "almacen"
+      ? "Almacén"
+      : info.tipo === "material"
+        ? "Material"
+        : info.tipo === "unidad"
+          ? "Unidad"
+          : "";
+  return (
+    <div>
+      <h2 className="font-semibold mb-2">{title}</h2>
+      <pre className="text-xs whitespace-pre-wrap break-all border rounded p-2 bg-white/5">
+        {JSON.stringify(obj, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/src/app/dashboard/inventario/page.tsx
+++ b/src/app/dashboard/inventario/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Html5Qrcode } from "html5-qrcode";
+import { useRouter } from "next/navigation";
+import { decodeQRImageFile } from "@/lib/qrImage";
+import { fetchScanInfo, hasCamera } from "@/lib/scanUtils";
+import { triggerDownload } from "@/app/dashboard/utils/auditoriaExport";
+import ScanInfo from "./ScanInfo";
+import { useDashboardUI } from "../ui";
+import { RotateCcw, Pencil, Download, Maximize2 } from "lucide-react";
+
+export default function InventarioPage() {
+  const router = useRouter();
+  const { toggleFullscreen } = useDashboardUI();
+  const [codigo, setCodigo] = useState<string | null>(null);
+  const [info, setInfo] = useState<any | null>(null);
+  const [camera, setCamera] = useState(false);
+  const [useCameraScan, setUseCameraScan] = useState(false);
+
+  useEffect(() => {
+    hasCamera().then((v) => {
+      setCamera(v);
+      setUseCameraScan(v);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!useCameraScan) return;
+    const qr = new Html5Qrcode("qr-reader-inv");
+    qr.start({ facingMode: "environment" }, { fps: 10, qrbox: 250 }, (txt) => setCodigo(txt))
+      .catch(() => setUseCameraScan(false));
+    return () => {
+      qr.stop().catch(() => {});
+    };
+  }, [useCameraScan]);
+
+  useEffect(() => {
+    if (!codigo) return;
+    fetchScanInfo(codigo).then((d) => setInfo(d)).catch(() => setInfo(null));
+  }, [codigo]);
+
+  const handleFile = async (files: FileList | null) => {
+    const file = files?.[0];
+    if (!file) return;
+    const txt = await decodeQRImageFile(file);
+    if (txt) setCodigo(txt);
+  };
+
+  const reload = () => {
+    setCodigo(null);
+    setInfo(null);
+  };
+
+  const edit = () => {
+    if (!info?.tipo) return;
+    const obj = info[info.tipo];
+    if (!obj?.id) return;
+    let path = "";
+    if (info.tipo === "almacen") path = `/dashboard/almacenes/${obj.id}/editar`;
+    if (info.tipo === "material") path = `/dashboard/materiales/${obj.id}/editar`;
+    if (info.tipo === "unidad") {
+      const mid = info.material?.id;
+      if (mid) path = `/dashboard/materiales/${mid}/unidades/${obj.id}/editar`;
+    }
+    if (path) router.push(path);
+  };
+
+  const exportar = () => {
+    if (!info) return;
+    const blob = new Blob([JSON.stringify(info, null, 2)], { type: "application/json" });
+    triggerDownload(blob, "escaneo.json");
+  };
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 p-4">
+      <div className="space-y-4">
+        {useCameraScan ? (
+          <div id="qr-reader-inv" className="w-full h-64 bg-black rounded" />
+        ) : (
+          <>
+            <button onClick={() => setUseCameraScan(camera)} className="dashboard-btn">
+              📷 Escanear código QR
+            </button>
+            {!camera && (
+              <input
+                type="file"
+                accept="image/*"
+                onChange={(e) => handleFile(e.target.files)}
+                aria-label="Subir QR"
+                className="dashboard-input mt-2"
+              />
+            )}
+          </>
+        )}
+        {camera && (
+          <button onClick={() => setUseCameraScan(!useCameraScan)} className="dashboard-btn">
+            {useCameraScan ? "Subir imagen" : "Usar cámara"}
+          </button>
+        )}
+      </div>
+      <div className="space-y-4">
+        <div className="flex gap-2">
+          <button onClick={reload} className="dashboard-btn" title="Recargar">
+            <RotateCcw className="w-4 h-4" />
+          </button>
+          <button onClick={edit} className="dashboard-btn" title="Editar">
+            <Pencil className="w-4 h-4" />
+          </button>
+          <button onClick={exportar} className="dashboard-btn" title="Exportar">
+            <Download className="w-4 h-4" />
+          </button>
+          <button onClick={toggleFullscreen} className="dashboard-btn" title="Pantalla completa">
+            <Maximize2 className="w-4 h-4" />
+          </button>
+        </div>
+        <ScanInfo info={info} />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/scanUtils.ts
+++ b/src/lib/scanUtils.ts
@@ -1,0 +1,21 @@
+export const hasCamera = async (): Promise<boolean> => {
+  if (!navigator.mediaDevices?.enumerateDevices) return false;
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return devices.some((d) => d.kind === 'videoinput');
+  } catch {
+    return false;
+  }
+};
+
+import { apiFetch } from '@lib/api';
+import { jsonOrNull } from '@lib/http';
+
+export const fetchScanInfo = async (codigo: string): Promise<any | null> => {
+  const res = await apiFetch('/api/qr/importar', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ codigo }),
+  });
+  return jsonOrNull(res);
+};

--- a/tests/scanInfoRender.test.tsx
+++ b/tests/scanInfoRender.test.tsx
@@ -1,0 +1,17 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import ScanInfo from '../src/app/dashboard/inventario/ScanInfo'
+
+;(global as any).React = React
+
+describe('ScanInfo', () => {
+  it('muestra titulo segun tipo', () => {
+    const html = renderToStaticMarkup(
+      <ScanInfo info={{ tipo: 'almacen', almacen: { id: 1, nombre: 'A' } }} />
+    )
+    expect(html).toContain('Almacén')
+    expect(html).toContain('nombre')
+  })
+})

--- a/tests/scanUtils.test.ts
+++ b/tests/scanUtils.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { hasCamera, fetchScanInfo } from '../src/lib/scanUtils'
+
+vi.mock('../lib/api', () => ({ apiFetch: vi.fn() }))
+vi.mock('../lib/http', () => ({ jsonOrNull: vi.fn(() => Promise.resolve({ ok: true })) }))
+
+const { apiFetch } = await import('../lib/api')
+const { jsonOrNull } = await import('../lib/http')
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete (navigator as any).mediaDevices
+})
+
+describe('hasCamera', () => {
+  it('detecta camara disponible', async () => {
+    ;(navigator as any).mediaDevices = {
+      enumerateDevices: vi.fn().mockResolvedValue([{ kind: 'videoinput' }]),
+    }
+    expect(await hasCamera()).toBe(true)
+  })
+
+  it('retorna false si falla', async () => {
+    ;(navigator as any).mediaDevices = {
+      enumerateDevices: vi.fn().mockRejectedValue(new Error('err')),
+    }
+    expect(await hasCamera()).toBe(false)
+  })
+})
+
+describe('fetchScanInfo', () => {
+  it('envia codigo al API', async () => {
+    ;(apiFetch as any).mockResolvedValue(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    await fetchScanInfo('abc')
+    expect(apiFetch).toHaveBeenCalled()
+    expect(jsonOrNull).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add `hasCamera` and `fetchScanInfo` helpers
- render scan results with new `ScanInfo` component
- implement `/dashboard/inventario` route for QR scanning
- register the route in sidebar
- ignore `node-compile-cache`
- test scan utilities and rendering

## Testing
- `pnpm run build` *(fails: Prisma connection error & SMTP env missing)*
- `pnpm test`

------
