### PR TITLE
fix(prisma): ordena parametros create_almacen_safe

### DIFF
--- a/prisma/migrations/6_fix_create_almacen_safe/migration.sql
+++ b/prisma/migrations/6_fix_create_almacen_safe/migration.sql
@@ -1,31 +1,30 @@
 -- required tables: public.usuario, public.entidad, public.almacen, public.usuario_almacen
--- drop obsolete create_almacen_safe signature and recreate with expected argument order
+-- remove previous version with parámetros opcionales antes de los obligatorios
 DROP FUNCTION IF EXISTS public.create_almacen_safe(
-  int,
-  int,
-  text,
-  text,
-  text,
-  text,
-  text,
-  text,
-  bytea,
-  text,
-  text
+  text,  -- p_codigo_unico
+  text,  -- p_descripcion
+  text,  -- p_entidad_correo
+  text,  -- p_entidad_nombre
+  text,  -- p_entidad_tipo
+  bytea, -- p_imagen
+  text,  -- p_imagen_nombre
+  text,  -- p_imagen_url
+  text,  -- p_nombre
+  integer -- p_usuario_id
 );
 
--- new signature matching application call order
+-- nueva firma con obligatorios antes de los que llevan DEFAULT
 CREATE OR REPLACE FUNCTION public.create_almacen_safe(
-  p_codigo_unico text,
-  p_descripcion text,
-  p_entidad_correo text DEFAULT NULL,
-  p_entidad_nombre text DEFAULT NULL,
-  p_entidad_tipo text DEFAULT NULL,
-  p_imagen bytea DEFAULT NULL,
-  p_imagen_nombre text DEFAULT NULL,
-  p_imagen_url text DEFAULT NULL,
-  p_nombre text,
-  p_usuario_id int
+  p_codigo_unico   text,
+  p_descripcion    text,
+  p_entidad_correo text,
+  p_entidad_nombre text,
+  p_entidad_tipo   text,
+  p_nombre         text,
+  p_usuario_id     int,
+  p_imagen         bytea    DEFAULT NULL,
+  p_imagen_nombre  text     DEFAULT NULL,
+  p_imagen_url     text     DEFAULT NULL
 )
 RETURNS int
 LANGUAGE plpgsql


### PR DESCRIPTION
## Summary
- ordena los parámetros obligatorios antes de los opcionales en `create_almacen_safe`
- elimina la firma antigua del RPC

## Testing
- `pnpm prisma migrate resolve --rolled-back "6_fix_create_almacen_safe"` *(falla: Environment variable not found: DIRECT_URL)*
- `pnpm prisma migrate dev` *(falla: Environment variable not found: DIRECT_URL)*
- `pnpm prisma migrate status` *(falla: Environment variable not found: DIRECT_URL)*
- `node -e "const {createClient}=require('@supabase/supabase-js'); const supabase=createClient(process.env.SUPABASE_URL||'', process.env.SUPABASE_SERVICE_ROLE_KEY||''); supabase.rpc('create_almacen_safe',{p_codigo_unico:'ABC123',p_descripcion:'Descripción',p_entidad_correo:'demo@empresa.com',p_entidad_nombre:'Empresa Demo',p_entidad_tipo:'privada',p_nombre:'Almacén central',p_usuario_id:42}).then(r=>{console.log(r);}).catch(e=>{console.error(e.message);});"` *(falla: supabaseUrl is required)*
- `pnpm run build` *(falla: ❌ Faltante: DB_PROVIDER en .env)*
- `pnpm test` *(fallan suites por falta de configuración de Supabase y DB_PROVIDER)*

------
https://chatgpt.com/codex/tasks/task_e_688e583c969c8328a5f58ec987d92452