### PR TITLE
fix: usa fecha_registro en selects de Supabase

### DIFF
--- a/src/app/api/almacenes/[id]/materiales/route.ts
+++ b/src/app/api/almacenes/[id]/materiales/route.ts
@@ -43,7 +43,7 @@ export async function GET(req: NextRequest) {
 
     const { data: rows, error } = await db
       .from('material')
-      .select('id,nombre,descripcion,miniaturaNombre,cantidad,unidad,lote,fechaCaducidad,ubicacion,proveedor,estado,observaciones,codigoBarra,codigoQR,minimo,maximo,fechaRegistro,fechaActualizacion, unidades:material_unidad(id)')
+      .select('id,nombre,descripcion,miniaturaNombre,cantidad,unidad,lote,fechaCaducidad,ubicacion,proveedor,estado,observaciones,codigoBarra,codigoQR,minimo,maximo,fecha_registro,fechaActualizacion, unidades:material_unidad(id)')
       .eq('almacenId', almacenId)
       .order('id', { ascending: false })
     if (error) throw error
@@ -64,7 +64,7 @@ export async function GET(req: NextRequest) {
       codigoQR: m.codigoQR,
       minimo: m.minimo,
       maximo: m.maximo,
-      fechaRegistro: m.fechaRegistro,
+      fechaRegistro: (m as any).fecha_registro,
       fechaActualizacion: m.fechaActualizacion,
       _count: { unidades: (m as any).unidades?.length ?? 0 },
     }))

--- a/src/app/api/almacenes/[id]/route.ts
+++ b/src/app/api/almacenes/[id]/route.ts
@@ -135,12 +135,20 @@ async function countMateriales(db: SupabaseClient, almacenId: number): Promise<n
 
 async function listMateriales(db: SupabaseClient, almacenId: number) {
   const cols =
-    'id,nombre,descripcion,miniaturaNombre,cantidad,unidad,lote,fechaCaducidad,ubicacion,proveedor,estado,observaciones,minimo,maximo,fechaRegistro,fechaActualizacion';
+    'id,nombre,descripcion,miniaturaNombre,cantidad,unidad,lote,fechaCaducidad,ubicacion,proveedor,estado,observaciones,minimo,maximo,fecha_registro,fechaActualizacion';
   const q1 = await db.from('material').select(cols).eq('almacenId', almacenId).order('id', { ascending: false });
-  if (!q1.error) return q1.data ?? [];
+  if (!q1.error)
+    return (q1.data ?? []).map((m: any) => {
+      const { fecha_registro, ...rest } = m;
+      return { ...rest, fechaRegistro: fecha_registro };
+    });
 
   const q2 = await db.from('material').select(cols).eq('almacen_id', almacenId).order('id', { ascending: false });
-  if (!q2.error) return q2.data ?? [];
+  if (!q2.error)
+    return (q2.data ?? []).map((m: any) => {
+      const { fecha_registro, ...rest } = m;
+      return { ...rest, fechaRegistro: fecha_registro };
+    });
 
   throw q1.error ?? q2.error;
 }

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -73,7 +73,7 @@ export async function GET(req: NextRequest) {
     logger.debug(req, 'Buscando perfil del usuario')
     const { data, error } = await supabase
       .from('usuario')
-      .select('id,nombre,apellidos,correo,tipo_cuenta,entidad_id,estado,fechaRegistro,fotoPerfilNombre,preferencias,tiene2FA,metodo2FA')
+      .select('id,nombre,apellidos,correo,tipo_cuenta,entidad_id,estado,fecha_registro,fotoPerfilNombre,preferencias,tiene2FA,metodo2FA')
       .eq('id', payload.id)
       .maybeSingle()
 
@@ -84,9 +84,11 @@ export async function GET(req: NextRequest) {
       ...data,
       tipoCuenta: (data as any).tipo_cuenta,
       entidadId: (data as any).entidad_id,
+      fechaRegistro: (data as any).fecha_registro,
     }
     delete (usuario as any).tipo_cuenta
     delete (usuario as any).entidad_id
+    delete (usuario as any).fecha_registro
 
     logger.info(req, 'Perfil recuperado correctamente')
     return NextResponse.json({ success: true, usuario }, { status: 200 })


### PR DESCRIPTION
## Summary
- ajusta GET /perfil para seleccionar `fecha_registro` y mapear a `fechaRegistro`
- corrige listados de materiales para usar `fecha_registro`
- normaliza `listMateriales` devolviendo `fechaRegistro`

## Testing
- `pnpm run build` *(fails: Faltante: DB_PROVIDER en .env)*
- `pnpm test` *(fails: db.rpc is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_688e648ccde08328b1b76e0a2504e366