### PR TITLE
fix: muestra nombre o correo en sidebar

### DIFF
--- a/src/app/dashboard/components/Sidebar.tsx
+++ b/src/app/dashboard/components/Sidebar.tsx
@@ -34,8 +34,8 @@ export default function Sidebar({ usuario }: { usuario: Usuario | null | undefin
   const { sidebarGlobalCollapsed: collapsed, toggleSidebarCollapsed } = useDashboardUI();
   const pathname = usePathname();
 
-  // Loading: sólo mientras no exista usuario
-  if (!usuario) {
+  // Loading: sólo mientras no exista usuario con datos básicos
+  if (!usuario || (!usuario.nombre && !usuario.correo && !usuario.email)) {
     return (
       <aside className="dashboard-sidebar flex flex-col w-[4.5rem] min-w-[4.5rem] h-screen fixed top-0 left-0 z-30 justify-center items-center bg-[var(--dashboard-sidebar)] shadow-xl">
         <Spinner className="text-[var(--dashboard-accent)]" />
@@ -55,7 +55,7 @@ export default function Sidebar({ usuario }: { usuario: Usuario | null | undefin
       ? sidebarMenu
       : sidebarMenu.filter(i => i.allowed.includes(tipo));
 
-  const displayName = usuario?.nombre?.trim() || usuario?.correo || "Usuario";
+  const displayName = usuario.nombre?.trim() || usuario.correo || usuario.email || "";
 
   return (
     <aside


### PR DESCRIPTION
## Summary
- valida que el sidebar solo renderice con usuario que tenga nombre, correo o email
- usa cualquiera de esos campos como displayName

## Testing
- `DB_PROVIDER=prisma SKIP_ENV_CHECK=true pnpm run build` *(falla: Identifier 'db' has already been declared)*
- `DB_PROVIDER=prisma SKIP_ENV_CHECK=true pnpm test` *(falla: 16 failed tests, db.from is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688dbffc0f9883289b875c378010e729