### PR TITLE
fix: compatibilidad supabase en materiales y auditorias

### DIFF
--- a/lib/auditoriaInit.ts
+++ b/lib/auditoriaInit.ts
@@ -9,7 +9,13 @@ export async function ensureAuditoriaTables() {
   try {
     const db = getDb().client as SupabaseClient
     const { error } = await db.rpc('ensure_auditoria_tables')
-    if (error) throw error
+    if (error) {
+      if ((error as any).code === 'PGRST202') {
+        logger.warn('RPC ensure_auditoria_tables no encontrada, se omite')
+      } else {
+        throw error
+      }
+    }
     checked = true
   } catch (err) {
     logger.error('ensureAuditoriaTables', err)

--- a/src/app/api/almacenes/[id]/route.ts
+++ b/src/app/api/almacenes/[id]/route.ts
@@ -133,23 +133,31 @@ async function countMateriales(db: SupabaseClient, almacenId: number): Promise<n
 }
 
 async function listMateriales(db: SupabaseClient, almacenId: number) {
-  const cols =
-    'id,nombre,descripcion,miniaturaNombre,cantidad,unidad,lote,fechaCaducidad,ubicacion,proveedor,estado,observaciones,minimo,maximo,fecha_registro,fechaActualizacion';
-  const q1 = await db.from('material').select(cols).eq('almacenId', almacenId).order('id', { ascending: false });
+  const base =
+    'id,nombre,descripcion,cantidad,unidad,lote,fechaCaducidad,ubicacion,proveedor,estado,observaciones,minimo,maximo,fecha_registro,fechaActualizacion'
+  const q1 = await db
+    .from('material')
+    .select(`miniaturaNombre,${base}`)
+    .eq('almacenId', almacenId)
+    .order('id', { ascending: false })
   if (!q1.error)
     return (q1.data ?? []).map((m: any) => {
-      const { fecha_registro, ...rest } = m;
-      return { ...rest, fechaRegistro: fecha_registro };
-    });
+      const { fecha_registro, ...rest } = m
+      return { ...rest, fechaRegistro: fecha_registro }
+    })
 
-  const q2 = await db.from('material').select(cols).eq('almacen_id', almacenId).order('id', { ascending: false });
+  const q2 = await db
+    .from('material')
+    .select(`miniatura_nombre:miniaturaNombre,${base}`)
+    .eq('almacen_id', almacenId)
+    .order('id', { ascending: false })
   if (!q2.error)
     return (q2.data ?? []).map((m: any) => {
-      const { fecha_registro, ...rest } = m;
-      return { ...rest, fechaRegistro: fecha_registro };
-    });
+      const { fecha_registro, ...rest } = m
+      return { ...rest, fechaRegistro: fecha_registro }
+    })
 
-  throw q1.error ?? q2.error;
+  throw q1.error ?? q2.error
 }
 
 /* ───────── GET /api/almacenes/[id] ───────── */


### PR DESCRIPTION
## Summary
- tolera ausencia de RPC `ensure_auditoria_tables`
- compatibilidad de columnas `miniatura_nombre` y `almacen_id` en endpoints de materiales

## Testing
- `DB_PROVIDER=supabase pnpm run build` *(falla: Faltan variables en .env)*
- `DB_PROVIDER=supabase pnpm test` *(falla: Supabase no configurado / db.rpc is not a function)*

------
