### PR TITLE
Add shared panel fetch hook

### DIFF
--- a/src/app/dashboard/paneles/PanelDataContext.tsx
+++ b/src/app/dashboard/paneles/PanelDataContext.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { createContext, useContext } from 'react';
+import usePanel, { type Panel } from '@/hooks/usePanel';
+
+interface PanelData extends ReturnType<typeof usePanel> {}
+
+const PanelDataContext = createContext<PanelData | null>(null);
+
+export function PanelDataProvider({ panelId, children }: { panelId?: string | null; children: React.ReactNode }) {
+  const value = usePanel(panelId);
+  return <PanelDataContext.Provider value={value}>{children}</PanelDataContext.Provider>;
+}
+
+export function usePanelData() {
+  const ctx = useContext(PanelDataContext);
+  if (!ctx) throw new Error('usePanelData must be used within PanelDataProvider');
+  return ctx;
+}

--- a/src/app/dashboard/paneles/[id]/layout.tsx
+++ b/src/app/dashboard/paneles/[id]/layout.tsx
@@ -1,11 +1,12 @@
 "use client";
 import { useEffect } from "react";
 import { useDashboardUI } from "../../ui";
-import { useRouter } from "next/navigation";
+import { useRouter, useParams } from "next/navigation";
 import PanelDetailNavbar from "../components/PanelDetailNavbar";
 import { PanelOpsProvider, usePanelOps } from "../PanelOpsContext";
 import Spinner from "@/components/Spinner";
 import useSession from "@/hooks/useSession";
+import { PanelDataProvider } from "../PanelDataContext";
 
 function ProtectedPanel({ children }: { children: React.ReactNode }) {
   const { fullscreen, setFullscreen } = useDashboardUI();
@@ -47,9 +48,13 @@ function ProtectedPanel({ children }: { children: React.ReactNode }) {
 }
 
 export default function PanelLayout({ children }: { children: React.ReactNode }) {
+  const params = useParams();
+  const panelId = Array.isArray(params?.id) ? params.id[0] : (params as any)?.id;
   return (
-    <PanelOpsProvider>
-      <ProtectedPanel>{children}</ProtectedPanel>
-    </PanelOpsProvider>
+    <PanelDataProvider panelId={panelId}>
+      <PanelOpsProvider>
+        <ProtectedPanel>{children}</ProtectedPanel>
+      </PanelOpsProvider>
+    </PanelDataProvider>
   );
 }

--- a/src/hooks/usePanel.ts
+++ b/src/hooks/usePanel.ts
@@ -1,0 +1,31 @@
+import useSWR from 'swr'
+import fetcher from '@lib/swrFetcher'
+import type { LayoutItem } from '@/types/panel'
+
+export interface Panel {
+  id: string
+  nombre?: string
+  widgets?: string[]
+  layout?: LayoutItem[]
+  permiso?: string
+  [key: string]: any
+}
+
+export default function usePanel(id?: string | number | null) {
+  const panelId = id ? String(id) : null
+  const { data, error, isLoading, mutate } = useSWR(
+    panelId ? `/api/paneles/${panelId}` : null,
+    fetcher,
+    {
+      dedupingInterval: 10000,
+      revalidateOnFocus: false,
+    }
+  )
+
+  return {
+    panel: data?.panel as Panel | undefined,
+    isLoading,
+    error,
+    mutate,
+  }
+}


### PR DESCRIPTION
## Summary
- add `usePanel` hook for fetching paneles
- share panel data via `PanelDataProvider`
- use hook in panel detail page and navbar

## Testing
- `SKIP_ENV_CHECK=true pnpm run build` *(fails: Prisma datasource URL and SMTP variables missing)*
- `pnpm test`

------
