### PR TITLE
chore: add supabase env template

### DIFF
--- a/.env.supabase
+++ b/.env.supabase
@@ -1,0 +1,8 @@
+# Variables de entorno para HoneyLabs con Supabase
+# Copia este archivo como .env y completa los valores requeridos
+
+POSTGRES_URL=
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+DB_PROVIDER=supabase

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yarn-error.log*
 .env.local
 .env*
 !.env.example
+!.env.supabase
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Debes definir `DATABASE_URL` con la URL de Prisma Accelerate y
 Si el sistema de reCAPTCHA está en mantenimiento asigna
 `NEXT_PUBLIC_DISABLE_RECAPTCHA=true`.
 
+Si deseas usar Supabase como proveedor de base de datos, copia
+`.env.supabase` a `.env` y completa las variables `POSTGRES_URL`,
+`SUPABASE_URL`, `SUPABASE_ANON_KEY` y `SUPABASE_SERVICE_ROLE_KEY`.
+Este archivo establece `DB_PROVIDER=supabase` para activar el adaptador
+correspondiente en `lib/db/index.ts`.
+
 Tras modificar `prisma/schema.prisma` ejecuta `pnpm install` o
 `pnpm prisma generate` para actualizar el cliente de Prisma.
 


### PR DESCRIPTION
## Summary
- add `.env.supabase` for Supabase configuration
- document Supabase env usage in README
- allow committing `.env.supabase`

## Testing
- `pnpm run build` *(fails: Error validating datasource `db`: the URL must contain a valid API key, missing email envs)*
- `pnpm test` *(fails: network errors and failing tests)*

------
