### PR TITLE
refactor(api): use supabase for almacenes

### DIFF
--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -2,8 +2,8 @@
 export const runtime = 'nodejs';
 
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from '@lib/db/prisma';
-import type { Prisma } from '@prisma/client'
+import { getDb } from '@lib/db'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import crypto from "node:crypto";
 import { getUsuarioFromSession } from "@lib/auth";
 import { hasManagePerms, normalizeTipoCuenta } from "@lib/permisos";
@@ -35,83 +35,113 @@ export async function GET(req: NextRequest) {
     if (usuarioIdParam && targetId !== usuario.id && !hasManagePerms(usuario)) {
       return NextResponse.json({ error: 'Sin permisos' }, { status: 403 });
     }
+    const db = getDb().client as SupabaseClient
 
-    const where = { usuario_almacen: { some: { usuarioId: targetId } } };
+    const { data: userAlmacenes, error: uaError } = await db
+      .from('usuario_almacen')
+      .select('almacenId')
+      .eq('usuarioId', targetId)
+      .order('almacenId', { ascending: true })
+      .limit(20)
+    if (uaError) throw uaError
 
-    const data = await prisma.almacen.findMany({
-      take: 20,
-      orderBy: { id: 'asc' },
-      where,
-      select: {
-        id: true,
-        nombre: true,
-        descripcion: true,
-        imagenUrl: true,
-        imagenNombre: true,
-        fechaCreacion: true,
-        codigoUnico: true,
-        usuario_almacen: {
-          take: 1,
-          select: {
-            usuario: { select: { nombre: true, correo: true } },
-          },
-        },
-        movimientos: {
-          orderBy: { fecha: "desc" },
-          take: 1,
-          select: { fecha: true },
-        },
-        notificaciones: {
-          where: { leida: false },
-          select: { id: true },
-        },
-      },
-    });
+    const ids = (userAlmacenes ?? []).map((u) => u.almacenId)
+    if (ids.length === 0) {
+      return NextResponse.json({ almacenes: [] })
+    }
 
-    const ids = data.map((a) => a.id);
-    const counts: Record<number, { entradas: number; salidas: number }> = {};
-    const materiales: Record<number, number> = {};
-    const unidades: Record<number, number> = {};
+    const { data, error } = await db
+      .from('almacen')
+      .select('id, nombre, descripcion, imagenUrl, imagenNombre, fechaCreacion, codigoUnico')
+      .in('id', ids)
+      .order('id', { ascending: true })
+    if (error) throw error
+
+    const counts: Record<number, { entradas: number; salidas: number }> = {}
+    const materiales: Record<number, number> = {}
+    const unidades: Record<number, number> = {}
+    const ultima: Record<number, string | null> = {}
+    const notifs: Record<number, number> = {}
+    const encargados: Record<number, { nombre: string | null; correo: string | null }> = {}
     ids.forEach((id) => {
-      counts[id] = { entradas: 0, salidas: 0 };
-      materiales[id] = 0;
-      unidades[id] = 0;
-    });
+      counts[id] = { entradas: 0, salidas: 0 }
+      materiales[id] = 0
+      unidades[id] = 0
+      ultima[id] = null
+      notifs[id] = 0
+      encargados[id] = { nombre: null, correo: null }
+    })
 
