### PR TITLE
feat(auth): fetch user data from supabase

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,24 +1,64 @@
-import { cookies as getCookies } from 'next/headers';
-import jwt from 'jsonwebtoken';
-import { SESSION_COOKIE } from '@lib/constants';
-import { getDb } from '@lib/db';
+import { cookies as getCookies } from 'next/headers'
+import jwt from 'jsonwebtoken'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { SESSION_COOKIE } from '@lib/constants'
+import { getDb } from '@lib/db'
 
-const JWT_SECRET = process.env.JWT_SECRET!;
+const JWT_SECRET = process.env.JWT_SECRET!
 
-export async function getUsuarioFromSession({ cookies }: { cookies?: ReturnType<typeof getCookies> } = {}) {
-  const jar = cookies ?? await getCookies();
-  const token = jar.get(SESSION_COOKIE)?.value;
-  if (!token) return null;
+function parseJson (v: any) {
+  try { return typeof v === 'string' ? JSON.parse(v) : v ?? null }
+  catch { return null }
+}
+
+export async function getUsuarioFromSession ({ cookies }: { cookies?: ReturnType<typeof getCookies> } = {}) {
+  const jar = cookies ?? await getCookies()
+  const token = jar.get(SESSION_COOKIE)?.value
+  if (!token) return null
 
   try {
-    const { id, sid } = jwt.verify(token, JWT_SECRET) as { id: number; sid?: number };
+    const { id, sid } = jwt.verify(token, JWT_SECRET) as { id: number; sid?: number }
+    const db = getDb().client as SupabaseClient
+
     try {
-      const db = getDb().client;
-      const { data: ses } = await db.from('sesion_usuario').select('id').eq('id', sid ?? -1).maybeSingle();
-      if (!ses) return null;
+      const { data: ses } = await db.from('sesion_usuario').select('id').eq('id', sid ?? -1).maybeSingle()
+      if (!ses) return null
     } catch {}
-    return { id };
+
+    const { data: usuario } = await db
+      .from('usuario')
+      .select(`
+        id, nombre, correo, tipo_cuenta, rol, preferencias,
+        plan:plan_id ( id, nombre, limites ),
+        roles:rol_usuario ( rol:rol_id ( id, nombre, descripcion, permisos ) )
+      `)
+      .eq('id', id)
+      .maybeSingle()
+
+    if (!usuario) return { id }
+
+    const roles = (usuario.roles ?? []).map((r: any) => ({
+      id: r.rol.id,
+      nombre: r.rol.nombre,
+      descripcion: r.rol.descripcion,
+      permisos: parseJson(r.rol.permisos),
+    }))
+
+    const plan = usuario.plan
+      ? { id: usuario.plan.id, nombre: usuario.plan.nombre, limites: parseJson(usuario.plan.limites) }
+      : null
+
+    return {
+      id: usuario.id,
+      nombre: usuario.nombre,
+      correo: usuario.correo,
+      tipoCuenta: usuario.tipo_cuenta,
+      rol: usuario.rol ?? undefined,
+      preferencias: parseJson(usuario.preferencias),
+      roles,
+      plan,
+    }
   } catch {
-    return null;
+    return null
   }
 }


### PR DESCRIPTION
## Summary
- get session data from Supabase and include roles and plan
- adapt auth session test for new fields

## Testing
- `DB_PROVIDER=supabase pnpm run build` *(fails: Faltan variables en .env: JWT_SECRET, NEXTAUTH_SECRET, NEXTAUTH_URL, EMAIL_ADMIN, EMAIL_DESTINO_ESTANDAR, EMAIL_DESTINO_VALIDACION, SMTP_USER, SMTP_PASS, NEXT_PUBLIC_RECAPTCHA_SITE_KEY, RECAPTCHA_SECRET_KEY, DIRECT_URL, SUPABASE_JWT_SECRET, NEXT_PUBLIC_SUPABASE_ANON_KEY, POSTGRES_PASSWORD, POSTGRES_USER, POSTGRES_HOST, POSTGRES_DATABASE)*
- `DB_PROVIDER=supabase pnpm test`

------
