### PR TITLE
feat: valida env para Supabase

### DIFF
--- a/lib/validateEnv.ts
+++ b/lib/validateEnv.ts
@@ -1,9 +1,19 @@
 import { warn } from './logger'
 
-const REQUIRED = ['JWT_SECRET', 'NEXTAUTH_SECRET', 'NEXTAUTH_URL'] as const
+const BASE_REQUIRED = ['JWT_SECRET', 'NEXTAUTH_SECRET', 'NEXTAUTH_URL'] as const
+const SUPABASE_REQUIRED = [
+  'SUPABASE_URL',
+  'SUPABASE_SERVICE_ROLE_KEY',
+  'POSTGRES_URL',
+  'POSTGRES_PRISMA_URL',
+] as const
 
 export default function validateEnv() {
-  const missing = REQUIRED.filter((key) => !process.env[key])
+  const required: string[] = [...BASE_REQUIRED]
+  if (process.env.DB_PROVIDER === 'supabase') {
+    required.push(...SUPABASE_REQUIRED)
+  }
+  const missing = required.filter((key) => !process.env[key])
   if (!missing.length) return
   const message = `Faltan variables de entorno: ${missing.join(', ')}`
   const shouldThrow =


### PR DESCRIPTION
## Summary
- extiende `validateEnv` para requerir variables de Supabase cuando `DB_PROVIDER` es `supabase`

## Testing
- `pnpm run build` (falla: SMTP_USER o SMTP_PASS faltantes)
- `pnpm test` (1 fallido, 154 pasados)
- `node` script de validación de env (lanza error listado de variables Supabase)


------
