### PR TITLE
fix: carga de usuario y debounce inventario

### DIFF
--- a/src/app/dashboard/components/Sidebar.tsx
+++ b/src/app/dashboard/components/Sidebar.tsx
@@ -34,8 +34,8 @@ export default function Sidebar({ usuario }: { usuario: Usuario | null | undefin
   const { sidebarGlobalCollapsed: collapsed, toggleSidebarCollapsed } = useDashboardUI();
   const pathname = usePathname();
 
-  // Loading: sólo si no hay objeto/ID aún
-  if (!usuario || (usuario as any).id == null) {
+  // Loading: sólo mientras no exista usuario
+  if (!usuario) {
     return (
       <aside className="dashboard-sidebar flex flex-col w-[4.5rem] min-w-[4.5rem] h-screen fixed top-0 left-0 z-30 justify-center items-center bg-[var(--dashboard-sidebar)] shadow-xl">
         <Spinner className="text-[var(--dashboard-accent)]" />
@@ -55,10 +55,7 @@ export default function Sidebar({ usuario }: { usuario: Usuario | null | undefin
       ? sidebarMenu
       : sidebarMenu.filter(i => i.allowed.includes(tipo));
 
-  const displayName =
-    (usuario as any).nombre && String((usuario as any).nombre).trim().length > 0
-      ? String((usuario as any).nombre).trim()
-      : String((usuario as any).correo ?? "Usuario");
+  const displayName = usuario?.nombre?.trim() || usuario?.correo || "Usuario";
 
   return (
     <aside

--- a/src/app/dashboard/inventario/page.tsx
+++ b/src/app/dashboard/inventario/page.tsx
@@ -43,15 +43,20 @@ export default function InventarioPage() {
 
   // Temporalmente se deshabilita la consulta a /api/qr/importar
   const fetchInfo = useDebouncedCallback((code: string) => {
-    logger.debug('fetchInfo disabled', code)
-    setInfo(null)
-  }, 300)
+    logger.debug('fetchInfo disabled', code);
+    setInfo(null);
+  }, 300);
+
+  const fetchRef = useRef(fetchInfo);
+  useEffect(() => {
+    fetchRef.current = fetchInfo;
+  }, [fetchInfo]);
 
   useEffect(() => {
     if (!codigo || codigo === prevCodigo.current) return;
     prevCodigo.current = codigo;
-    fetchInfo(codigo);
-  }, [codigo, fetchInfo]);
+    fetchRef.current(codigo);
+  }, [codigo]);
 
   const handleFile = async (files: FileList | null) => {
     const file = files?.[0];


### PR DESCRIPTION
## Summary
- Evita que el sidebar oculte el nombre cuando el objeto usuario aún no tiene ID
- Usa una referencia para estabilizar el callback de escaneo en inventario

## Testing
- `pnpm run build` *(fails: ❌ Faltante: DB_PROVIDER en .env)*
- `pnpm test` *(fails: DB_PROVIDER missing and Supabase no configurado)*

------
