### PR TITLE
fix(login): manejar contraseñas nulas

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -56,7 +56,11 @@ export async function POST(req: NextRequest) {
         },
       })
 
-      if (!usuario || !(await bcrypt.compare(contrasena, usuario.contrasena))) {
+      if (
+        !usuario ||
+        !usuario.contrasena ||
+        !(await bcrypt.compare(contrasena, usuario.contrasena))
+      ) {
         return NextResponse.json(
           { success: false, error: 'Credenciales inválidas.' },
           { status: 401 }
@@ -155,7 +159,12 @@ export async function POST(req: NextRequest) {
       )
       .eq('correo', correo.toLowerCase().trim())
       .maybeSingle()
-    if (error || !usuario || !(await bcrypt.compare(contrasena, usuario.contrasena))) {
+    if (
+      error ||
+      !usuario ||
+      !usuario.contrasena ||
+      !(await bcrypt.compare(contrasena, usuario.contrasena))
+    ) {
       return NextResponse.json(
         { success: false, error: 'Credenciales inválidas.' },
         { status: 401 }

--- a/tests/login.test.ts
+++ b/tests/login.test.ts
@@ -41,4 +41,45 @@ describe('login', () => {
     const res = await POST(req)
     expect(res.status).toBe(403)
   })
+
+  it('retorna 401 si la contraseña es incorrecta', async () => {
+    vi.spyOn(prisma.usuario, 'findUnique').mockResolvedValue({
+      id: 1,
+      nombre: 'Test',
+      correo: 'test@user.com',
+      contrasena: 'hash',
+      tipoCuenta: 'individual',
+      estado: 'activo',
+      entidad: null,
+      roles: [],
+      suscripciones: [],
+    } as any)
+    vi.spyOn(bcrypt, 'compare').mockResolvedValue(false as any)
+    const req = new NextRequest('http://localhost/api/login', {
+      method: 'POST',
+      body: JSON.stringify({ correo: 'test@user.com', contrasena: 'wrong' }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('retorna 401 si el usuario no tiene contraseña', async () => {
+    vi.spyOn(prisma.usuario, 'findUnique').mockResolvedValue({
+      id: 1,
+      nombre: 'Test',
+      correo: 'test@user.com',
+      contrasena: null,
+      tipoCuenta: 'individual',
+      estado: 'activo',
+      entidad: null,
+      roles: [],
+      suscripciones: [],
+    } as any)
+    const req = new NextRequest('http://localhost/api/login', {
+      method: 'POST',
+      body: JSON.stringify({ correo: 'test@user.com', contrasena: 'pass' }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+  })
 })

--- a/tests/loginSuccess.test.ts
+++ b/tests/loginSuccess.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import bcrypt from 'bcryptjs'
+import { prisma } from '@lib/db/prisma'
+import { SESSION_COOKIE } from '@lib/constants'
+
+process.env.JWT_SECRET = 'test-secret'
+process.env.DB_PROVIDER = 'prisma'
+
+const { POST } = await import('../src/app/api/login/route')
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('login success', () => {
+  it('retorna 200 y cookie de sesion si credenciales validas', async () => {
+    vi.spyOn(prisma.usuario, 'findUnique').mockResolvedValue({
+      id: 1,
+      nombre: 'Test',
+      correo: 'test@user.com',
+      contrasena: 'hash',
+      tipoCuenta: 'individual',
+      estado: 'activo',
+      entidad: null,
+      roles: [],
+      suscripciones: [],
+    } as any)
+    const originalSesion = (prisma as any).sesionUsuario
+    ;(prisma as any).sesionUsuario = { create: vi.fn().mockResolvedValue({ id: 10 }) }
+    vi.spyOn(bcrypt, 'compare').mockResolvedValue(true as any)
+
+    const req = new NextRequest('http://localhost/api/login', {
+      method: 'POST',
+      body: JSON.stringify({ correo: 'test@user.com', contrasena: 'pass' }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    expect(res.cookies.get(SESSION_COOKIE)?.value).toBeTruthy()
+    ;(prisma as any).sesionUsuario = originalSesion
+  })
+})


### PR DESCRIPTION
## Summary
- valida contraseña nula antes de comparar en `/api/login`
- amplia pruebas de login e incluye caso exitoso

## Testing
- `JWT_SECRET=1 NEXTAUTH_SECRET=1 NEXTAUTH_URL=http://localhost EMAIL_ADMIN=a EMAIL_DESTINO_ESTANDAR=a EMAIL_DESTINO_VALIDACION=a SMTP_USER=a SMTP_PASS=a NEXT_PUBLIC_RECAPTCHA_SITE_KEY=a RECAPTCHA_SECRET_KEY=a DIRECT_DB_URL=postgres://a DB_PROVIDER=prisma pnpm run build` ⚠️ *warnings de compilación y errores P6001 de Prisma*
- `DB_PROVIDER=prisma pnpm test` ❌ *2 pruebas fallaron: ReferenceError: db is not defined*


------
https://chatgpt.com/codex/tasks/task_e_688d47aafc3c8328a5dbc752d844e6a4