### PR TITLE
fix: ajusta relación usuario_almacen en almacenes

### DIFF
--- a/src/app/api/almacenes/[id]/duplicar/route.ts
+++ b/src/app/api/almacenes/[id]/duplicar/route.ts
@@ -45,7 +45,7 @@ export async function POST(req: NextRequest) {
         imagen: almacen.imagen as any,
         codigoUnico,
         entidadId: almacen.entidadId,
-        usuarios: { create: { usuarioId: usuario.id, rolEnAlmacen: 'propietario' } },
+        usuario_almacen: { create: { usuarioId: usuario.id, rolEnAlmacen: 'propietario' } },
       },
       select: { id: true, nombre: true },
     });

--- a/src/app/api/almacenes/[id]/route.ts
+++ b/src/app/api/almacenes/[id]/route.ts
@@ -55,7 +55,7 @@ export async function GET(req: NextRequest) {
         descripcion: true,
         imagenUrl: true,
         imagenNombre: true,
-        usuarios: {
+        usuario_almacen: {
           take: 1,
           select: {
             usuario: { select: { nombre: true, correo: true } },
@@ -115,8 +115,8 @@ export async function GET(req: NextRequest) {
         nombre: almacen.nombre,
         descripcion: almacen.descripcion,
         imagenUrl: almacen.imagenNombre ? `/api/almacenes/foto?nombre=${encodeURIComponent(almacen.imagenNombre)}` : almacen.imagenUrl,
-        encargado: almacen.usuarios[0]?.usuario.nombre ?? null,
-        correo: almacen.usuarios[0]?.usuario.correo ?? null,
+        encargado: almacen.usuario_almacen[0]?.usuario.nombre ?? null,
+        correo: almacen.usuario_almacen[0]?.usuario.correo ?? null,
         ultimaActualizacion: almacen.movimientos[0]?.fecha ?? null,
         entradas,
         salidas,

--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -36,7 +36,7 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: 'Sin permisos' }, { status: 403 });
     }
 
-    const where = { usuarios: { some: { usuarioId: targetId } } };
+    const where = { usuario_almacen: { some: { usuarioId: targetId } } };
 
     const data = await prisma.almacen.findMany({
       take: 20,
@@ -50,7 +50,7 @@ export async function GET(req: NextRequest) {
         imagenNombre: true,
         fechaCreacion: true,
         codigoUnico: true,
-        usuarios: {
+        usuario_almacen: {
           take: 1,
           select: {
             usuario: { select: { nombre: true, correo: true } },
@@ -127,8 +127,8 @@ export async function GET(req: NextRequest) {
       imagenUrl: a.imagenNombre ? `/api/almacenes/foto?nombre=${encodeURIComponent(a.imagenNombre)}` : a.imagenUrl,
       codigoUnico: a.codigoUnico,
       fechaCreacion: a.fechaCreacion,
-      encargado: a.usuarios[0]?.usuario.nombre ?? null,
-      correo: a.usuarios[0]?.usuario.correo ?? null,
+      encargado: a.usuario_almacen[0]?.usuario.nombre ?? null,
+      correo: a.usuario_almacen[0]?.usuario.correo ?? null,
       ultimaActualizacion: a.movimientos[0]?.fecha ?? null,
       notificaciones: a.notificaciones.length,
       entradas: counts[a.id].entradas,
@@ -239,7 +239,7 @@ export async function POST(req: NextRequest) {
           imagenNombre,
           imagen: imagenBuffer,
           entidadId: usuario.entidadId,
-          usuarios: {
+          usuario_almacen: {
             create: { usuarioId: usuario.id, rolEnAlmacen: 'propietario' },
           },
         },

--- a/src/app/api/perfil/export/route.ts
+++ b/src/app/api/perfil/export/route.ts
@@ -83,7 +83,7 @@ export async function GET(req: NextRequest) {
     // ======= 4. Almacenes creados por el usuario (no colaborador) =======
     if (secciones.includes('almacenes')) {
       const almacenes = await prisma.almacen.findMany({
-        where: { usuarios: { some: { usuarioId, rolEnAlmacen: 'creador' } } },
+        where: { usuario_almacen: { some: { usuarioId, rolEnAlmacen: 'creador' } } },
         select: {
           id: true,
           nombre: true,

--- a/tests/almacenesRoute.test.ts
+++ b/tests/almacenesRoute.test.ts
@@ -31,7 +31,7 @@ describe('GET /api/almacenes', () => {
     const find = vi.spyOn(prisma.almacen, 'findMany').mockResolvedValue([] as any)
     const req = new NextRequest('http://localhost/api/almacenes?usuarioId=5')
     await GET(req)
-    expect(find).toHaveBeenCalledWith(expect.objectContaining({ where: { usuarios: { some: { usuarioId: 5 } } } }))
+    expect(find).toHaveBeenCalledWith(expect.objectContaining({ where: { usuario_almacen: { some: { usuarioId: 5 } } } }))
   })
 
   it('incluye total de unidades', async () => {
@@ -47,7 +47,7 @@ describe('GET /api/almacenes', () => {
         imagenUrl: null,
         fechaCreacion: new Date(),
         codigoUnico: 'c',
-        usuarios: [],
+        usuario_almacen: [],
         movimientos: [],
         notificaciones: [],
       },


### PR DESCRIPTION
## Summary
- usa la relación `usuario_almacen` en consultas y creación de almacenes
- actualiza exportación de perfil y duplicado de almacenes
- corrige prueba de `/api/almacenes`

## Testing
- `pnpm run build` *(falla: Identifier 'db' has already been declared en src/app/api/auditorias/route.ts)*
- `pnpm test` *(falla: DB_PROVIDER en .env faltante y errores de compilación en auditorias)*

------
