### PR TITLE
feat: mejora login y supabase en dashboard

### DIFF
--- a/src/app/api/dashboard/resumen/route.ts
+++ b/src/app/api/dashboard/resumen/route.ts
@@ -1,18 +1,34 @@
 export const runtime = 'nodejs';
 
 import { NextResponse } from 'next/server';
-import { prisma } from '@lib/db/prisma';
+import { getDb } from '@lib/db';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import * as logger from '@lib/logger';
 
 export async function GET() {
   try {
-    const [almacenes, materiales, unidades, movimientos] = await Promise.all([
-      prisma.almacen.count(),
-      prisma.material.count(),
-      prisma.materialUnidad.count(),
-      prisma.movimiento.count(),
+    const db = getDb().client as SupabaseClient;
+    const [almacenesRes, materialesRes, unidadesRes, movimientosRes] = await Promise.all([
+      db.from('almacen').select('id', { count: 'exact', head: true }),
+      db.from('material').select('id', { count: 'exact', head: true }),
+      db.from('material_unidad').select('id', { count: 'exact', head: true }),
+      db.from('movimiento').select('id', { count: 'exact', head: true }),
     ]);
-    return NextResponse.json({ almacenes, materiales, unidades, movimientos });
+
+    const errors = [
+      almacenesRes.error,
+      materialesRes.error,
+      unidadesRes.error,
+      movimientosRes.error,
+    ].filter(Boolean);
+    if (errors.length) throw new Error(errors.map((e) => e!.message).join('; '));
+
+    return NextResponse.json({
+      almacenes: almacenesRes.count ?? 0,
+      materiales: materialesRes.count ?? 0,
+      unidades: unidadesRes.count ?? 0,
+      movimientos: movimientosRes.count ?? 0,
+    });
   } catch (err) {
     logger.error('GET /api/dashboard/resumen', err);
     return NextResponse.json({ error: 'Error' }, { status: 500 });

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -96,6 +96,18 @@ export default function LoginForm() {
         autoComplete="current-password"
       />
 
+      <div className="flex justify-between text-sm">
+        <a
+          href="/olvide-contrasena"
+          className="text-amber-600 hover:underline"
+        >
+          Olvidé la contraseña
+        </a>
+        <a href="/registro" className="text-amber-600 hover:underline">
+          Crear cuenta
+        </a>
+      </div>
+
       {mensaje && (
         <p className="text-sm text-center text-red-600">{mensaje}</p>
       )}
@@ -109,6 +121,36 @@ export default function LoginForm() {
       >
         {loading ? "Entrando..." : "Entrar"}
       </button>
+
+      <div className="flex items-center text-xs text-amber-600 uppercase before:flex-1 before:border-t before:border-amber-200 before:me-2 after:flex-1 after:border-t after:border-amber-200 after:ms-2 mt-4">
+        Próximamente
+      </div>
+      <div className="grid gap-2 sm:grid-cols-3">
+        <button
+          type="button"
+          disabled
+          title="En mantenimiento"
+          className="w-full bg-gray-200 text-gray-500 font-semibold py-2 px-4 rounded cursor-not-allowed"
+        >
+          Google
+        </button>
+        <button
+          type="button"
+          disabled
+          title="En mantenimiento"
+          className="w-full bg-gray-200 text-gray-500 font-semibold py-2 px-4 rounded cursor-not-allowed"
+        >
+          Facebook
+        </button>
+        <button
+          type="button"
+          disabled
+          title="En mantenimiento"
+          className="w-full bg-gray-200 text-gray-500 font-semibold py-2 px-4 rounded cursor-not-allowed"
+        >
+          GitHub
+        </button>
+      </div>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- rediseña el formulario de login con enlaces y botones sociales en mantenimiento
- reemplaza Prisma por Supabase en los endpoints de dashboard
- ajusta prueba de layout para nuevo cliente de base de datos

## Testing
- `pnpm run build` *(falla: Faltante DB_PROVIDER en .env)*
- `DB_PROVIDER=supabase SUPABASE_URL=http://localhost SUPABASE_SERVICE_ROLE_KEY=dummy pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688da23932188328b25b6539ad66d27e