### PR TITLE
Disable recaptcha in maintenance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ JWT_SECRET="8b7e2f4c9a1d6e3f5b0c7a2e9d4f1b6c"
 # Claves para Google reCAPTCHA (opcional)
 NEXT_PUBLIC_RECAPTCHA_SITE_KEY=
 RECAPTCHA_SECRET_KEY=
-NEXT_PUBLIC_DISABLE_RECAPTCHA=false
+NEXT_PUBLIC_DISABLE_RECAPTCHA=true
 
 # Ejemplos de otras variables (correos SMTP)
 EMAIL_ADMIN="logisticshoneylabs@gmail.com"

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ pnpm prisma migrate deploy
 Configura las variables de entorno copiando `.env.example` a `.env`.
 Debes definir `DATABASE_URL` con la URL de Prisma Accelerate y
 `DIRECT_DB_URL` con la conexión directa usada en las migraciones.
+Si el sistema de reCAPTCHA está en mantenimiento asigna
+`NEXT_PUBLIC_DISABLE_RECAPTCHA=true`.
 
 Tras modificar `prisma/schema.prisma` ejecuta `pnpm install` o
 `pnpm prisma generate` para actualizar el cliente de Prisma.

--- a/lib/recaptcha.ts
+++ b/lib/recaptcha.ts
@@ -1,4 +1,7 @@
-const DISABLED = process.env.NEXT_PUBLIC_DISABLE_RECAPTCHA === 'true'
+const RECAPTCHA_MAINTENANCE = true // Cambiar a false al reactivar
+const DISABLED =
+  RECAPTCHA_MAINTENANCE ||
+  process.env.NEXT_PUBLIC_DISABLE_RECAPTCHA === 'true'
 
 export function isRecaptchaEnabled(): boolean {
   return !DISABLED


### PR DESCRIPTION
## Summary
- put recaptcha into maintenance mode using constant
- disable recaptcha by default in env example
- document how to disable the captcha in README

## Testing
- `pnpm run build` *(fails: InvalidDatasourceError, SMTP_USER missing)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6889753f5aac8328b616ecee6a087e3a