### PR TITLE
Add error boundary for inventory

### DIFF
--- a/src/app/dashboard/almacenes/layout.tsx
+++ b/src/app/dashboard/almacenes/layout.tsx
@@ -1,10 +1,15 @@
 "use client";
 import { AlmacenesUIProvider } from "./ui";
+import InventarioErrorBoundary from "@/components/InventarioErrorBoundary";
 
 export default function AlmacenesLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <AlmacenesUIProvider>{children}</AlmacenesUIProvider>;
+  return (
+    <InventarioErrorBoundary>
+      <AlmacenesUIProvider>{children}</AlmacenesUIProvider>
+    </InventarioErrorBoundary>
+  );
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -4,6 +4,10 @@ import { error as logError } from "@lib/logger";
 
 interface Props {
   children: ReactNode;
+  /** Mensaje a mostrar en caso de error */
+  message?: string;
+  /** Callback para manejo adicional del error */
+  onError?: (err: unknown) => void;
 }
 interface State {
   hasError: boolean;
@@ -18,11 +22,16 @@ export default class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(err: unknown) {
     logError("ErrorBoundary", err);
+    this.props.onError?.(err);
   }
 
   render() {
     if (this.state.hasError) {
-      return <p className="text-red-500">Algo salió mal.</p>;
+      return (
+        <p className="text-red-500">
+          {this.props.message || "Algo salió mal."}
+        </p>
+      );
     }
     return this.props.children;
   }

--- a/src/components/InventarioErrorBoundary.tsx
+++ b/src/components/InventarioErrorBoundary.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { ReactNode } from "react";
+import ErrorBoundary from "./ErrorBoundary";
+import { useToast } from "@/components/Toast";
+import * as logger from "@lib/logger";
+
+export default function InventarioErrorBoundary({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const toast = useToast();
+  return (
+    <ErrorBoundary
+      message="Error en inventario"
+      onError={(err) => {
+        logger.error("InventarioError", err);
+        const msg = err instanceof Error ? err.message : String(err);
+        toast.show(msg, "error");
+      }}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/tests/inventarioErrorBoundary.test.tsx
+++ b/tests/inventarioErrorBoundary.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import { render } from '@testing-library/react'
+(global as any).React = React
+
+const toast = { show: vi.fn() }
+vi.mock('../src/components/Toast', () => ({ useToast: () => toast }))
+
+import InventarioErrorBoundary from '../src/components/InventarioErrorBoundary'
+
+function Boom() {
+  throw new Error('boom')
+}
+
+describe('InventarioErrorBoundary', () => {
+  it('muestra mensaje y notifica', () => {
+    const { getByText } = render(
+      <InventarioErrorBoundary>
+        <Boom />
+      </InventarioErrorBoundary>
+    )
+    expect(getByText(/Error en inventario/)).toBeTruthy()
+    expect(toast.show).toHaveBeenCalledWith('boom', 'error')
+  })
+})


### PR DESCRIPTION
## Summary
- allow ErrorBoundary to receive onError and custom message
- add InventarioErrorBoundary with Toast notification
- wrap inventory layout with the new boundary
- add unit test for the boundary

## Testing
- `pnpm run build` *(fails: Failed to collect page data for /api/almacenes/compartir)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688a857f4f208328b826c29aee2e0cfb