### PR TITLE
fix(login): validar tipos de credenciales

### DIFF
--- a/tests/login.test.ts
+++ b/tests/login.test.ts
@@ -41,4 +41,13 @@ describe('login', () => {
     const res = await POST(req)
     expect(res.status).toBe(403)
   })
+
+  it('retorna 400 si los campos no son válidos', async () => {
+    const req = new NextRequest('http://localhost/api/login', {
+      method: 'POST',
+      body: JSON.stringify({ correo: 123, contrasena: {} }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
 })


### PR DESCRIPTION
## Summary
- valida tipo de correo y contraseña en `/api/login`
- cubre caso de payload inválido en pruebas

## Testing
- `pnpm run build` *(falla: Prisma connection error)*
- `pnpm test` *(falla: ReferenceError: db is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688d47aafc3c8328a5dbc752d844e6a4