### PR TITLE
Fix 404 from double slash in apiPath

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,4 +1,6 @@
-export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+// Normaliza base path removiendo cualquier '/' final para evitar
+// rutas duplicadas como '/base//api/perfil'
+export const BASE_PATH = (process.env.NEXT_PUBLIC_BASE_PATH ?? '').replace(/\/+$/, '');
 
 export function apiPath(path: string): string {
   if (!path.startsWith('/')) path = '/' + path;

--- a/tests/apiPath.test.ts
+++ b/tests/apiPath.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Este test asegura que apiPath maneja BASE_PATH con barra final
+
+describe('apiPath', () => {
+  it('elimina barra final en BASE_PATH', async () => {
+    const original = process.env.NEXT_PUBLIC_BASE_PATH
+    process.env.NEXT_PUBLIC_BASE_PATH = '/base/'
+    const mod = await import('../lib/api')
+    expect(mod.apiPath('/api/perfil')).toBe('/base/api/perfil')
+    vi.resetModules()
+    process.env.NEXT_PUBLIC_BASE_PATH = original
+  })
+})


### PR DESCRIPTION
## Summary
- sanitize `NEXT_PUBLIC_BASE_PATH` in `apiPath`
- add regression test for `apiPath` when base path ends with `/`

## Testing
- `pnpm test`
- `pnpm run build` *(fails: InvalidDatasourceError)*

------
