### PR TITLE
refactor: use getDb and add supabase support

### DIFF
--- a/src/app/api/almacenes/[id]/materiales/route.ts
+++ b/src/app/api/almacenes/[id]/materiales/route.ts
@@ -1,7 +1,7 @@
 export const runtime = 'nodejs'
 
 import { NextRequest, NextResponse } from 'next/server'
-import { prisma } from '@lib/db/prisma'
+import { getDb } from '@lib/db'
 import type { Prisma } from '@prisma/client'
 import { materialSchema } from '@/lib/validators/material'
 import { getUsuarioFromSession } from '@lib/auth'
@@ -13,7 +13,6 @@ import { registrarAuditoria } from '@lib/reporter'
 import { snapshotMaterial } from '@/lib/snapshot'
 import { emitEvent } from '@/lib/events'
 
-
 function getAlmacenIdFromRequest(req: NextRequest): number | null {
   const parts = req.nextUrl.pathname.split('/')
   const idx = parts.findIndex((p) => p === 'almacenes')
@@ -22,6 +21,7 @@ function getAlmacenIdFromRequest(req: NextRequest): number | null {
 }
 
 export async function GET(req: NextRequest) {
+  const prisma = getDb().client as any
   logger.debug(req, 'GET /api/almacenes/[id]/materiales')
   try {
     const usuario = await getUsuarioFromSession(req)
@@ -74,6 +74,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
+  const prisma = getDb().client as any
   logger.debug(req, 'POST /api/almacenes/[id]/materiales')
   try {
     const usuario = await getUsuarioFromSession(req)

--- a/src/app/api/almacenes/[id]/route.ts
+++ b/src/app/api/almacenes/[id]/route.ts
@@ -1,7 +1,7 @@
 export const runtime = 'nodejs';
 
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from '@lib/db/prisma';
+import { getDb } from '@lib/db';
 import type { Prisma } from '@prisma/client';
 import { getUsuarioFromSession } from "@lib/auth";
 import { hasManagePerms } from "@lib/permisos";
@@ -30,6 +30,7 @@ const IMAGE_TYPES = [
 
 
 export async function GET(req: NextRequest) {
+  const prisma = getDb().client as any
   logger.debug(req, 'GET /api/almacenes/[id]')
   try {
     const usuario = await getUsuarioFromSession(req);
@@ -133,6 +134,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
+  const prisma = getDb().client as any
   try {
     const usuario = await getUsuarioFromSession(req);
     if (!usuario) {
@@ -190,6 +192,7 @@ export async function DELETE(req: NextRequest) {
 }
 
 export async function PUT(req: NextRequest) {
+  const prisma = getDb().client as any
   try {
     const usuario = await getUsuarioFromSession(req);
     if (!usuario) {

--- a/src/app/api/almacenes/compartir/route.ts
+++ b/src/app/api/almacenes/compartir/route.ts
@@ -1,7 +1,8 @@
 export const runtime = 'nodejs'
 
 import { NextRequest, NextResponse } from 'next/server'
-import { prisma } from '@lib/db/prisma'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { getDb } from '@lib/db'
 import { getUsuarioFromSession } from '@lib/auth'
 import { emitEvent } from '@/lib/events'
 import * as logger from '@lib/logger'
@@ -15,7 +16,13 @@ export async function POST(req: NextRequest) {
     const { codigo, correos } = await req.json()
     if (!codigo) return NextResponse.json({ error: 'Código requerido' }, { status: 400 })
 
-    const cod = await prisma.codigoAlmacen.findUnique({ where: { codigo } })
+    const db = getDb().client as SupabaseClient
+    const { data: cod, error } = await db
+      .from('codigo_almacen')
+      .select('*')
+      .eq('codigo', codigo)
+      .maybeSingle()
+    if (error) throw error
     if (!cod || !cod.activo) return NextResponse.json({ error: 'Código inválido' }, { status: 404 })
     if (Array.isArray(correos) && correos.length > 0) {
       const base = `${req.nextUrl.origin}${process.env.NEXT_PUBLIC_BASE_PATH || ''}`
@@ -30,24 +37,25 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Código sin usos' }, { status: 410 })
     }
 
-    await prisma.usuarioAlmacen.upsert({
-      where: { usuarioId_almacenId: { usuarioId: usuario.id, almacenId: cod.almacenId } },
-      create: {
-        usuarioId: usuario.id,
-        almacenId: cod.almacenId,
-        rolEnAlmacen: cod.rolAsignado,
-        permisosExtra: cod.permisos,
-      },
-      update: {},
-    })
+    await db
+      .from('usuario_almacen')
+      .upsert(
+        {
+          usuarioId: usuario.id,
+          almacenId: cod.almacenId,
+          rolEnAlmacen: cod.rolAsignado,
+          permisosExtra: cod.permisos,
+        },
+        { onConflict: 'usuarioId,almacenId' },
+      )
 
     emitEvent({ type: 'usuarios_update', payload: { almacenId: cod.almacenId } })
 
     if (cod.usosDisponibles !== null) {
-      await prisma.codigoAlmacen.update({
-        where: { id: cod.id },
-        data: { usosDisponibles: { decrement: 1 } },
-      })
+      await db
+        .from('codigo_almacen')
+        .update({ usosDisponibles: (cod.usosDisponibles ?? 0) - 1 })
+        .eq('id', cod.id)
     }
 
     return NextResponse.json({ success: true, almacenId: cod.almacenId })

--- a/src/app/api/almacenes/orden/route.ts
+++ b/src/app/api/almacenes/orden/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { prisma } from '@lib/db/prisma'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { getDb } from '@lib/db'
 import { getUsuarioFromSession } from '@lib/auth'
 import * as logger from '@lib/logger'
 
@@ -26,10 +27,11 @@ export async function POST(req: NextRequest) {
     }
     const prefs = usuario.preferencias ? JSON.parse(usuario.preferencias) : {}
     prefs.ordenAlmacenes = ids
-    await prisma.usuario.update({
-      where: { id: usuario.id },
-      data: { preferencias: JSON.stringify(prefs) },
-    })
+    const db = getDb().client as SupabaseClient
+    await db
+      .from('usuario')
+      .update({ preferencias: JSON.stringify(prefs) })
+      .eq('id', usuario.id)
     return NextResponse.json({ ok: true })
   } catch (err) {
     logger.error('POST /api/almacenes/orden', err)

--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -2,7 +2,7 @@
 export const runtime = 'nodejs';
 
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from '@lib/db/prisma';
+import { getDb } from '@lib/db';
 import type { Prisma } from '@prisma/client'
 import crypto from "node:crypto";
 import { getUsuarioFromSession } from "@lib/auth";
@@ -24,6 +24,7 @@ const IMAGE_TYPES = [
 
 
 export async function GET(req: NextRequest) {
+  const prisma = getDb().client as any
   try {
     const usuario = await getUsuarioFromSession(req);
     if (!usuario) {
@@ -158,6 +159,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
+  const prisma = getDb().client as any
   try {
     const usuario = await getUsuarioFromSession(req);
     if (!usuario) {


### PR DESCRIPTION
## Summary
- add Supabase branch in snapshotAlmacen and audit logging
- refactor almacenes share and order APIs to use getDb supabase client
- switch remaining almacenes routes from direct prisma imports to getDb

## Testing
- `pnpm run build` *(fails: ❌ Faltante: DB_PROVIDER en .env)*
- `pnpm test` *(fails: Supabase no configurado)*

------
