### PR TITLE
feat: normalizar datos de almacenes y usuarios

### DIFF
--- a/src/hooks/useAlmacenUsuarios.ts
+++ b/src/hooks/useAlmacenUsuarios.ts
@@ -72,8 +72,14 @@ export default function useAlmacenUsuarios(almacenId?: number | string) {
     mutate()
   }
 
+  const raw = (data?.usuarios as any[]) ?? []
+
   return {
-    usuarios: (data?.usuarios as AlmacenUsuario[]) ?? [],
+    usuarios: raw.map((u) => ({
+      correo: u.correo ?? u.email ?? '',
+      nombre: u.nombre ?? u.nombre_usuario ?? null,
+      rol: u.rol ?? u.rolEnAlmacen ?? u.rol_en_almacen ?? '',
+    })),
     loading: isLoading,
     error,
     revocar,

--- a/src/hooks/useAlmacenes.ts
+++ b/src/hooks/useAlmacenes.ts
@@ -8,18 +8,38 @@ export interface Almacen {
   imagenUrl?: string | null
   fechaCreacion?: string | null
   ultimaActualizacion?: string | null
-  entradas?: number
-  salidas?: number
-  inventario?: number
-  unidades?: number
+  entradas: number
+  salidas: number
+  inventario: number
+  unidades: number
   encargado?: string | null
   correo?: string | null
-  notificaciones?: number
+  notificaciones: number
   codigoUnico?: string
 }
 
 
 const EMPTY_ALMACENES: Almacen[] = []
+
+function normalize(raw: any): Almacen {
+  return {
+    id: Number(raw.id),
+    nombre: String(raw.nombre),
+    descripcion: raw.descripcion ?? null,
+    imagenUrl: raw.imagenUrl ?? raw.imagen_url ?? null,
+    fechaCreacion: raw.fechaCreacion ?? raw.fecha_creacion ?? null,
+    ultimaActualizacion:
+      raw.ultimaActualizacion ?? raw.ultima_actualizacion ?? null,
+    entradas: Number(raw.entradas ?? raw.total_entradas ?? 0),
+    salidas: Number(raw.salidas ?? raw.total_salidas ?? 0),
+    inventario: Number(raw.inventario ?? raw.materiales ?? 0),
+    unidades: Number(raw.unidades ?? raw.total_unidades ?? 0),
+    encargado: raw.encargado ?? raw.encargado_nombre ?? null,
+    correo: raw.correo ?? raw.encargado_correo ?? null,
+    notificaciones: Number(raw.notificaciones ?? raw.notificaciones_count ?? 0),
+    codigoUnico: raw.codigoUnico ?? raw.codigo_unico ?? undefined,
+  }
+}
 
 export default function useAlmacenes(opts?: {
   usuarioId?: number
@@ -35,8 +55,10 @@ export default function useAlmacenes(opts?: {
     revalidateOnFocus: true,
   })
 
+  const raw = (data?.almacenes as any[]) ?? EMPTY_ALMACENES
+
   return {
-    almacenes: (data?.almacenes as Almacen[]) ?? EMPTY_ALMACENES,
+    almacenes: raw.map(normalize),
     loading: isLoading,
     error,
     mutate,

--- a/src/hooks/useAlmacenesLogic.ts
+++ b/src/hooks/useAlmacenesLogic.ts
@@ -64,11 +64,12 @@ export default function useAlmacenesLogic() {
         body: JSON.stringify({ nombre, descripcion }),
       })
       const data = await jsonOrNull(res)
-      if (res.ok && data.almacen) {
+      const nuevo = data?.almacen ?? data?.data
+      if (res.ok && nuevo) {
         mutate()
         toast.show('Almacén creado', 'success')
       } else {
-        toast.show(data.error || 'Error al crear', 'error')
+        toast.show(data?.error || 'Error al crear', 'error')
       }
     } catch {
       toast.show('Error de red', 'error')
@@ -173,10 +174,11 @@ export default function useAlmacenesLogic() {
       try {
         const res = await apiFetch(`/api/almacenes/${id}/duplicar`, { method: 'POST' })
         const data = await jsonOrNull(res)
-        if (res.ok && data?.almacen) {
+        const nuevo = data?.almacen ?? data?.data
+        if (res.ok && nuevo) {
           mutate()
           toast.show('Almacén duplicado', 'success')
-          return data.almacen.id as number
+          return nuevo.id as number
         }
         toast.show(data?.error || 'Error al duplicar', 'error')
       } catch {

--- a/tests/almacenesAuditoria.test.ts
+++ b/tests/almacenesAuditoria.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { NextRequest } from 'next/server'
+import * as db from '../lib/db'
 
 afterEach(() => {
   vi.restoreAllMocks()
   vi.resetModules()
 })
+
+const from = vi.fn()
+vi.spyOn(db, 'getDb').mockReturnValue({ client: { from } } as any)
 
 describe('POST /api/almacenes', () => {
   it('retorna auditoria al crear', async () => {

--- a/tests/almacenesRoute.test.ts
+++ b/tests/almacenesRoute.test.ts
@@ -4,10 +4,13 @@ import { NextRequest } from 'next/server'
 import * as auth from '../lib/auth'
 import * as permisos from '../lib/permisos'
 import { prisma } from '@lib/db/prisma'
+import * as db from '../lib/db'
 
 afterEach(() => vi.restoreAllMocks())
 
 describe('GET /api/almacenes', () => {
+  const from = vi.fn()
+  vi.spyOn(db, 'getDb').mockReturnValue({ client: { from } } as any)
   it('requiere sesion', async () => {
     vi.spyOn(auth, 'getUsuarioFromSession').mockResolvedValue(null as any)
     const res = await GET(new NextRequest('http://localhost/api/almacenes'))

--- a/tests/almacenesShare.test.ts
+++ b/tests/almacenesShare.test.ts
@@ -4,8 +4,12 @@ import { NextRequest } from 'next/server'
 import { prisma } from '@lib/db/prisma'
 import * as auth from '../lib/auth'
 import * as email from '../src/lib/email/enviarInvitacionAlmacen'
+import * as db from '../lib/db'
 
 afterEach(() => vi.restoreAllMocks())
+
+const from = vi.fn()
+vi.spyOn(db, 'getDb').mockReturnValue({ client: { from } } as any)
 
 describe('POST /api/almacenes/compartir', () => {
   it('requiere sesion', async () => {


### PR DESCRIPTION
## Resumen
- Normaliza respuestas de almacenes y usuarios para soportar Supabase
- Ajusta lógica de creación y duplicado de almacenes a nuevos formatos de respuesta
- Añade mock básico de Supabase en pruebas de almacenes

## Testing
- `JWT_SECRET=a NEXTAUTH_SECRET=b NEXTAUTH_URL=http://localhost EMAIL_ADMIN=a@a.com EMAIL_DESTINO_ESTANDAR=b@b.com EMAIL_DESTINO_VALIDACION=c@c.com SMTP_USER=user SMTP_PASS=pass NEXT_PUBLIC_RECAPTCHA_SITE_KEY=site RECAPTCHA_SECRET_KEY=secret DIRECT_DB_URL=postgres://test DB_PROVIDER=prisma pnpm run build`
- `JWT_SECRET=a NEXTAUTH_SECRET=b NEXTAUTH_URL=http://localhost EMAIL_ADMIN=a@a.com EMAIL_DESTINO_ESTANDAR=b@b.com EMAIL_DESTINO_VALIDACION=c@c.com SMTP_USER=user SMTP_PASS=pass NEXT_PUBLIC_RECAPTCHA_SITE_KEY=site RECAPTCHA_SECRET_KEY=secret DIRECT_DB_URL=postgres://test DB_PROVIDER=prisma pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688dad3317888328ba7de4eff2b75a25