### PR TITLE
fix: usa cliente supabase y ajusta efectos

### DIFF
--- a/src/app/dashboard/macros/page.tsx
+++ b/src/app/dashboard/macros/page.tsx
@@ -15,7 +15,7 @@ export default function MacrosPage() {
   const [lista, setLista] = useState<Macro[]>([]);
   const [accion, setAccion] = useState(acciones[0]);
   const [intervalo, setIntervalo] = useState(60);
-  const toast = useToast();
+  const { show } = useToast();
 
   useEffect(() => {
     const saved = localStorage.getItem("macros");
@@ -28,10 +28,10 @@ export default function MacrosPage() {
 
   useEffect(() => {
     const timers = lista.map((m) =>
-      setInterval(() => toast.show(`Macro: ${m.accion}`, 'info'), m.intervalo * 1000),
+      setInterval(() => show(`Macro: ${m.accion}`, 'info'), m.intervalo * 1000),
     );
     return () => timers.forEach(clearInterval);
-  }, [lista, toast]);
+  }, [lista]);
 
   const agregar = () => {
     setLista([...lista, { id: nanoid(), accion, intervalo }]);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,7 +34,7 @@ function HeroSection() {
       const timer = setTimeout(() => setShowDesc(true), 300);
       return () => clearTimeout(timer);
     }
-  }, [textoTyped, titulo.length]);
+  }, [textoTyped, titulo]);
 
   return (
     <section className="relative w-full min-h-[85vh] flex flex-col md:flex-row items-center justify-between px-4 md:px-16 py-16 md:py-24 overflow-hidden gap-10">


### PR DESCRIPTION
## Summary
- reemplaza uso de Prisma por cliente Supabase tipado en `/api/almacenes`
- estabiliza `useToast` en macros y corrige dependencias de intervalos
- corrige efecto de tipo `typewriter` en `page.tsx`

## Testing
- `pnpm run build` *(falla: ❌ Faltante: DB_PROVIDER en .env)*
- `pnpm test` *(falla: Supabase no configurado, 11 suites fallidas)*

------
https://chatgpt.com/codex/tasks/task_e_688dcaa9307c83289190ee22ca9af7bf