### PR TITLE
feat(prisma): enforce snake_case joins

### DIFF
--- a/prisma/migrations/20250806000000_add_foreign_keys/migration.sql
+++ b/prisma/migrations/20250806000000_add_foreign_keys/migration.sql
@@ -1,0 +1,15 @@
+-- Añade claves foráneas para relaciones principales
+ALTER TABLE "usuario"
+  ADD CONSTRAINT "usuario_entidad_id_fkey" FOREIGN KEY ("entidad_id") REFERENCES "entidad"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "usuario"
+  ADD CONSTRAINT "usuario_plan_id_fkey" FOREIGN KEY ("plan_id") REFERENCES "plan"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "suscripcion"
+  ADD CONSTRAINT "suscripcion_usuario_id_fkey" FOREIGN KEY ("usuario_id") REFERENCES "usuario"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "suscripcion"
+  ADD CONSTRAINT "suscripcion_entidad_id_fkey" FOREIGN KEY ("entidad_id") REFERENCES "entidad"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "suscripcion"
+  ADD CONSTRAINT "suscripcion_plan_id_fkey" FOREIGN KEY ("plan_id") REFERENCES "plan"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,35 +18,38 @@ model Plan {
   entidades     Entidad[]
   suscripciones Suscripcion[]
   usuarios      Usuario[]
+  @@map("plan")
 }
 
 model Suscripcion {
   id          Int       @id @default(autoincrement())
-  usuarioId   Int?
-  entidadId   Int?
-  planId      Int
-  fechaInicio DateTime  @default(now())
-  fechaFin    DateTime?
+  usuarioId   Int?      @map("usuario_id")
+  entidadId   Int?      @map("entidad_id")
+  planId      Int       @map("plan_id")
+  fechaInicio DateTime  @default(now()) @map("fecha_inicio")
+  fechaFin    DateTime? @map("fecha_fin")
   activo      Boolean   @default(true)
   entidad     Entidad?  @relation(fields: [entidadId], references: [id])
   plan        Plan      @relation(fields: [planId], references: [id])
   usuario     Usuario?  @relation(fields: [usuarioId], references: [id])
+  @@map("suscripcion")
 }
 
 model Entidad {
   id             Int           @id @default(autoincrement())
   nombre         String
   tipo           String
-  correoContacto String
+  correoContacto String        @map("correo_contacto")
   telefono       String?
   direccion      String?
-  fechaCreacion  DateTime      @default(now())
-  planId         Int?
+  fechaCreacion  DateTime      @default(now()) @map("fecha_creacion")
+  planId         Int?          @map("plan_id")
   almacenes      Almacen[]
   plan           Plan?         @relation(fields: [planId], references: [id])
   roles          Rol[]
   suscripciones  Suscripcion[]
   usuarios       Usuario[]
+  @@map("entidad")
 }
 
 model Usuario {
@@ -55,22 +58,22 @@ model Usuario {
   apellidos            String
   correo               String                 @unique
   contrasena           String
-  googleId             String?
-  tipoCuenta           String
+  googleId             String?                @map("google_id")
+  tipoCuenta           String                 @map("tipo_cuenta")
   estado               String                 @default("pendiente")
-  fechaRegistro        DateTime               @default(now())
-  entidadId            Int?
-  archivoBuffer        Bytes?
-  archivoNombre        String?
-  codigoUsado          String?
-  planId               Int?
-  codigo2FASecret      String?
-  fotoPerfil           Bytes?
-  fotoPerfilNombre     String?
-  metodo2FA            String?
+  fechaRegistro        DateTime               @default(now()) @map("fecha_registro")
+  entidadId            Int?                   @map("entidad_id")
+  archivoBuffer        Bytes?                 @map("archivo_buffer")
+  archivoNombre        String?                @map("archivo_nombre")
+  codigoUsado          String?                @map("codigo_usado")
+  planId               Int?                   @map("plan_id")
+  codigo2FASecret      String?                @map("codigo_2fa_secret")
+  fotoPerfil           Bytes?                 @map("foto_perfil")
+  fotoPerfilNombre     String?                @map("foto_perfil_nombre")
+  metodo2FA            String?                @map("metodo_2fa")
   preferencias         String?
-  tiene2FA             Boolean?               @default(false)
-  esSuperAdmin         Boolean?               @default(false)
+  tiene2FA             Boolean?               @default(false) @map("tiene_2fa")
+  esSuperAdmin         Boolean?               @default(false) @map("es_super_admin")
   archivosMaterial     ArchivoMaterial[]
   archivosUnidad       ArchivoUnidad[]
   auditLogs            AuditLog[]
@@ -108,6 +111,7 @@ model Usuario {
   plan                 Plan?                  @relation(fields: [planId], references: [id])
   almacenes            UsuarioAlmacen[]
   roles                Rol[]                  @relation("RolToUsuario")
+  @@map("usuario")
 }
 
 model BitacoraCambioPerfil {
@@ -120,13 +124,14 @@ model BitacoraCambioPerfil {
 
 model SesionUsuario {
   id          Int      @id @default(autoincrement())
-  usuarioId   Int
-  userAgent   String?
+  usuarioId   Int      @map("usuario_id")
+  userAgent   String?  @map("user_agent")
   ip          String?
-  fechaInicio DateTime @default(now())
-  fechaUltima DateTime @default(now())
+  fechaInicio DateTime @default(now()) @map("fecha_inicio")
+  fechaUltima DateTime @default(now()) @map("fecha_ultima")
   activa      Boolean  @default(true)
   usuario     Usuario  @relation(fields: [usuarioId], references: [id])
+  @@map("sesion_usuario")
 }
 
 model Rol {


### PR DESCRIPTION
## Summary
- map core models to snake_case tables and columns
- add foreign keys for usuario.entidad_id and suscripcion.plan_id

## Testing
- `JWT_SECRET=x NEXTAUTH_SECRET=x NEXTAUTH_URL=http://localhost EMAIL_ADMIN=x EMAIL_DESTINO_ESTANDAR=x EMAIL_DESTINO_VALIDACION=x SMTP_USER=x SMTP_PASS=x NEXT_PUBLIC_RECAPTCHA_SITE_KEY=x RECAPTCHA_SECRET_KEY=x DIRECT_DB_URL=postgresql://user:pass@localhost:5432/db DB_PROVIDER=prisma pnpm run build` (fails: Prisma connection error: Error validating datasource `db`: the URL must start with the protocol `prisma://` or `prisma+postgres://`)
- `DB_PROVIDER=prisma JWT_SECRET=x pnpm test` (fails: 5 tests failed)


------
https://chatgpt.com/codex/tasks/task_e_688d6201ddb4832894162c60ad3f6138