### PR TITLE
feat: soporte supabase en snapshots y hooks

### DIFF
--- a/src/hooks/useHistorialAlmacen.ts
+++ b/src/hooks/useHistorialAlmacen.ts
@@ -20,7 +20,7 @@ export default function useHistorialAlmacen(almacenId?: number | string) {
   })
 
   return {
-    historial: (data?.historial as HistorialAlmacenEntry[]) ?? [],
+    historial: (data?.historial ?? data?.data ?? []) as HistorialAlmacenEntry[],
     loading: isLoading,
     error,
     mutate,

--- a/src/hooks/useMovimientos.ts
+++ b/src/hooks/useMovimientos.ts
@@ -22,7 +22,7 @@ export default function useMovimientos(almacenId?: number | string) {
   })
 
   return {
-    movimientos: (data?.movimientos as Movimiento[]) ?? [],
+    movimientos: (data?.movimientos ?? data?.data ?? []) as Movimiento[],
     loading: isLoading,
     error,
     mutate,


### PR DESCRIPTION
## Summary
- emulate transactions for Supabase adapter using RPC calls when available
- allow snapshot utilities to accept Supabase client and persist history
- normalize SWR hooks to new `{ data }` response shape

## Testing
- `pnpm run build`
- `pnpm test`


------
