### PR TITLE
feat: usar Supabase en notas y ajustar adaptador

### DIFF
--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -9,9 +9,9 @@ export interface DbClient {
 }
 
 export function getDb(): DbClient {
-  return process.env.DB_PROVIDER === 'supabase'
-    ? SupabaseAdapter
-    : PrismaAdapter
+  return process.env.DB_PROVIDER === 'prisma'
+    ? PrismaAdapter
+    : SupabaseAdapter
 }
 
 export { PrismaAdapter, SupabaseAdapter }

--- a/src/app/api/notas/[id]/route.ts
+++ b/src/app/api/notas/[id]/route.ts
@@ -1,7 +1,8 @@
 export const runtime = 'nodejs'
 
 import { NextRequest, NextResponse } from 'next/server'
-import prisma from '@lib/prisma'
+import { getDb } from '@lib/db'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { getUsuarioFromSession } from '@lib/auth'
 import * as logger from '@lib/logger'
 
@@ -22,8 +23,15 @@ export async function PUT(req: NextRequest) {
     if (typeof contenido !== 'string') {
       return NextResponse.json({ error: 'Datos inválidos' }, { status: 400 })
     }
-    const nota = await (prisma as any).nota.update({ where: { id }, data: { contenido } })
-    return NextResponse.json({ nota })
+    const db = getDb().client as SupabaseClient
+    const { data, error } = await db
+      .from('nota')
+      .update({ contenido })
+      .eq('id', id)
+      .select()
+      .single()
+    if (error) throw error
+    return NextResponse.json({ nota: data })
   } catch (err) {
     logger.error('PUT /api/notas/[id]', err)
     return NextResponse.json({ error: 'Error' }, { status: 500 })
@@ -36,7 +44,9 @@ export async function DELETE(req: NextRequest) {
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     const id = getNotaId(req)
     if (!id) return NextResponse.json({ error: 'ID inválido' }, { status: 400 })
-    await (prisma as any).nota.delete({ where: { id } })
+    const db = getDb().client as SupabaseClient
+    const { error } = await db.from('nota').delete().eq('id', id)
+    if (error) throw error
     return NextResponse.json({ ok: true })
   } catch (err) {
     logger.error('DELETE /api/notas/[id]', err)

--- a/src/app/api/notas/route.ts
+++ b/src/app/api/notas/route.ts
@@ -1,7 +1,8 @@
 export const runtime = 'nodejs'
 
 import { NextRequest, NextResponse } from 'next/server'
-import prisma from '@lib/prisma'
+import { getDb } from '@lib/db'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { getUsuarioFromSession } from '@lib/auth'
 import * as logger from '@lib/logger'
 
@@ -11,8 +12,14 @@ export async function GET(req: NextRequest) {
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     const tabId = req.nextUrl.searchParams.get('tabId')
     if (!tabId) return NextResponse.json({ error: 'tabId requerido' }, { status: 400 })
-    const notas = await (prisma as any).nota.findMany({ where: { tabId }, orderBy: { id: 'asc' } })
-    return NextResponse.json({ notas })
+    const db = getDb().client as SupabaseClient
+    const { data, error } = await db
+      .from('nota')
+      .select('*')
+      .eq('tabId', tabId)
+      .order('id', { ascending: true })
+    if (error) throw error
+    return NextResponse.json({ notas: data })
   } catch (err) {
     logger.error('GET /api/notas', err)
     return NextResponse.json({ error: 'Error' }, { status: 500 })
@@ -48,8 +55,14 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Datos incompletos' }, { status: 400 })
     }
 
-    const nota = await (prisma as any).nota.create({ data: { tabId, tipo, contenido } })
-    return NextResponse.json({ nota }, { status: 201 })
+    const db = getDb().client as SupabaseClient
+    const { data, error } = await db
+      .from('nota')
+      .insert({ tabId, tipo, contenido })
+      .select()
+      .single()
+    if (error) throw error
+    return NextResponse.json({ nota: data }, { status: 201 })
   } catch (err) {
     logger.error('POST /api/notas', err)
     return NextResponse.json({ error: 'Error' }, { status: 500 })

--- a/src/estado_supabase.txt
+++ b/src/estado_supabase.txt
@@ -1,0 +1,8 @@
+Migración a Supabase - estado actual
+
+- Adaptador de base de datos configurado para usar Supabase por defecto; Prisma queda reservado para la estructura y generación de tipos.
+- Endpoints de notas (`/api/notas` y `/api/notas/[id]`) ya operan con el cliente de Supabase.
+- Aún existen numerosas rutas y utilidades que consumen Prisma directamente; requieren migración gradual.
+- Faltan transacciones reales y manejo de errores específico para Supabase.
+- Los tests dependen de mocks de Prisma; es necesario reemplazarlos progresivamente por stubs de Supabase.
+- Revisar rendimiento y límites de seguridad antes de deshabilitar Prisma por completo.

--- a/tests/notasApi.test.ts
+++ b/tests/notasApi.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { NextRequest } from 'next/server'
-import prisma from '../lib/prisma'
+import * as db from '../lib/db'
 import * as auth from '../lib/auth'
 
 const { GET, POST } = await import('../src/app/api/notas/route')
-const { PUT, DELETE } = await import('../src/app/api/notas/[id]/route')
+const { PUT } = await import('../src/app/api/notas/[id]/route')
 
 afterEach(() => vi.restoreAllMocks())
 
@@ -18,17 +18,26 @@ describe('api notas', () => {
 
   it('crea nota', async () => {
     vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ id: 1 } as any)
-    const create = vi.spyOn((prisma as any).nota, 'create').mockResolvedValue({ id: 2 })
+    const single = vi.fn().mockResolvedValue({ data: { id: 2 }, error: null })
+    const select = vi.fn(() => ({ single }))
+    const insert = vi.fn(() => ({ select }))
+    const from = vi.fn(() => ({ insert }))
+    vi.spyOn(db, 'getDb').mockReturnValue({ client: { from } } as any)
     const body = JSON.stringify({ tabId: 't1', tipo: 'url', contenido: 'http://x' })
     const req = new NextRequest('http://localhost/api/notas', { method: 'POST', body })
     const res = await POST(req)
     expect(res.status).toBe(201)
-    expect(create).toHaveBeenCalledWith({ data: { tabId: 't1', tipo: 'url', contenido: 'http://x' } })
+    expect(insert).toHaveBeenCalledWith({ tabId: 't1', tipo: 'url', contenido: 'http://x' })
   })
 
   it('actualiza nota', async () => {
     vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ id: 1 } as any)
-    const update = vi.spyOn((prisma as any).nota, 'update').mockResolvedValue({ id: 2 })
+    const single = vi.fn().mockResolvedValue({ data: { id: 2 }, error: null })
+    const select = vi.fn(() => ({ single }))
+    const eq = vi.fn(() => ({ select }))
+    const update = vi.fn(() => ({ eq }))
+    const from = vi.fn(() => ({ update }))
+    vi.spyOn(db, 'getDb').mockReturnValue({ client: { from } } as any)
     const req = new NextRequest('http://localhost/api/notas/2', { method: 'PUT', body: JSON.stringify({ contenido: 'c2' }) })
     const res = await PUT(req)
     expect(res.status).toBe(200)


### PR DESCRIPTION
## Summary
- usa Supabase como proveedor por defecto en el adaptador de base de datos
- migra los endpoints de notas a Supabase
- documenta estado de la migración en `src/estado_supabase.txt`
- actualiza pruebas de notas para mockear Supabase

## Testing
- `pnpm run build` (falla: Faltan variables de entorno: JWT_SECRET, NEXTAUTH_SECRET, NEXTAUTH_URL)
- `pnpm test`

------
