### PR TITLE
fix(dashboard): render sidebar correctly

### DIFF
--- a/src/app/dashboard/components/Sidebar.tsx
+++ b/src/app/dashboard/components/Sidebar.tsx
@@ -109,9 +109,9 @@ export default function Sidebar({ usuario }: { usuario: Usuario }) {
 
   return (
     <aside
-      className="dashboard-sidebar flex flex-col transition-all duration-200 shadow-xl fixed top-0 left-0 z-30 bg-[var(--dashboard-sidebar)] border-r border-[var(--dashboard-border)]"
+      className="dashboard-sidebar flex flex-col transition-all duration-200 shadow-xl bg-[var(--dashboard-sidebar)] border-r border-[var(--dashboard-border)]"
       style={{
-        minHeight: '100vh',
+        height: '100%',
         width: collapsed
           ? 'var(--sidebar-collapsed-width)'
           : 'var(--sidebar-width)',


### PR DESCRIPTION
## Summary
- avoid double fixed positioning so dashboard sidebar renders inside layout

## Testing
- `DB_PROVIDER=prisma SKIP_ENV_CHECK=true pnpm run build` *(fails: Identifier 'db' already declared)*
- `DB_PROVIDER=prisma SKIP_ENV_CHECK=true pnpm test` *(fails: db already declared)*

------
