### PR TITLE
fix: normalize entidad plan reference

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -101,7 +101,7 @@ export async function getUsuarioFromSession(
       .from('usuario')
       .select(
         'id,nombre,correo,tipoCuenta,entidadId,esSuperAdmin,' +
-          'roles:rol(nombre,_RolToUsuario!inner(usuarioId)),plan:planId(nombre),preferencias',
+          'roles:rol(nombre,_RolToUsuario!inner(usuarioId)),plan:plan_id(nombre),preferencias',
       )
       .eq('id', decoded.id)
       .maybeSingle()

--- a/prisma/migrations/20250810000000_entidad_plan_fk_refresh/migration.sql
+++ b/prisma/migrations/20250810000000_entidad_plan_fk_refresh/migration.sql
@@ -1,0 +1,15 @@
+-- Normalize entidad.plan_id and refresh FK
+ALTER TABLE IF EXISTS "Entidad" RENAME TO entidad;
+
+ALTER TABLE entidad
+  RENAME COLUMN IF EXISTS "planId" TO plan_id;
+
+ALTER TABLE entidad
+  DROP CONSTRAINT IF EXISTS "Entidad_planId_fkey",
+  DROP CONSTRAINT IF EXISTS entidad_plan_fk,
+  DROP CONSTRAINT IF EXISTS entidad_plan_id_fkey;
+
+ALTER TABLE entidad
+  ADD CONSTRAINT entidad_plan_fk
+  FOREIGN KEY (plan_id)
+  REFERENCES plan(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
- rename `entidad.planId` to `plan_id` and refresh FK to `plan`
- query user auth with `plan_id` join

## Testing
- `pnpm run build` *(fails: DB_PROVIDER missing)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688d793a0038832895e98f8903809371