### PR TITLE
feat: migrate auditoria to supabase

### DIFF
--- a/src/app/api/auditorias/[id]/route.ts
+++ b/src/app/api/auditorias/[id]/route.ts
@@ -1,8 +1,8 @@
 export const runtime = 'nodejs'
 
 import { NextRequest, NextResponse } from 'next/server'
-import { prisma } from '@lib/db/prisma'
-import { Prisma } from '@prisma/client'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { getDb } from '@lib/db'
 import { getUsuarioFromSession } from '@lib/auth'
 import * as logger from '@lib/logger'
 
@@ -19,35 +19,23 @@ export async function GET(req: NextRequest) {
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     const id = getAuditoriaId(req)
     if (!id) return NextResponse.json({ error: 'ID inválido' }, { status: 400 })
-    const auditoria = await prisma.auditoria.findUnique({
-      where: { id },
-      include: {
-        usuario: {
-          select: {
-            nombre: true,
-            correo: true,
-            roles: { select: { nombre: true } },
-          },
-        },
-        almacen: { select: { nombre: true } },
-        material: { select: { nombre: true } },
-        unidad: { select: { nombre: true } },
-        archivos: { select: { id: true, nombre: true, archivoNombre: true } },
-      },
-    })
-    if (!auditoria) return NextResponse.json({ error: 'No encontrado' }, { status: 404 })
-    return NextResponse.json({ auditoria })
-  } catch (err) {
-    if (
-      err instanceof Prisma.PrismaClientKnownRequestError &&
-      err.code === 'P2021'
-    ) {
-      logger.error('GET /api/auditorias/[id]', err)
-      return NextResponse.json(
-        { error: 'Base de datos no inicializada.' },
-        { status: 500 },
+    const db = getDb().client as SupabaseClient
+    const { data, error } = await db
+      .from('Auditoria')
+      .select(
+        `id, tipo, categoria, fecha, observaciones,
+        usuario:usuario ( nombre, correo ),
+        almacen:Almacen ( nombre ),
+        material:Material ( nombre ),
+        unidad:MaterialUnidad ( nombre ),
+        archivos:ArchivoAuditoria ( id, nombre, archivoNombre )`
       )
-    }
+      .eq('id', id)
+      .maybeSingle()
+    if (error) throw error
+    if (!data) return NextResponse.json({ error: 'No encontrado' }, { status: 404 })
+    return NextResponse.json({ auditoria: data })
+  } catch (err) {
     logger.error('GET /api/auditorias/[id]', err)
     return NextResponse.json({ error: 'Error' }, { status: 500 })
   }
@@ -59,20 +47,11 @@ export async function DELETE(req: NextRequest) {
     if (!usuario) return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
     const id = getAuditoriaId(req)
     if (!id) return NextResponse.json({ error: 'ID inválido' }, { status: 400 })
-    await prisma.archivoAuditoria.deleteMany({ where: { auditoriaId: id } })
-    await prisma.auditoria.delete({ where: { id } })
+    const db = getDb().client as SupabaseClient
+    await db.from('ArchivoAuditoria').delete().eq('auditoriaId', id)
+    await db.from('Auditoria').delete().eq('id', id)
     return NextResponse.json({ ok: true })
   } catch (err) {
-    if (
-      err instanceof Prisma.PrismaClientKnownRequestError &&
-      err.code === 'P2021'
-    ) {
-      logger.error('DELETE /api/auditorias/[id]', err)
-      return NextResponse.json(
-        { error: 'Base de datos no inicializada.' },
-        { status: 500 },
-      )
-    }
     logger.error('DELETE /api/auditorias/[id]', err)
     return NextResponse.json({ error: 'Error' }, { status: 500 })
   }

--- a/tests/auditoriaArchivoRoute.test.ts
+++ b/tests/auditoriaArchivoRoute.test.ts
@@ -9,8 +9,9 @@ afterEach(() => {
 describe('GET /api/auditorias/[id]/archivos/[archivoId]', () => {
   it('devuelve 200 con archivo', async () => {
     vi.doMock('../lib/auth', () => ({ getUsuarioFromSession: vi.fn().mockResolvedValue({ id: 1 }) }))
-    vi.doMock('@lib/db/prisma', () => ({ prisma: { archivoAuditoria: { findUnique: vi.fn().mockResolvedValue({ archivo: Buffer.from('data'), archivoNombre: 'a.txt' }) } }
-    }))
+    const maybeSingle = vi.fn().mockResolvedValue({ data: { archivo: Buffer.from('data'), archivoNombre: 'a.txt' }, error: null })
+    const from = vi.fn(() => ({ select: () => ({ eq: () => ({ maybeSingle }) }) }))
+    vi.doMock('@lib/db', () => ({ getDb: () => ({ client: { from } }) }))
     const { GET } = await import('../src/app/api/auditorias/[id]/archivos/[archivoId]/route')
     const req = new NextRequest('http://localhost/api/auditorias/1/archivos/2')
     const res = await GET(req)

--- a/tests/auditoriaInit.test.ts
+++ b/tests/auditoriaInit.test.ts
@@ -6,18 +6,13 @@ afterEach(() => {
 })
 
 describe('ensureAuditoriaTables', () => {
-  it('crea tablas con columna version', async () => {
-    const query = vi.fn().mockResolvedValue([{ exists: false }])
-    const exec = vi.fn()
-    const prismaMock = { $queryRaw: query, $executeRawUnsafe: exec }
-    vi.doMock('@lib/db/prisma', () => ({ prisma: prismaMock }))
+  it('invoca rpc para crear tablas', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: null, error: null })
+    vi.doMock('@lib/db', () => ({ getDb: () => ({ client: { rpc } }) }))
     const { ensureAuditoriaTables } = await import('../lib/auditoriaInit')
 
     await ensureAuditoriaTables()
 
-    expect(exec).toHaveBeenCalledWith(
-      expect.stringContaining('"version" INTEGER NOT NULL DEFAULT 1')
-    )
-    vi.unmock('@lib/db/prisma')
+    expect(rpc).toHaveBeenCalledWith('ensure_auditoria_tables')
   })
 })

--- a/tests/auditoriasRoute.test.ts
+++ b/tests/auditoriasRoute.test.ts
@@ -10,12 +10,16 @@ describe('POST /api/auditorias', () => {
   it('crea auditoria con datos válidos', async () => {
     vi.doMock('../lib/auth', () => ({ getUsuarioFromSession: vi.fn().mockResolvedValue({ id: 1 }) }))
     vi.doMock('../lib/auditoriaInit', () => ({ ensureAuditoriaTables: vi.fn() }))
-    const prismaMock = {
-      auditoria: { create: vi.fn().mockResolvedValue({ id: 3 }), count: vi.fn().mockResolvedValue(0) },
-      archivoAuditoria: { create: vi.fn() },
-      $transaction: vi.fn(async (cb: any) => cb(prismaMock)),
-    }
-    vi.doMock('@lib/db/prisma', () => ({ prisma: prismaMock }))
+    const auditoriaInsert = vi.fn(() => ({ select: () => ({ single: vi.fn().mockResolvedValue({ data: { id: 3 }, error: null }) }) }))
+    const auditoriaSelect = vi.fn(() => ({ match: vi.fn().mockResolvedValue({ count: 0, error: null }) }))
+    const archivoInsert = vi.fn().mockResolvedValue({ error: null })
+    const from = vi.fn((table: string) => {
+      if (table === 'Auditoria') return { select: auditoriaSelect, insert: auditoriaInsert }
+      if (table === 'ArchivoAuditoria') return { insert: archivoInsert }
+      return {}
+    })
+    const supabaseMock = { from }
+    vi.doMock('@lib/db', () => ({ getDb: () => ({ client: supabaseMock, transaction: async (fn: any) => fn(supabaseMock) }) }))
 
     const { POST } = await import('../src/app/api/auditorias/route')
     const body = JSON.stringify({ tipo: 'almacen', objetoId: 2, categoria: 'creacion', observaciones: '{}' })
@@ -24,13 +28,13 @@ describe('POST /api/auditorias', () => {
     expect(res.status).toBe(200)
     const data = await res.json()
     expect(data.auditoria).toEqual({ id: 3 })
-    expect(prismaMock.auditoria.create).toHaveBeenCalled()
+    expect(auditoriaInsert).toHaveBeenCalled()
   })
 
   it('retorna 400 cuando datos inválidos', async () => {
     vi.doMock('../lib/auth', () => ({ getUsuarioFromSession: vi.fn().mockResolvedValue({ id: 1 }) }))
     vi.doMock('../lib/auditoriaInit', () => ({ ensureAuditoriaTables: vi.fn() }))
-    vi.doMock('@lib/db/prisma', () => ({ prisma: {} }))
+    vi.doMock('@lib/db', () => ({ getDb: () => ({ client: {}, transaction: async (fn: any) => fn({}) }) }))
     const { POST } = await import('../src/app/api/auditorias/route')
     const req = new NextRequest('http://localhost/api/auditorias', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' })
     const res = await POST(req)
@@ -40,7 +44,7 @@ describe('POST /api/auditorias', () => {
   it('retorna 400 con form-data inválido', async () => {
     vi.doMock('../lib/auth', () => ({ getUsuarioFromSession: vi.fn().mockResolvedValue({ id: 1 }) }))
     vi.doMock('../lib/auditoriaInit', () => ({ ensureAuditoriaTables: vi.fn() }))
-    vi.doMock('@lib/db/prisma', () => ({ prisma: {} }))
+    vi.doMock('@lib/db', () => ({ getDb: () => ({ client: {}, transaction: async (fn: any) => fn({}) }) }))
     const { POST } = await import('../src/app/api/auditorias/route')
     const form = new FormData()
     form.set('tipo', 'almacen')


### PR DESCRIPTION
## Summary
- migrate auditoria and attachment endpoints to Supabase
- replace Prisma audit init with RPC call
- update auditoria tests for Supabase client

## Testing
- `DB_PROVIDER=supabase pnpm test` *(fails: Supabase no configurado)*
- `DB_PROVIDER=supabase pnpm run build` *(fails: Faltan variables en .env)*

------
https://chatgpt.com/codex/tasks/task_e_688dad5ae4f083289284621e4a89b6c6