### PR TITLE
fix: corregir mapeo de 2FA

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,7 +76,7 @@ model Usuario {
   foto_perfil_nombre   String?
   metodo2FA            String?
   preferencias         String?
-  tiene2_FA            Boolean?               @default(false)
+  tiene2FA             Boolean?               @default(false) @map("tiene2_fa")
   esSuperAdmin         Boolean?               @default(false)
   archivosAuditorias   ArchivoAuditoria[]     @relation("ArchivoAuditoriaSubidoPor")
   archivosMaterial     ArchivoMaterial[]

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -73,7 +73,7 @@ export async function GET(req: NextRequest) {
     logger.debug(req, 'Buscando perfil del usuario')
     const { data, error } = await supabase
       .from('usuario')
-      .select('id,nombre,apellidos,correo,tipo_cuenta,entidad_id,estado,fecha_registro,foto_perfil_nombre,preferencias,tiene2_FA,metodo2FA')
+      .select('id,nombre,apellidos,correo,tipo_cuenta,entidad_id,estado,fecha_registro,foto_perfil_nombre,preferencias,tiene2_fa,metodo2FA')
       .eq('id', payload.id)
       .maybeSingle()
 
@@ -85,10 +85,12 @@ export async function GET(req: NextRequest) {
       tipoCuenta: (data as any).tipo_cuenta,
       entidadId: (data as any).entidad_id,
       fechaRegistro: (data as any).fecha_registro,
+      tiene2FA: (data as any).tiene2_fa,
     }
     delete (usuario as any).tipo_cuenta
     delete (usuario as any).entidad_id
     delete (usuario as any).fecha_registro
+    delete (usuario as any).tiene2_fa
 
     logger.info(req, 'Perfil recuperado correctamente')
     return NextResponse.json({ success: true, usuario }, { status: 200 })
@@ -261,7 +263,7 @@ export async function POST(req: NextRequest) {
     const { error } = await supabase
       .from('usuario')
       .update({
-        tiene2_FA: activar2FA,
+        tiene2_fa: activar2FA,
         metodo2FA: activar2FA ? metodo2FA : null,
       })
       .eq('id', usuarioId)


### PR DESCRIPTION
## Summary
- Ajustar API de perfil para consultar y actualizar `tiene2_fa` y exponer `tiene2FA`.
- Mapear `Usuario.tiene2FA` a la columna `tiene2_fa` en Prisma.

## Testing
- `SKIP_ENV_CHECK=true DB_PROVIDER=supabase pnpm run build` (falla: Prisma connection error y variables SMTP faltantes)
- `DB_PROVIDER=supabase pnpm test` (17 tests fallidos: Supabase no configurado)


------
https://chatgpt.com/codex/tasks/task_e_688e67b8f0688328b0be24aec6e0cc88