### PR TITLE
fix: map 2FA method column

### DIFF
--- a/prisma/_migrations_history/20250601020542_dasboard/migration.sql
+++ b/prisma/_migrations_history/20250601020542_dasboard/migration.sql
@@ -2,9 +2,9 @@
 ALTER TABLE "Usuario" ADD COLUMN     "codigo2FASecret" TEXT,
 ADD COLUMN     "fotoPerfil" BYTEA,
 ADD COLUMN     "fotoPerfilNombre" TEXT,
-ADD COLUMN     "metodo2FA" TEXT,
+ADD COLUMN     "metodo2_fa" TEXT,
 ADD COLUMN     "preferencias" TEXT,
-ADD COLUMN     "tiene2FA" BOOLEAN DEFAULT false;
+ADD COLUMN     "tiene2_fa" BOOLEAN DEFAULT false;
 
 -- CreateTable
 CREATE TABLE "BitacoraCambioPerfil" (

--- a/prisma/migrations/0_baseline/migration.sql
+++ b/prisma/migrations/0_baseline/migration.sql
@@ -62,9 +62,9 @@ CREATE TABLE "usuario" (
     "codigo2FASecret" TEXT,
     "fotoPerfil" BYTEA,
     "fotoPerfilNombre" TEXT,
-    "metodo2FA" TEXT,
+    "metodo2_fa" TEXT,
     "preferencias" TEXT,
-    "tiene2FA" BOOLEAN DEFAULT false,
+    "tiene2_fa" BOOLEAN DEFAULT false,
     "esSuperAdmin" BOOLEAN DEFAULT false,
 
     CONSTRAINT "Usuario_pkey" PRIMARY KEY ("id")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -74,7 +74,7 @@ model Usuario {
   codigo2FASecret      String?
   fotoPerfil           Bytes?
   fotoPerfilNombre     String?               @map("foto_perfil_nombre")
-  metodo2FA            String?
+  metodo2FA            String?               @map("metodo2_fa")
   preferencias         String?
   tiene2FA             Boolean?               @default(false) @map("tiene2_fa")
   esSuperAdmin         Boolean?               @default(false)

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -73,7 +73,7 @@ export async function GET(req: NextRequest) {
     logger.debug(req, 'Buscando perfil del usuario')
     const { data, error } = await supabase
       .from('usuario')
-      .select('id,nombre,apellidos,correo,tipo_cuenta,entidad_id,estado,fecha_registro,foto_perfil_nombre,preferencias,tiene2_fa,metodo2FA')
+      .select('id,nombre,apellidos,correo,tipo_cuenta,entidad_id,estado,fecha_registro,foto_perfil_nombre,preferencias,tiene2_fa,metodo2_fa')
       .eq('id', payload.id)
       .maybeSingle()
 
@@ -86,11 +86,13 @@ export async function GET(req: NextRequest) {
       entidadId: (data as any).entidad_id,
       fechaRegistro: (data as any).fecha_registro,
       tiene2FA: (data as any).tiene2_fa,
+      metodo2FA: (data as any).metodo2_fa,
     }
     delete (usuario as any).tipo_cuenta
     delete (usuario as any).entidad_id
     delete (usuario as any).fecha_registro
     delete (usuario as any).tiene2_fa
+    delete (usuario as any).metodo2_fa
 
     logger.info(req, 'Perfil recuperado correctamente')
     return NextResponse.json({ success: true, usuario }, { status: 200 })
@@ -264,7 +266,7 @@ export async function POST(req: NextRequest) {
       .from('usuario')
       .update({
         tiene2_fa: activar2FA,
-        metodo2FA: activar2FA ? metodo2FA : null,
+        metodo2_fa: activar2FA ? metodo2FA : null,
       })
       .eq('id', usuarioId)
     if (error) throw error

--- a/src/types/usuario.ts
+++ b/src/types/usuario.ts
@@ -10,5 +10,6 @@ export interface Usuario {
   avatarUrl?: string | null;
   imagen?: string | null;
   tiene2FA?: boolean;
+  metodo2FA?: 'email' | 'app' | null;
   esSuperAdmin?: boolean;
 }


### PR DESCRIPTION
## Summary
- map `metodo2FA` field to existing `metodo2_fa` column
- update perfil API to read/write correct column
- extend `Usuario` type with optional 2FA method

## Testing
- `pnpm run build` *(fails: Critical dependency warning and Prisma connection errors)*
- `pnpm test` *(fails: db.rpc is not a function, fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_688e71191e1c8328bef758819017652e