### PR TITLE
fix: evitar bucles en /api/preferences

### DIFF
--- a/src/hooks/usePreferences.ts
+++ b/src/hooks/usePreferences.ts
@@ -1,0 +1,21 @@
+import useSWR from 'swr'
+import { apiFetch } from '@lib/api'
+import { jsonOrNull } from '@lib/http'
+
+export interface Preferences {
+  theme?: string
+  favoritosAlmacenes?: number[]
+  [key: string]: unknown
+}
+
+export default function usePreferences(usuarioId?: number | null) {
+  const { data, error, isLoading, mutate } = useSWR<Preferences>(
+    usuarioId ? '/api/preferences' : null,
+    async (url) => {
+      const res = await apiFetch(url)
+      return (await jsonOrNull(res)) ?? {}
+    },
+  )
+
+  return { prefs: data, loading: isLoading, error, mutate }
+}


### PR DESCRIPTION
## Summary
- centralizar preferencias en hook con cache SWR
- usar preferencias en UserMenu para tema y en almacenes para favoritos

## Testing
- `pnpm run build` *(falla: Identifier 'db' has already been declared)*
- `pnpm test` *(falla: DB_PROVIDER missing / Supabase no configurado)*

------
