### PR TITLE
refactor: renombrar creadoId

### DIFF
--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -183,18 +183,20 @@ export async function POST(req: NextRequest) {
 
     }
 
+    const creado_por_id = rpcId;
+
     // side-effects no críticos
-    snapshotAlmacen(db as any, creadoId, usuario.id, 'Creación').catch((e) =>
+    snapshotAlmacen(db as any, creado_por_id, usuario.id, 'Creación').catch((e) =>
       logger.warn?.('snapshotAlmacen', e),
     );
-    logAudit(usuario.id, 'creacion', 'almacen', { almacenId: creadoId }).catch((e) =>
+    logAudit(usuario.id, 'creacion', 'almacen', { almacenId: creado_por_id }).catch((e) =>
       logger.warn?.('logAudit', e),
     );
 
     let auditoria = null,
       auditError = null as any;
     try {
-      const r = await registrarAuditoria(req, 'almacen', creadoId, 'creacion', {
+      const r = await registrarAuditoria(req, 'almacen', creado_por_id, 'creacion', {
         nombre,
         descripcion,
         funciones,
@@ -212,7 +214,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({
       almacen: {
-        id: creadoId,
+        id: creado_por_id,
         nombre,
         descripcion: descripcion || null,
         codigoUnico: codigoUnico,


### PR DESCRIPTION
## Summary
- renombrar creadoId por creado_por_id en ruta de almacenes

## Testing
- `pnpm run build` *(falla: Faltante DB_PROVIDER en .env)*
- `pnpm test` *(1 fallo: POST /api/almacenes/[id]/duplicar > retorna auditoria al duplicar)*

------
https://chatgpt.com/codex/tasks/task_e_688e609414f8832889c9cbafd560e698