### PR TITLE
fix: soporte seguro para callbacks OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,4 +39,5 @@ GITHUB_CLIENT_SECRET=
 FACEBOOK_CLIENT_ID=
 FACEBOOK_CLIENT_SECRET=
 NEXTAUTH_SECRET=
+# URL base para NextAuth (incluye dominio y subdirectorio si existe)
 NEXTAUTH_URL=

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -24,6 +24,7 @@ const handler = NextAuth({
     }),
   ],
   session: { strategy: 'database' },
+  trustHost: true,
   secret: process.env.NEXTAUTH_SECRET,
 })
 

--- a/src/app/api/login/social/route.ts
+++ b/src/app/api/login/social/route.ts
@@ -13,6 +13,7 @@ export function GET(req: NextRequest) {
     )
   }
 
-  const redirectUrl = new URL(`/api/auth/signin?provider=${provider}`, req.url)
+  const base = process.env.NEXT_PUBLIC_BASE_PATH || ''
+  const redirectUrl = new URL(`${base}/api/auth/signin?provider=${provider}`, req.url)
   return NextResponse.redirect(redirectUrl)
 }


### PR DESCRIPTION
## Summary
- documentar `NEXTAUTH_URL`
- habilitar `trustHost` en NextAuth
- considerar `NEXT_PUBLIC_BASE_PATH` al redirigir login social

## Testing
- `pnpm run lint` *(fails: many errors)*
- `pnpm run build` *(fails: InvalidDatasourceError & missing SMTP vars)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68895558e834832896e7e0eee0b8033e