### PR TITLE
feat(dashboard): ampliar resumen con supabase

### DIFF
--- a/src/app/api/dashboard/resumen/route.ts
+++ b/src/app/api/dashboard/resumen/route.ts
@@ -8,10 +8,19 @@ import * as logger from '@lib/logger';
 export async function GET() {
   try {
     const db = getDb().client as SupabaseClient;
-    const [almacenesRes, materialesRes, unidadesRes, movimientosRes] = await Promise.all([
+    const [
+      almacenesRes,
+      materialesRes,
+      unidadesRes,
+      auditoriasRes,
+      panelesRes,
+      inventarioRes,
+    ] = await Promise.all([
       db.from('almacen').select('id', { count: 'exact', head: true }),
       db.from('material').select('id', { count: 'exact', head: true }),
       db.from('material_unidad').select('id', { count: 'exact', head: true }),
+      db.from('auditoria').select('id', { count: 'exact', head: true }),
+      db.from('panel').select('id', { count: 'exact', head: true }),
       db.from('movimiento').select('id', { count: 'exact', head: true }),
     ]);
 
@@ -19,7 +28,9 @@ export async function GET() {
       almacenesRes.error,
       materialesRes.error,
       unidadesRes.error,
-      movimientosRes.error,
+      auditoriasRes.error,
+      panelesRes.error,
+      inventarioRes.error,
     ].filter(Boolean);
     if (errors.length) throw new Error(errors.map((e) => e!.message).join('; '));
 
@@ -27,7 +38,9 @@ export async function GET() {
       almacenes: almacenesRes.count ?? 0,
       materiales: materialesRes.count ?? 0,
       unidades: unidadesRes.count ?? 0,
-      movimientos: movimientosRes.count ?? 0,
+      auditorias: auditoriasRes.count ?? 0,
+      paneles: panelesRes.count ?? 0,
+      inventario: inventarioRes.count ?? 0,
     });
   } catch (err) {
     logger.error('GET /api/dashboard/resumen', err);

--- a/tests/dashboardResumenRoute.test.ts
+++ b/tests/dashboardResumenRoute.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+afterEach(() => {
+  vi.resetModules()
+  vi.restoreAllMocks()
+})
+
+describe('dashboard resumen api', () => {
+  it('returns section counts', async () => {
+    const counts = {
+      almacen: 2,
+      material: 3,
+      material_unidad: 4,
+      auditoria: 5,
+      panel: 6,
+      movimiento: 7,
+    }
+    const from = vi.fn((table: string) => ({
+      select: vi.fn().mockResolvedValue({
+        count: counts[table as keyof typeof counts],
+        error: null,
+      }),
+    }))
+
+    vi.doMock('@lib/db', () => ({ getDb: () => ({ client: { from } }) }))
+
+    const { GET } = await import('../src/app/api/dashboard/resumen/route')
+    const res = await GET()
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data).toEqual({
+      almacenes: 2,
+      materiales: 3,
+      unidades: 4,
+      auditorias: 5,
+      paneles: 6,
+      inventario: 7,
+    })
+    expect(from).toHaveBeenCalledTimes(6)
+  })
+})
+


### PR DESCRIPTION
## Summary
- agrega métricas de auditorías, paneles e inventario en el resumen del dashboard usando Supabase
- prueba de ruta para validar conteos de secciones

## Testing
- `SKIP_ENV_CHECK=true DB_PROVIDER=supabase pnpm run build` (falla: Prisma connection error / variables faltantes)
- `DB_PROVIDER=supabase pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688da54ecd8c8328a047b5667542a4e5