### PR TITLE
Fix login redirect loop when basePath set

### DIFF
--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -29,8 +29,15 @@ export default function ClientLayout({
   const pathname = usePathname();
   const router = useRouter();
   const { usuario, loading } = useSession();
-  const ocultarNavbar = debeOcultarNavbarFooter(pathname);
-  const esRutaAuth = /^\/auth(\/|$)|^\/login$|^\/registro$/.test(pathname);
+
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+  const cleanPath =
+    basePath && pathname.startsWith(basePath)
+      ? pathname.slice(basePath.length) || "/"
+      : pathname;
+
+  const ocultarNavbar = debeOcultarNavbarFooter(cleanPath);
+  const esRutaAuth = /^\/auth(\/|$)|^\/login$|^\/registro$/.test(cleanPath);
 
   useEffect(() => {
     if (!loading && !usuario && !esRutaAuth) {


### PR DESCRIPTION
## Summary
- avoid infinite redirect by trimming basePath before auth checks

## Testing
- `pnpm test`
- `pnpm run build` *(fails: Prisma/SMTP env vars missing)*

------
