### PR TITLE
refactor: abstraer prisma

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,11 +1,48 @@
 import { cookies, type RequestCookies } from 'next/headers'
 import jwt from 'jsonwebtoken'
-import prisma from '@lib/prisma'
+import { getDb } from '@lib/db'
 import { SESSION_COOKIE } from '@lib/constants'
+import type { Usuario } from '@/types/usuario'
+
+interface SesionUsuario {
+  activa: boolean
+  usuarioId: number
+}
+
+interface AuthDb {
+  sesionUsuario: {
+    findUnique(args: {
+      where: { id: number }
+      select: { activa: true; usuarioId: true }
+    }): Promise<SesionUsuario | null>
+    update(args: {
+      where: { id: number }
+      data: { fechaUltima: Date }
+    }): Promise<void>
+  }
+  usuario: {
+    findUnique(args: {
+      where: { id: number }
+      select: {
+        id: true
+        nombre: true
+        correo: true
+        tipoCuenta: true
+        entidadId: true
+        esSuperAdmin: true
+        roles: { select: { nombre: true } }
+        plan: { select: { nombre: true } }
+        preferencias: true
+      }
+    }): Promise<Usuario | null>
+  }
+}
 
 const JWT_SECRET = process.env.JWT_SECRET
 
-export async function getUsuarioFromSession(req?: { cookies: RequestCookies }) {
+export async function getUsuarioFromSession(
+  req?: { cookies: RequestCookies },
+): Promise<Usuario | null> {
   if (!JWT_SECRET) return null
 
   const cookieStore = req?.cookies ?? await cookies()
@@ -14,19 +51,20 @@ export async function getUsuarioFromSession(req?: { cookies: RequestCookies }) {
   if (!token) return null
 
   try {
+    const db = getDb().client as AuthDb
     const decoded = jwt.verify(token, JWT_SECRET) as { id: number; sid?: number }
     if (decoded.sid) {
-      const sesion = await prisma.sesionUsuario.findUnique({
+      const sesion = await db.sesionUsuario.findUnique({
         where: { id: decoded.sid },
         select: { activa: true, usuarioId: true },
       })
       if (!sesion || !sesion.activa || sesion.usuarioId !== decoded.id) return null
-      await prisma.sesionUsuario.update({
+      await db.sesionUsuario.update({
         where: { id: decoded.sid },
         data: { fechaUltima: new Date() },
       })
     }
-    const usuario = await prisma.usuario.findUnique({
+    const usuario = await db.usuario.findUnique({
       where: { id: decoded.id },
       select: {
         id: true,

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,19 +1,34 @@
 import * as logger from '@lib/logger'
+import { getDb } from '@lib/db'
+
+interface AuditDb {
+  auditLog?: {
+    create(args: {
+      data: {
+        usuarioId: number | null
+        accion: string
+        entidad: string
+        payload?: any
+      }
+    }): Promise<void>
+  }
+  $executeRawUnsafe?: (query: string, ...params: any[]) => Promise<void>
+}
 
 export async function logAudit(
   usuarioId: number | null,
   accion: string,
   entidad: string,
   payload?: any,
-) {
+): Promise<void> {
   try {
-    const prisma = (await import('@lib/prisma')).default
-    if (prisma.auditLog?.create) {
-      await prisma.auditLog.create({
+    const db = getDb().client as AuditDb
+    if (db.auditLog?.create) {
+      await db.auditLog.create({
         data: { usuarioId, accion, entidad, payload },
       })
-    } else if (prisma.$executeRawUnsafe) {
-      await prisma.$executeRawUnsafe(
+    } else if (db.$executeRawUnsafe) {
+      await db.$executeRawUnsafe(
         `INSERT INTO "AuditLog" ("usuarioId", accion, entidad, payload, fecha)
          VALUES ($1,$2,$3,$4,NOW())`,
         usuarioId,

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -1,9 +1,106 @@
-import type { Prisma, PrismaClient } from '@prisma/client'
-
-export type DB = Prisma.TransactionClient | PrismaClient
+export interface SnapshotDb {
+  almacen: {
+    findUnique(args: {
+      where: { id: number }
+      select: {
+        nombre: true
+        descripcion: true
+        imagen: true
+        imagenNombre: true
+        imagenUrl: true
+        codigoUnico: true
+      }
+    }): Promise<{
+      nombre: string
+      descripcion: string | null
+      imagen: Buffer | null
+      imagenNombre: string | null
+      imagenUrl: string | null
+      codigoUnico: string | null
+    } | null>
+  }
+  historialAlmacen: {
+    create(args: {
+      data: {
+        almacenId: number
+        usuarioId: number
+        descripcion: string
+        estado: any
+      }
+    }): Promise<void>
+  }
+  material: {
+    findUnique(args: {
+      where: { id: number }
+      include: {
+        archivos: {
+          select: {
+            nombre: true
+            archivoNombre: true
+            archivo: true
+          }
+        }
+      }
+    }): Promise<{
+      miniatura: Buffer | null
+      archivos: {
+        nombre: string
+        archivoNombre: string
+        archivo: Buffer | null
+      }[]
+      lote: string | null
+      ubicacion: string | null
+      cantidad: number | null
+    } | null>
+  }
+  historialLote: {
+    create(args: {
+      data: {
+        materialId: number
+        usuarioId: number
+        descripcion: string
+        lote: string | null
+        ubicacion: string | null
+        cantidad: number | null
+        estado: any
+      }
+    }): Promise<void>
+  }
+  materialUnidad: {
+    findUnique(args: {
+      where: { id: number }
+      include: {
+        archivos: {
+          select: {
+            nombre: true
+            archivoNombre: true
+            archivo: true
+          }
+        }
+      }
+    }): Promise<{
+      imagen: Buffer | null
+      archivos: {
+        nombre: string
+        archivoNombre: string
+        archivo: Buffer | null
+      }[]
+    } | null>
+  }
+  historialUnidad: {
+    create(args: {
+      data: {
+        unidadId: number
+        usuarioId: number
+        descripcion: string
+        estado: any
+      }
+    }): Promise<void>
+  }
+}
 
 export async function snapshotAlmacen(
-  db: DB,
+  db: SnapshotDb,
   almacenId: number,
   usuarioId: number,
   descripcion: string,
@@ -33,7 +130,7 @@ export async function snapshotAlmacen(
 }
 
 export async function snapshotMaterial(
-  db: DB,
+  db: SnapshotDb,
   materialId: number,
   usuarioId: number,
   descripcion: string,
@@ -74,7 +171,7 @@ export async function snapshotMaterial(
 }
 
 export async function snapshotUnidad(
-  db: DB,
+  db: SnapshotDb,
   unidadId: number,
   usuarioId: number,
   descripcion: string,
@@ -98,7 +195,6 @@ export async function snapshotUnidad(
         })),
       }
     : null
-  // @ts-ignore
   await db.historialUnidad.create({
     data: { unidadId, usuarioId, descripcion, estado },
   })


### PR DESCRIPTION
## Summary
- adapt auth to generic DB and centralised types
- reuse db adapter for audit logging and snapshot utilities

## Testing
- `pnpm run build` *(fails: Faltan variables de entorno: JWT_SECRET, NEXTAUTH_SECRET, NEXTAUTH_URL)*
- `pnpm test` *(fails: 1 failed | 154 passed)*

------
