### PR TITLE
Fix social login callback url

### DIFF
--- a/src/app/api/login/social/route.ts
+++ b/src/app/api/login/social/route.ts
@@ -14,6 +14,9 @@ export function GET(req: NextRequest) {
   }
 
   const base = process.env.NEXT_PUBLIC_BASE_PATH || ''
-  const redirectUrl = new URL(`${base}/api/auth/signin?provider=${provider}`, req.url)
+  const redirectUrl = new URL(
+    `${base}/api/auth/callback/${provider}`,
+    req.url,
+  )
   return NextResponse.redirect(redirectUrl)
 }

--- a/tests/loginSocial.test.ts
+++ b/tests/loginSocial.test.ts
@@ -8,7 +8,9 @@ describe('GET /api/login/social', () => {
     const req = new NextRequest('http://localhost/api/login/social?provider=google')
     const res = GET(req)
     expect(res.status).toBe(307)
-    expect(res.headers.get('location')).toBe('http://localhost/api/auth/signin?provider=google')
+    expect(res.headers.get('location')).toBe(
+      'http://localhost/api/auth/callback/google',
+    )
   })
 
   it('retorna 400 si provider invalido', () => {


### PR DESCRIPTION
## Summary
- redirect social login route to NextAuth callback
- update unit test

## Testing
- `pnpm run build` *(fails: Error validating datasource `db`)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6889639d71188328b7eff15e43a3f294