### PR TITLE
feat: utilizar RPC para crear almacén

### DIFF
--- a/prisma/migrations/4_create_almacen_safe/migration.sql
+++ b/prisma/migrations/4_create_almacen_safe/migration.sql
@@ -1,0 +1,28 @@
+-- create function to insert almacen and link usuario atomically
+CREATE OR REPLACE FUNCTION public.create_almacen_safe(
+  p_usuario_id int,
+  p_entidad_id int,
+  p_nombre text,
+  p_descripcion text,
+  p_codigo_unico text,
+  p_imagen bytea DEFAULT NULL,
+  p_imagen_nombre text DEFAULT NULL,
+  p_imagen_url text DEFAULT NULL
+)
+RETURNS int
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_id int;
+BEGIN
+  INSERT INTO public.almacen(nombre, descripcion, codigo_unico, imagen, imagen_nombre, imagen_url, entidad_id)
+  VALUES (p_nombre, p_descripcion, p_codigo_unico, p_imagen, p_imagen_nombre, p_imagen_url, p_entidad_id)
+  RETURNING id INTO v_id;
+
+  INSERT INTO public.usuario_almacen(usuario_id, almacen_id, rol_en_almacen)
+  VALUES (p_usuario_id, v_id, 'propietario');
+
+  RETURN v_id;
+END;
+$$;


### PR DESCRIPTION
## Summary
- define SQL function `create_almacen_safe` to insert almacen and link owner atomically
- refactor POST `/api/almacenes` to call RPC and build response using returned id

## Testing
- `pnpm run build` *(fails: ❌ Faltante: DB_PROVIDER en .env)*
- `pnpm test` *(fails: 21 failed | 146 passed | Supabase no configurado)*

------
https://chatgpt.com/codex/tasks/task_e_688e4c8592e88328814b64131640c166