### PR TITLE
fix: alias suscripcion join

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -45,7 +45,7 @@ export async function POST (req: NextRequest) {
         roles:rol_usuario!inner(
           rol:Rol ( id, nombre, descripcion, permisos )
         ),
-        suscripciones!inner(
+        suscripciones:suscripcion!inner(
           id, activo, fecha_fin,
           plan:plan_id ( nombre, limites )
         )


### PR DESCRIPTION
## Summary
- fix login query by aliasing `suscripcion` relationship

## Testing
- `DB_PROVIDER=prisma JWT_SECRET=secret NEXTAUTH_SECRET=secret NEXTAUTH_URL=http://localhost EMAIL_ADMIN=foo@bar.com EMAIL_DESTINO_ESTANDAR=foo@bar.com EMAIL_DESTINO_VALIDACION=foo@bar.com SMTP_USER=user SMTP_PASS=pass NEXT_PUBLIC_RECAPTCHA_SITE_KEY=sitekey RECAPTCHA_SECRET_KEY=secret DIRECT_DB_URL=postgres://user:pass@localhost:5432/db pnpm run build`
- `pnpm test` *(fails: Supabase no configurado; db.from is not a function; Faltante: DB_PROVIDER en .env)*

------
https://chatgpt.com/codex/tasks/task_e_688d6a88728c83288ca978a4ccfa9de8