### PR TITLE
feat(api): log supabase error details

### DIFF
--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -30,7 +30,8 @@ async function tryInsert<T = any>(
   for (const body of payloads) {
     const { data, error } = await db.from(table).insert(body).select(select).single();
     if (error)
-      logger.error(`[ALM_CREATE] insert ${table}`, {
+      logger.error('[ALM_CREATE] insert', {
+        table,
         code: error.code,
         details: error.details,
         hint: error.hint,
@@ -57,7 +58,8 @@ async function tryUpdate(
     Object.entries(match).forEach(([k, v]) => (q as any).eq(k, v));
     const { error } = await q;
     if (error)
-      logger.error(`[ALM_UPDATE] update ${table}`, {
+      logger.error('[ALM_UPDATE] update', {
+        table,
         code: error.code,
         details: error.details,
         hint: error.hint,


### PR DESCRIPTION
## Summary
- log Supabase error metadata in warehouse inserts
- log Supabase error metadata in warehouse updates

## Testing
- `DB_PROVIDER=supabase SKIP_ENV_CHECK=true pnpm run build` *(fails: missing env vars)*
- `DB_PROVIDER=supabase SKIP_ENV_CHECK=true pnpm test` *(fails: 21 failed, 147 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688e4e4780c0832897a474cedbb983bb