### PR TITLE
fix(paneles): evita loop en ChatPanel

### DIFF
--- a/src/app/dashboard/paneles/components/ChatPanel.tsx
+++ b/src/app/dashboard/paneles/components/ChatPanel.tsx
@@ -32,9 +32,10 @@ export default function ChatPanel({ canalId }: { canalId: number }) {
     setTimeout(() => listRef.current?.scrollTo(0, listRef.current.scrollHeight), 50)
   }, [texto, canalId, mutate])
   useEffect(() => {
+    if (!canalId) return
     const id = setInterval(() => mutate(), 4000)
     return () => clearInterval(id)
-  }, [canalId, mutate])
+  }, [canalId])
 
   useEffect(() => {
     const el = listRef.current


### PR DESCRIPTION
## Summary
- fix interval effect in `ChatPanel` to avoid running when no channel ID

## Testing
- `pnpm run build` *(fails: Missing env vars and Prisma URL)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688bf14dc1908328840dd818a74a75e9