### PR TITLE
Agregar página global de error

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+import { Home, RotateCcw, AlertTriangle } from 'lucide-react'
+import { error as logError } from '@lib/logger'
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    logError('GlobalError', error)
+  }, [error])
+
+  return (
+    <html>
+      <body className="min-h-screen flex items-center justify-center bg-[var(--color-background)] text-[var(--color-foreground)] p-6">
+        <div className="max-w-md text-center space-y-6">
+          <AlertTriangle className="w-16 h-16 mx-auto text-red-500" />
+          <h2 className="text-2xl font-semibold">Algo salió mal</h2>
+          <p className="text-sm">
+            Puede que tu conexión haya fallado o que nuestros servidores estén experimentando problemas.
+          </p>
+          <div className="flex justify-center gap-4">
+            <button
+              onClick={() => reset()}
+              className="flex items-center gap-2 px-4 py-2 bg-amber-400 hover:bg-amber-500 text-black rounded-md"
+            >
+              <RotateCcw className="w-4 h-4" />
+              Reintentar
+            </button>
+            <Link
+              href="/"
+              className="flex items-center gap-2 px-4 py-2 bg-white/20 hover:bg-white/30 rounded-md"
+            >
+              <Home className="w-4 h-4" />
+              Volver al inicio
+            </Link>
+          </div>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/tests/globalErrorPage.test.tsx
+++ b/tests/globalErrorPage.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import { render } from '@testing-library/react'
+
+;(global as any).React = React
+
+import GlobalError from '../src/app/error'
+
+describe('GlobalError page', () => {
+  it('muestra mensaje y acciones', () => {
+    const { getByText } = render(
+      <GlobalError error={new Error('fail')} reset={vi.fn()} />
+    )
+    expect(getByText(/algo salió mal/i)).toBeTruthy()
+    expect(getByText(/volver al inicio/i)).toBeTruthy()
+    expect(getByText(/reintentar/i)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- implementar `src/app/error.tsx` para manejar fallos globales
- añadir prueba `globalErrorPage.test.tsx`

## Testing
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688bd4183ce4832883753eafc9036749