### PR TITLE
Fix keyboard save handler

### DIFF
--- a/src/app/dashboard/paneles/components/PanelDetailNavbar.tsx
+++ b/src/app/dashboard/paneles/components/PanelDetailNavbar.tsx
@@ -63,6 +63,19 @@ export default function PanelDetailNavbar({ onShowHistory }: { onShowHistory?: (
   } = usePanelOps();
   const router = useRouter();
 
+  const guardarNombre = async () => {
+    if (!panelId) return;
+    setSaving("saving");
+    await apiFetch(`/api/paneles/${panelId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ nombre }),
+    });
+    setSaving("saved");
+    setTimeout(() => setSaving("idle"), 2000);
+  };
+
+
   useEffect(() => {
     const close = () => {
       setOpenExport(false);
@@ -131,17 +144,6 @@ export default function PanelDetailNavbar({ onShowHistory }: { onShowHistory?: (
       .catch(() => {});
   }, [panelId]);
 
-  const guardarNombre = async () => {
-    if (!panelId) return;
-    setSaving("saving");
-    await apiFetch(`/api/paneles/${panelId}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ nombre }),
-    });
-    setSaving("saved");
-    setTimeout(() => setSaving("idle"), 2000);
-  };
 
   const exportar = async (formato: string) => {
     if (!panelId) return;


### PR DESCRIPTION
## Summary
- avoid "guardarNombre" initialization error by defining it before useEffect

## Testing
- `pnpm run build` *(fails: missing environment vars)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688bea5ea2f083289634ff69fef539ec