### PR TITLE
feat: use supabase for reportes api

### DIFF
--- a/src/app/api/reportes/route.ts
+++ b/src/app/api/reportes/route.ts
@@ -1,27 +1,39 @@
 export const runtime = 'nodejs'
 
 import { NextRequest, NextResponse } from 'next/server'
-import { prisma } from '@lib/db/prisma'
+import { getDb } from '@lib/db'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { getUsuarioFromSession } from '@lib/auth'
+import { getMainRole, normalizeRol, normalizeTipoCuenta } from '@lib/permisos'
 import * as logger from '@lib/logger'
 
 export async function GET(req: NextRequest) {
   try {
+    const usuario = await getUsuarioFromSession(req)
+    if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
+
+    const rolMain = getMainRole(usuario)
+    const rol = normalizeRol(typeof rolMain === 'string' ? rolMain : rolMain?.nombre)
+    const tipoCuenta = normalizeTipoCuenta(usuario.tipoCuenta)
+    const allowedRoles = ['admin', 'administrador']
+    const allowedTipos = ['institucional', 'empresarial', 'admin']
+    if (!allowedRoles.includes(rol) && !allowedTipos.includes(tipoCuenta)) {
+      return NextResponse.json({ error: 'Sin permisos' }, { status: 403 })
+    }
+
     const tipo = req.nextUrl.searchParams.get('tipo') || undefined
-    const where: any = tipo && ['almacen', 'material', 'unidad'].includes(tipo) ? { tipo } : {}
-    const reportes = await prisma.reporte.findMany({
-      take: 20,
-      orderBy: { fecha: 'desc' },
-      where,
-      select: {
-        id: true,
-        tipo: true,
-        categoria: true,
-        fecha: true,
-        observaciones: true,
-      },
-    })
-    return NextResponse.json({ reportes })
+    const db = getDb().client as SupabaseClient
+    let query = db
+      .from('reporte')
+      .select('id, tipo, categoria, fecha, observaciones')
+      .order('fecha', { ascending: false })
+      .limit(20)
+    if (tipo && ['almacen', 'material', 'unidad'].includes(tipo)) {
+      query = query.eq('tipo', tipo)
+    }
+    const { data, error } = await query
+    if (error) throw error
+    return NextResponse.json({ reportes: data })
   } catch (err) {
     logger.error('GET /api/reportes', err)
     return NextResponse.json({ error: 'Error' }, { status: 500 })
@@ -32,6 +44,15 @@ export async function POST(req: NextRequest) {
   try {
     const usuario = await getUsuarioFromSession(req)
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
+
+    const rolMain = getMainRole(usuario)
+    const rol = normalizeRol(typeof rolMain === 'string' ? rolMain : rolMain?.nombre)
+    const tipoCuenta = normalizeTipoCuenta(usuario.tipoCuenta)
+    const allowedRoles = ['admin', 'administrador']
+    const allowedTipos = ['institucional', 'empresarial', 'admin']
+    if (!allowedRoles.includes(rol) && !allowedTipos.includes(tipoCuenta)) {
+      return NextResponse.json({ error: 'Sin permisos' }, { status: 403 })
+    }
 
     let tipo: string | null = null
     let objetoId: string | null = null
@@ -58,29 +79,35 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Datos incompletos' }, { status: 400 })
     }
 
-    const data: any = { tipo, observaciones, categoria, usuarioId: usuario.id }
-    if (tipo === 'almacen') data.almacenId = Number(objetoId)
-    if (tipo === 'material') data.materialId = Number(objetoId)
-    if (tipo === 'unidad') data.unidadId = Number(objetoId)
+    const data: any = { tipo, observaciones, categoria, usuario_id: usuario.id }
+    if (tipo === 'almacen') data.almacen_id = Number(objetoId)
+    if (tipo === 'material') data.material_id = Number(objetoId)
+    if (tipo === 'unidad') data.unidad_id = Number(objetoId)
 
-    const reporte = await prisma.reporte.create({ data, select: { id: true } })
+    const db = getDb().client as SupabaseClient
+    const { data: rep, error } = await db
+      .from('reporte')
+      .insert(data)
+      .select('id')
+      .single()
+    if (error) throw error
 
     if (files.length > 0) {
       await Promise.all(
         files.map(async (f) => {
           const buffer = Buffer.from(await f.arrayBuffer())
-          await prisma.archivoReporte.create({
-            data: {
-              nombre: f.name,
-              archivo: buffer as any,
-              reporteId: reporte.id,
-            },
+          const { error: errArchivo } = await db.from('archivo_reporte').insert({
+            nombre: f.name,
+            archivo: buffer.toString('base64'),
+            reporte_id: rep.id,
+            subido_por_id: usuario.id,
           })
+          if (errArchivo) throw errArchivo
         }),
       )
     }
 
-    return NextResponse.json({ reporte })
+    return NextResponse.json({ reporte: rep })
   } catch (err) {
     logger.error('POST /api/reportes', err)
     return NextResponse.json({ error: 'Error' }, { status: 500 })

--- a/tests/reportesRoute.test.ts
+++ b/tests/reportesRoute.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+import * as db from '../lib/db'
+import * as auth from '../lib/auth'
+
+const { GET, POST } = await import('../src/app/api/reportes/route')
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('api reportes', () => {
+  it('requiere sesion en GET', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue(null as any)
+    const req = new NextRequest('http://localhost/api/reportes')
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('lista reportes', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ tipoCuenta: 'empresarial' } as any)
+    const limit = vi.fn().mockResolvedValue({ data: [], error: null })
+    const order = vi.fn(() => ({ limit }))
+    const select = vi.fn(() => ({ order, limit }))
+    const from = vi.fn(() => ({ select }))
+    vi.spyOn(db, 'getDb').mockReturnValue({ client: { from } } as any)
+    const req = new NextRequest('http://localhost/api/reportes')
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    expect(from).toHaveBeenCalledWith('reporte')
+  })
+
+  it('crea reporte', async () => {
+    vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue({ id: 1, tipoCuenta: 'empresarial' } as any)
+    const single = vi.fn().mockResolvedValue({ data: { id: 2 }, error: null })
+    const select = vi.fn(() => ({ single }))
+    const insert = vi.fn(() => ({ select }))
+    const from = vi.fn(() => ({ insert }))
+    vi.spyOn(db, 'getDb').mockReturnValue({ client: { from } } as any)
+    const body = JSON.stringify({ tipo: 'almacen', objetoId: 3, categoria: 'test', observaciones: '{}' })
+    const req = new NextRequest('http://localhost/api/reportes', { method: 'POST', body, headers: { 'Content-Type': 'application/json' } })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    expect(insert).toHaveBeenCalled()
+  })
+})
+


### PR DESCRIPTION
## Summary
- switch reportes API to Supabase queries with auth and role checks
- test reportes API behaviour

## Testing
- `DB_PROVIDER=supabase pnpm run build` *(fails: Faltan variables en .env: JWT_SECRET, NEXTAUTH_SECRET, NEXTAUTH_URL, EMAIL_ADMIN, EMAIL_DESTINO_ESTANDAR, EMAIL_DESTINO_VALIDACION, SMTP_USER, SMTP_PASS, NEXT_PUBLIC_RECAPTCHA_SITE_KEY, RECAPTCHA_SECRET_KEY, DIRECT_URL, SUPABASE_JWT_SECRET, NEXT_PUBLIC_SUPABASE_ANON_KEY, POSTGRES_PASSWORD, POSTGRES_USER, POSTGRES_HOST, POSTGRES_DATABASE)*
- `DB_PROVIDER=supabase pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688dadccdbf08328b92fdd7372a18010