### PR TITLE
fix: normaliza usuario y usa email en Sidebar

### DIFF
--- a/src/app/dashboard/components/Sidebar.tsx
+++ b/src/app/dashboard/components/Sidebar.tsx
@@ -55,7 +55,9 @@ export default function Sidebar({ usuario }: { usuario: Usuario | null | undefin
       ? sidebarMenu
       : sidebarMenu.filter(i => i.allowed.includes(tipo));
 
-  const displayName = usuario?.nombre?.trim() || usuario?.correo || "Usuario";
+  // Acepta sesiones que sólo aportan email
+  const displayName =
+    usuario?.nombre?.trim() || usuario?.correo || usuario?.email || "";
 
   return (
     <aside

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -23,7 +23,16 @@ export default function useSession() {
     revalidateOnFocus: true,
   })
 
-  const usuario = data?.success ? (data.usuario as Usuario) : null
+  const raw = data?.success ? (data.usuario as any) : null
+  const usuario: Usuario | null = raw
+    ? {
+        ...raw,
+        // Normaliza nombre/correo cuando la sesión usa campos en inglés
+        nombre: raw.nombre || raw.name,
+        correo: raw.correo || raw.email,
+        email: raw.email || raw.correo,
+      }
+    : null
 
   return { usuario, loading: isLoading }
 }


### PR DESCRIPTION
## Summary
- normaliza datos de sesión para incluir `nombre`/`correo`
- utiliza email como respaldo al mostrar el usuario en Sidebar

## Testing
- `pnpm run build` *(falla: DB_PROVIDER en .env faltante)*
- `pnpm test` *(11 failed, 68 passed)*

------
