### PR TITLE
fix: normalizar fk entidad usuario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.30
+- Normalizamos `Usuario.entidad_id` y declaramos la FK a `Entidad`.
+
 ## 0.8.29
 - Desconectamos por completo las llamadas de inventario, dejando solo la interfaz.
 

--- a/prisma/migrations/20250715000000_usuario_entidad_snake/migration.sql
+++ b/prisma/migrations/20250715000000_usuario_entidad_snake/migration.sql
@@ -1,0 +1,5 @@
+-- Normalize usuario.entidad_id for PostgREST relations
+ALTER TABLE "Usuario" DROP CONSTRAINT IF EXISTS "Usuario_entidadId_fkey";
+ALTER TABLE "Usuario" RENAME COLUMN "entidadId" TO entidad_id;
+ALTER TABLE "Usuario"
+  ADD CONSTRAINT "Usuario_entidad_id_fkey" FOREIGN KEY (entidad_id) REFERENCES "Entidad"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,7 +59,7 @@ model Usuario {
   tipoCuenta           String
   estado               String                 @default("pendiente")
   fechaRegistro        DateTime               @default(now())
-  entidadId            Int?
+  entidadId            Int?                   @map("entidad_id")
   archivoBuffer        Bytes?
   archivoNombre        String?
   codigoUsado          String?


### PR DESCRIPTION
## Summary
- normaliza la columna `usuario.entidad_id`
- agrega FK explícita a `Entidad`

## Testing
- `DB_PROVIDER=prisma JWT_SECRET=1 NEXTAUTH_SECRET=1 NEXTAUTH_URL=http://localhost EMAIL_ADMIN=a EMAIL_DESTINO_ESTANDAR=a EMAIL_DESTINO_VALIDACION=a SMTP_USER=a SMTP_PASS=a NEXT_PUBLIC_RECAPTCHA_SITE_KEY=a RECAPTCHA_SECRET_KEY=a DIRECT_DB_URL=postgresql://localhost:5432/db pnpm run build` *(warnings: require-in-the-middle; Prisma datasource)*
- `DB_PROVIDER=prisma JWT_SECRET=1 pnpm test` *(6 tests failed: db.from not a function, missing vars)*

------
https://chatgpt.com/codex/tasks/task_e_688d61d78758832883fe9fd6d2d42929