### PR TITLE
Evita bucle en interceptor de console.error

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -4,6 +4,15 @@ import { NextRequest } from 'next/server'
 const levels = ['debug', 'info', 'warn', 'error'] as const
 export type LogLevel = (typeof levels)[number]
 
+// Capturamos métodos originales para evitar reintercepción
+const baseConsole = {
+  debug: console.debug.bind(console),
+  info: console.info.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  log: console.log.bind(console),
+}
+
 const envLevel = process.env.LOG_LEVEL?.toLowerCase() as LogLevel | undefined
 const currentLevel = envLevel && levels.includes(envLevel) ? envLevel : 'info'
 
@@ -33,7 +42,7 @@ function baseLog(level: LogLevel, args: any[]) {
   }
 
   const prefix = formatPrefix(req)
-  const fn = console[level] || console.log
+  const fn = baseConsole[level] || baseConsole.log
   fn(prefix, ...args)
 }
 

--- a/src/client/components/globals/intercept-console-error.ts
+++ b/src/client/components/globals/intercept-console-error.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { error as logError } from '@lib/logger';
+
+const originalConsoleError = console.error;
+
+console.error = (...args: any[]) => {
+  logError(...args);
+};
+
+export function restoreConsoleError() {
+  console.error = originalConsoleError;
+}

--- a/tests/logger-intercept.test.ts
+++ b/tests/logger-intercept.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi, afterAll } from 'vitest'
+import * as logger from '@lib/logger'
+import { restoreConsoleError } from '../src/client/components/globals/intercept-console-error'
+
+describe('interceptor de console.error', () => {
+  afterAll(() => {
+    restoreConsoleError()
+  })
+
+  it('no duplica registros al interceptar', () => {
+    const spy = vi.spyOn(logger, 'error')
+    console.error('fallo')
+    expect(spy).toHaveBeenCalledTimes(1)
+    spy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- Captura métodos originales de `console` en `lib/logger` para evitar reintercepción
- Intercepta `console.error` en cliente y permite restaurar el original
- Añade prueba que garantiza que un error solo se registra una vez

## Testing
- `DB_PROVIDER=prisma SKIP_ENV_CHECK=true DATABASE_URL=postgresql://user:pass@localhost:5432/db DIRECT_DB_URL=postgresql://user:pass@localhost:5432/db pnpm run build` *(failed: Identifier 'db' has already been declared)*
- `DB_PROVIDER=prisma SKIP_ENV_CHECK=true VITEST=true pnpm test` *(failed: 7 failed test files)*

------
