### PR TITLE
feat(almacenes): registra metadata de errores

### DIFF
--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -149,8 +149,19 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({ almacenes });
   } catch (err) {
-    logger.error('GET /api/almacenes', err);
-    return NextResponse.json({ error: msg(err, 'Error al obtener almacenes') }, { status: 500 });
+    const errorId = crypto.randomUUID();
+    const e: any = err;
+    logger.error('GET /api/almacenes', err, {
+      errorId,
+      message: e?.message,
+      code: e?.code,
+      hint: e?.hint,
+      details: e?.details,
+    });
+    return NextResponse.json(
+      { error: msg(err, 'Error al obtener almacenes'), errorId },
+      { status: 500 },
+    );
   }
 }
 
@@ -280,7 +291,18 @@ export async function POST(req: NextRequest) {
       auditError,
     });
   } catch (err) {
-    logger.error('POST /api/almacenes', err);
-    return NextResponse.json({ error: msg(err, 'Error al crear almacén') }, { status: 500 });
+    const errorId = crypto.randomUUID();
+    const e: any = err;
+    logger.error('POST /api/almacenes', err, {
+      errorId,
+      message: e?.message,
+      code: e?.code,
+      hint: e?.hint,
+      details: e?.details,
+    });
+    return NextResponse.json(
+      { error: msg(err, 'Error al crear almacén'), errorId },
+      { status: 500 },
+    );
   }
 }


### PR DESCRIPTION
## Summary
- logea codigo, hint y detalles de errores en GET/POST de /api/almacenes
- incluye un errorId en la respuesta para correlacionar con logs

## Testing
- `pnpm run build` *(fails: ❌ Faltante: DB_PROVIDER en .env)*
- `pnpm test` *(fails: Test Files 10 failed | 72 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688e50eca6008328b6c9d307f1b160dd