### PR TITLE
fix(auth): consulta de suscripción separada

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -44,10 +44,6 @@ export async function POST (req: NextRequest) {
         entidad:entidad_id ( id, nombre, tipo, plan_id ),
         roles:rol_usuario!inner(
           rol:Rol ( id, nombre, descripcion, permisos )
-        ),
-        suscripciones:suscripcion!inner(
-          id, activo, fecha_fin,
-          plan:plan_id ( nombre, limites )
         )
       `)
       .eq('correo', email)
@@ -75,7 +71,16 @@ export async function POST (req: NextRequest) {
       permisos: parseJson(rol.permisos),
     }))
 
-    const susActiva = (usuario.suscripciones ?? []).find(s => s.activo)
+    const { data: susActiva } = await db
+      .from('suscripcion')
+      .select(`
+        id, fecha_fin,
+        plan:plan_id ( nombre, limites )
+      `)
+      .eq('usuario_id', usuario.id)
+      .eq('activo', true)
+      .maybeSingle()
+
     const plan =
       susActiva && susActiva.plan
         ? {


### PR DESCRIPTION
## Summary
- evita joins sin FK al cargar suscripción activa tras autenticar
- actualiza pruebas de login con mock de Supabase

## Testing
- `DB_PROVIDER=prisma pnpm run build` *(fails: missing env vars)*
- `DB_PROVIDER=prisma pnpm test` *(fails: 1 test file with ReferenceError)*

------
