### PR TITLE
feat(prisma): agrega politicas RLS por usuario

### DIFF
--- a/docs/rls-local.md
+++ b/docs/rls-local.md
@@ -1,0 +1,20 @@
+# Ajustar RLS en entornos locales
+
+Las políticas de Row Level Security pueden bloquear operaciones durante el desarrollo. Para probar sin restricciones existen dos opciones:
+
+1. **Usar la clave `service_role`**
+   - Define la variable `SUPABASE_SERVICE_ROLE` en `.env.local`.
+   - Las solicitudes que incluyan esta clave omiten las políticas RLS.
+
+2. **Modificar RLS temporalmente**
+   - Desactivar RLS:
+     ```sql
+     ALTER TABLE public.almacen DISABLE ROW LEVEL SECURITY;
+     ```
+   - Crear una política abierta para pruebas:
+     ```sql
+     ALTER TABLE public.almacen ENABLE ROW LEVEL SECURITY;
+     CREATE POLICY "allow_all" ON public.almacen FOR ALL USING (true) WITH CHECK (true);
+     ```
+
+Recuerda revertir estos cambios antes de subir a producción y usar migraciones en `prisma/migrations` para ajustes permanentes.

--- a/prisma/migrations/5_rls_almacen_usuario_entidad/migration.sql
+++ b/prisma/migrations/5_rls_almacen_usuario_entidad/migration.sql
@@ -1,0 +1,45 @@
+-- Habilita RLS y define políticas basadas en auth.uid() para tablas clave
+
+-- Tabla: almacen
+ALTER TABLE public.almacen ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "allow_all" ON public.almacen;
+CREATE POLICY "almacen_select" ON public.almacen
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.usuario u
+      WHERE u.id = auth.uid() AND u.entidad_id = almacen.entidad_id
+    )
+  );
+CREATE POLICY "almacen_insert" ON public.almacen
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.usuario u
+      WHERE u.id = auth.uid() AND u.entidad_id = NEW.entidad_id
+    )
+  );
+
+-- Tabla: usuario_almacen
+ALTER TABLE public.usuario_almacen ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "allow_all" ON public.usuario_almacen;
+CREATE POLICY "usuario_almacen_select" ON public.usuario_almacen
+  FOR SELECT USING (usuario_id = auth.uid());
+CREATE POLICY "usuario_almacen_insert" ON public.usuario_almacen
+  FOR INSERT WITH CHECK (usuario_id = auth.uid());
+
+-- Tabla: entidad
+ALTER TABLE public.entidad ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "allow_all" ON public.entidad;
+CREATE POLICY "entidad_select" ON public.entidad
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.usuario u
+      WHERE u.id = auth.uid() AND u.entidad_id = entidad.id
+    )
+  );
+CREATE POLICY "entidad_insert" ON public.entidad
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.usuario u
+      WHERE u.id = auth.uid() AND u.entidad_id = NEW.id
+    )
+  );


### PR DESCRIPTION
## Summary
- habilita RLS en almacen, usuario_almacen y entidad con politicas basadas en `auth.uid()`
- documenta como ajustar RLS en entornos locales

## Testing
- `pnpm run build` *(fails: ❌ Faltante: DB_PROVIDER en .env)*
- `pnpm test` *(fails: 10 failed | 72 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688e50e5b6ec8328b0dede2cef22564f