### PR TITLE
feat(auth): soporte supabase en sesión

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -3,6 +3,7 @@ import jwt from 'jsonwebtoken'
 import { getDb } from '@lib/db'
 import { SESSION_COOKIE } from '@lib/constants'
 import type { Usuario } from '@/types/usuario'
+import type { SupabaseClient } from '@supabase/supabase-js'
 
 interface SesionUsuario {
   activa: boolean
@@ -51,34 +52,60 @@ export async function getUsuarioFromSession(
   if (!token) return null
 
   try {
-    const db = getDb().client as AuthDb
     const decoded = jwt.verify(token, JWT_SECRET) as { id: number; sid?: number }
-    if (decoded.sid) {
-      const sesion = await db.sesionUsuario.findUnique({
-        where: { id: decoded.sid },
-        select: { activa: true, usuarioId: true },
+
+    if (process.env.DB_PROVIDER === 'prisma') {
+      const db = getDb().client as AuthDb
+      if (decoded.sid) {
+        const sesion = await db.sesionUsuario.findUnique({
+          where: { id: decoded.sid },
+          select: { activa: true, usuarioId: true },
+        })
+        if (!sesion || !sesion.activa || sesion.usuarioId !== decoded.id) return null
+        await db.sesionUsuario.update({
+          where: { id: decoded.sid },
+          data: { fechaUltima: new Date() },
+        })
+      }
+      const usuario = await db.usuario.findUnique({
+        where: { id: decoded.id },
+        select: {
+          id: true,
+          nombre: true,
+          correo: true,
+          tipoCuenta: true,
+          entidadId: true,
+          esSuperAdmin: true,
+          roles: { select: { nombre: true } },
+          plan: { select: { nombre: true } },
+          preferencias: true,
+        },
       })
-      if (!sesion || !sesion.activa || sesion.usuarioId !== decoded.id) return null
-      await db.sesionUsuario.update({
-        where: { id: decoded.sid },
-        data: { fechaUltima: new Date() },
-      })
+      return usuario
     }
-    const usuario = await db.usuario.findUnique({
-      where: { id: decoded.id },
-      select: {
-        id: true,
-        nombre: true,
-        correo: true,
-        tipoCuenta: true,
-        entidadId: true,
-        esSuperAdmin: true,
-        roles: { select: { nombre: true } },
-        plan: { select: { nombre: true } },
-        preferencias: true,
-      },
-    })
-    return usuario
+
+    const db = getDb().client as SupabaseClient
+    if (decoded.sid) {
+      const { data: sesion } = await db
+        .from('SesionUsuario')
+        .select('activa,usuarioId')
+        .eq('id', decoded.sid)
+        .maybeSingle()
+      if (!sesion || !sesion.activa || sesion.usuarioId !== decoded.id) return null
+      await db
+        .from('SesionUsuario')
+        .update({ fechaUltima: new Date().toISOString() })
+        .eq('id', decoded.sid)
+    }
+    const { data: usuario } = await db
+      .from('Usuario')
+      .select(
+        'id,nombre,correo,tipoCuenta,entidadId,esSuperAdmin,' +
+          'roles:rol(nombre,_RolToUsuario!inner(usuarioId)),plan:planId(nombre),preferencias',
+      )
+      .eq('id', decoded.id)
+      .maybeSingle()
+    return usuario as unknown as Usuario | null
   } catch {
     return null
   }

--- a/tests/authGetUsuarioFromSession.test.ts
+++ b/tests/authGetUsuarioFromSession.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import jwt from 'jsonwebtoken'
+import { SESSION_COOKIE } from '@lib/constants'
+
+vi.mock('@lib/db', () => ({ getDb: vi.fn() }))
+
+process.env.JWT_SECRET = 'test-secret'
+process.env.DB_PROVIDER = 'prisma'
+
+const { getDb } = await import('@lib/db')
+const { getUsuarioFromSession } = await import('../lib/auth')
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  process.env.DB_PROVIDER = 'prisma'
+})
+
+describe('getUsuarioFromSession', () => {
+  it('retorna usuario con prisma', async () => {
+    process.env.JWT_SECRET = 'test-secret'
+    process.env.DB_PROVIDER = 'prisma'
+
+    const token = jwt.sign({ id: 1, sid: 1 }, 'test-secret')
+    const req = {
+      cookies: { get: (name: string) => (name === SESSION_COOKIE ? { value: token } : undefined) },
+    }
+
+    const usuario = {
+      id: 1,
+      nombre: 'Test',
+      correo: 'test@example.com',
+      tipoCuenta: 'individual',
+      entidadId: null,
+      esSuperAdmin: false,
+      roles: [{ nombre: 'user' }],
+      plan: { nombre: 'free' },
+      preferencias: null,
+    }
+
+    const sesionUsuario = {
+      findUnique: vi.fn().mockResolvedValue({ activa: true, usuarioId: 1 }),
+      update: vi.fn().mockResolvedValue(undefined),
+    }
+    const usuarioModel = { findUnique: vi.fn().mockResolvedValue(usuario) }
+
+    vi.mocked(getDb).mockReturnValue({ client: { sesionUsuario, usuario: usuarioModel } as any })
+
+    const res = await getUsuarioFromSession(req as any)
+    expect(res).toEqual(usuario)
+    expect(sesionUsuario.update).toHaveBeenCalledOnce()
+  })
+
+  it('retorna usuario con supabase', async () => {
+    process.env.JWT_SECRET = 'test-secret'
+    process.env.DB_PROVIDER = 'supabase'
+
+    const token = jwt.sign({ id: 1, sid: 1 }, 'test-secret')
+    const req = {
+      cookies: { get: (name: string) => (name === SESSION_COOKIE ? { value: token } : undefined) },
+    }
+
+    const usuario = {
+      id: 1,
+      nombre: 'Test',
+      correo: 'test@example.com',
+      tipoCuenta: 'individual',
+      entidadId: null,
+      esSuperAdmin: false,
+      roles: [{ nombre: 'user' }],
+      plan: { nombre: 'free' },
+      preferencias: null,
+    }
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'SesionUsuario') {
+          return {
+            select: () => ({
+              eq: () => ({ maybeSingle: () => Promise.resolve({ data: { activa: true, usuarioId: 1 } }) }),
+            }),
+            update: () => ({ eq: () => Promise.resolve({}) }),
+          }
+        }
+        if (table === 'Usuario') {
+          return {
+            select: () => ({
+              eq: () => ({ maybeSingle: () => Promise.resolve({ data: usuario }) }),
+            }),
+          }
+        }
+        throw new Error('tabla desconocida')
+      }),
+    }
+
+    vi.mocked(getDb).mockReturnValue({ client: supabase as any })
+
+    const res = await getUsuarioFromSession(req as any)
+    expect(res).toEqual(usuario)
+    expect(supabase.from).toHaveBeenCalledWith('SesionUsuario')
+    expect(supabase.from).toHaveBeenCalledWith('Usuario')
+  })
+})
+


### PR DESCRIPTION
## Summary
- agrega rama que usa SupabaseClient cuando DB_PROVIDER no es `prisma`
- prueba de `getUsuarioFromSession` para Prisma y Supabase

## Testing
- `DB_PROVIDER=prisma pnpm run build` *(fails: Faltan variables en .env)*
- `DB_PROVIDER=prisma pnpm test` *(fails: ReferenceError db is not defined in notasApi.test.ts)*


------
