### PR TITLE
feat(api): log supabase errors on insert/update

### DIFF
--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -29,6 +29,13 @@ async function tryInsert<T = any>(
   let last: any = null;
   for (const body of payloads) {
     const { data, error } = await db.from(table).insert(body).select(select).single();
+    if (error)
+      logger.error(`[ALM_CREATE] insert ${table}`, {
+        code: error.code,
+        details: error.details,
+        hint: error.hint,
+        message: error.message,
+      });
     if (!error && data) return data as T;
     last = error;
     // si es columna o tabla inexistente, probamos siguiente variante
@@ -49,6 +56,13 @@ async function tryUpdate(
     const q = db.from(table).update(body);
     Object.entries(match).forEach(([k, v]) => (q as any).eq(k, v));
     const { error } = await q;
+    if (error)
+      logger.error(`[ALM_UPDATE] update ${table}`, {
+        code: error.code,
+        details: error.details,
+        hint: error.hint,
+        message: error.message,
+      });
     if (!error) return;
     last = error;
     if (['PGRST204', '42P01', '42703'].includes(error?.code)) continue;


### PR DESCRIPTION
## Summary
- log Supabase failures on insert with `[ALM_CREATE]`
- log Supabase failures on update with `[ALM_UPDATE]`

## Testing
- `pnpm run build` *(fails: Identifier 'db' has already been declared in src/app/api/auditorias/route.ts)*
- `pnpm test` *(fails: 21 failing tests, Supabase not configured)*

------
https://chatgpt.com/codex/tasks/task_e_688e4c81da4c832884c43fa981de5af3