### PR TITLE
fix: consulta de login con join opcional

### DIFF
--- a/lib/db/supabase.ts
+++ b/lib/db/supabase.ts
@@ -10,7 +10,7 @@ function getClient() {
   if (!url || !key) {
     throw new Error('Supabase no configurado')
   }
-  client = createClient(url, key)
+  client = createClient(url, key, { auth: { persistSession: false } })
   return client
 }
 

--- a/tests/login.test.ts
+++ b/tests/login.test.ts
@@ -15,7 +15,8 @@ describe('login', () => {
   it('retorna 401 si el usuario no existe', async () => {
     const from = vi.fn().mockReturnValue({
       select: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
+      ilike: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
       maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
     })
     vi.mocked(getDb).mockReturnValue({ client: { from } } as any)
@@ -30,7 +31,8 @@ describe('login', () => {
   it('retorna 403 si la cuenta no está activa', async () => {
     const from = vi.fn().mockReturnValue({
       select: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
+      ilike: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
       maybeSingle: vi.fn().mockResolvedValue({
         data: {
           id: 1,


### PR DESCRIPTION
## Resumen
- usa LEFT JOIN y `ilike` en la consulta de login para permitir correo case-insensitive y roles opcionales
- desactiva la persistencia de sesión en el cliente de Supabase con clave de servicio
- actualiza los mocks del login para reflejar la nueva cadena de consulta

## Testing
- `pnpm run build` ⚠️ (Critical dependency: require function; Prisma connection error: URL must contain a valid API key)
- `pnpm test` ✅


------