-    if (ids.length > 0) {
-      const movs = await prisma.movimiento.groupBy({
-        by: ["almacenId", "tipo"],
-        _sum: { cantidad: true },
-        where: { almacenId: { in: ids } },
-      });
-
-      for (const m of movs) {
-        if (m.tipo === "entrada") counts[m.almacenId].entradas = m._sum.cantidad ?? 0;
-        if (m.tipo === "salida") counts[m.almacenId].salidas = m._sum.cantidad ?? 0;
+    const { data: encargadosData, error: encError } = await db
+      .from('usuario_almacen')
+      .select('almacenId, usuario:usuario(nombre, correo)')
+      .in('almacenId', ids)
+    if (encError) throw encError
+    for (const e of encargadosData ?? []) {
+      if (!encargados[e.almacenId].nombre) {
+        encargados[e.almacenId] = {
+          nombre: e.usuario?.nombre ?? null,
+          correo: e.usuario?.correo ?? null,
+        }
       }
+    }
 
-      const mats = await prisma.material.groupBy({
-        by: ["almacenId"],
-        _count: { _all: true },
-        where: { almacenId: { in: ids } },
-      });
-      for (const m of mats) materiales[m.almacenId] = m._count._all;
+    const { data: notifData, error: notifError } = await db
+      .from('notificacion')
+      .select('almacenId')
+      .eq('leida', false)
+      .in('almacenId', ids)
+    if (notifError) throw notifError
+    for (const n of notifData ?? []) {
+      notifs[n.almacenId] = (notifs[n.almacenId] ?? 0) + 1
+    }
 
-      const unidadesPorMaterial = await prisma.material.findMany({
-        where: { almacenId: { in: ids } },
-        select: { almacenId: true, _count: { select: { unidades: true } } },
-      });
-      for (const u of unidadesPorMaterial) {
-        unidades[u.almacenId] += u._count.unidades;
-      }
+    const { data: movs, error: movError } = await db
+      .from('movimiento')
+      .select('almacenId, tipo, sum:cantidad', { group: 'almacenId,tipo' })
+      .in('almacenId', ids)
+    if (movError) throw movError
+    for (const m of movs ?? []) {
+      const sum = (m as any).sum ?? (m as any).sum_cantidad ?? (m as any).cantidad
+      if (m.tipo === 'entrada') counts[m.almacenId].entradas = sum ?? 0
+      if (m.tipo === 'salida') counts[m.almacenId].salidas = sum ?? 0
+    }
+
+    const { data: movFechas, error: fechaError } = await db
+      .from('movimiento')
+      .select('almacenId, max:fecha', { group: 'almacenId' })
+      .in('almacenId', ids)
+    if (fechaError) throw fechaError
+    for (const f of movFechas ?? []) {
+      ultima[f.almacenId] = (f as any).max ?? null
+    }
+
+    const { data: mats, error: matsError } = await db
+      .from('material')
+      .select('almacenId, count:id', { group: 'almacenId' })
+      .in('almacenId', ids)
+    if (matsError) throw matsError
+    for (const m of mats ?? []) {
+      materiales[m.almacenId] = (m as any).count ?? 0
+    }
+
+    const { data: unidadRows, error: uniError } = await db
+      .from('material_unidad')
+      .select('material:material(almacenId)')
+      .in('material.almacenId', ids)
+    if (uniError) throw uniError
+    for (const u of unidadRows ?? []) {
+      const id = (u as any).material?.almacenId
+      if (id != null) unidades[id] = (unidades[id] ?? 0) + 1
     }
 
     let orden: number[] = []
     if (targetId) {
-      const prefsUser = await prisma.usuario.findUnique({
-        where: { id: targetId },
-        select: { preferencias: true },
-      })
+      const { data: prefsUser } = await db
+        .from('usuario')
+        .select('preferencias')
+        .eq('id', targetId)
+        .single()
       if (prefsUser?.preferencias) {
         try {
           const p = JSON.parse(prefsUser.preferencias)
@@ -120,17 +150,17 @@ export async function GET(req: NextRequest) {
       }
     }
 
-    const almacenes = data.map((a) => ({
+    const almacenes = (data ?? []).map((a) => ({
       id: a.id,
       nombre: a.nombre,
       descripcion: a.descripcion,
       imagenUrl: a.imagenNombre ? `/api/almacenes/foto?nombre=${encodeURIComponent(a.imagenNombre)}` : a.imagenUrl,
       codigoUnico: a.codigoUnico,
       fechaCreacion: a.fechaCreacion,
-      encargado: a.usuario_almacen[0]?.usuario.nombre ?? null,
-      correo: a.usuario_almacen[0]?.usuario.correo ?? null,
-      ultimaActualizacion: a.movimientos[0]?.fecha ?? null,
-      notificaciones: a.notificaciones.length,
+      encargado: encargados[a.id].nombre,
+      correo: encargados[a.id].correo,
+      ultimaActualizacion: ultima[a.id],
+      notificaciones: notifs[a.id] ?? 0,
       entradas: counts[a.id].entradas,
       salidas: counts[a.id].salidas,
       inventario: materiales[a.id],
@@ -167,6 +197,7 @@ export async function POST(req: NextRequest) {
     if (!hasManagePerms(usuario)) {
       return NextResponse.json({ error: 'Sin permisos' }, { status: 403 });
     }
+    const prisma = getDb().client as any
 
     let nombre = '';
     let descripcion = '';


### PR DESCRIPTION
## Summary
- refactor GET /api/almacenes to use Supabase queries instead of Prisma
- adapt tests to mock Supabase client and cover unit counting

## Testing
- `pnpm run build` *(fails: ❌ Faltante: DB_PROVIDER en .env)*
- `pnpm test` *(fails: DB_PROVIDER missing and Supabase not configurado)*

------
