### PR TITLE
feat: vista almacen_resumen con alias snake_case

### DIFF
--- a/prisma/migrations/7_almacen_resumen_snake/migration.sql
+++ b/prisma/migrations/7_almacen_resumen_snake/migration.sql
@@ -1,0 +1,52 @@
+-- Redefine vista almacen_resumen con columnas snake_case y totales
+DROP VIEW IF EXISTS public."AlmacenResumen";
+DROP VIEW IF EXISTS public.almacen_resumen;
+
+CREATE OR REPLACE VIEW public.almacen_resumen AS
+SELECT
+  a.id,
+  a.nombre,
+  a.descripcion,
+  a."imagenUrl"      AS imagen_url,
+  a."imagenNombre"   AS imagen_nombre,
+  a."fechaCreacion"  AS fecha_creacion,
+  a."codigoUnico"    AS codigo_unico,
+  enc.nombre          AS encargado_nombre,
+  enc.correo          AS encargado_correo,
+  mov.ultima          AS ultima_actualizacion,
+  COALESCE(mat.inventario, 0) AS inventario,
+  COALESCE(mat.unidades, 0)   AS unidades,
+  COALESCE(notif.notificaciones, 0) AS notificaciones,
+  COALESCE(mov.entradas, 0)   AS entradas,
+  COALESCE(mov.salidas, 0)    AS salidas
+FROM public."Almacen" a
+LEFT JOIN LATERAL (
+  SELECT u.nombre, u.correo
+  FROM public.usuario_almacen ua
+  JOIN public.usuario u ON u.id = ua."usuarioId"
+  WHERE ua."almacenId" = a.id
+  ORDER BY ua."usuarioId" ASC
+  LIMIT 1
+) enc ON TRUE
+LEFT JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(CASE WHEN m."tipo" = 'entrada' THEN m."cantidad" END), 0) AS entradas,
+    COALESCE(SUM(CASE WHEN m."tipo" = 'salida'  THEN m."cantidad" END), 0) AS salidas,
+    MAX(m."fecha") AS ultima
+  FROM public."Movimiento" m
+  WHERE m."almacenId" = a.id
+) mov ON TRUE
+LEFT JOIN LATERAL (
+  SELECT COUNT(*) AS notificaciones
+  FROM public."Notificacion" n
+  WHERE n."almacenId" = a.id
+    AND n."leida" = FALSE
+) notif ON TRUE
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(DISTINCT m.id) AS inventario,
+    COUNT(u.id) AS unidades
+  FROM public."Material" m
+  LEFT JOIN public."MaterialUnidad" u ON u."materialId" = m.id
+  WHERE m."almacenId" = a.id
+) mat ON TRUE;

--- a/src/app/api/almacenes/route.ts
+++ b/src/app/api/almacenes/route.ts
@@ -56,7 +56,9 @@ export async function GET(req: NextRequest) {
 
     const { data, error } = await db
       .from<Row>('almacen_resumen')
-      .select('id,nombre,descripcion,imagenUrl,imagenNombre,fechaCreacion,codigoUnico,encargado_nombre,encargado_correo,ultima_actualizacion,notificaciones,entradas,salidas,inventario,unidades')
+      .select(
+        'id,nombre,descripcion,imagen_url:imagenUrl,imagen_nombre:imagenNombre,fecha_creacion:fechaCreacion,codigo_unico:codigoUnico,encargado_nombre,encargado_correo,ultima_actualizacion,notificaciones,entradas,salidas,inventario,unidades',
+      )
       .in('id', ids)
       .order('id', { ascending: true });
     if (error) throw error;


### PR DESCRIPTION
## Summary
- redefine `almacen_resumen` con columnas snake_case y agrega totales `inventario` y `unidades`
- ajusta API de almacenes para usar alias camelCase al consultar la vista

## Testing
- `DB_PROVIDER=supabase JWT_SECRET=1 NEXTAUTH_SECRET=1 NEXTAUTH_URL=http://localhost EMAIL_ADMIN=a EMAIL_DESTINO_ESTANDAR=a EMAIL_DESTINO_VALIDACION=a SMTP_USER=a SMTP_PASS=a NEXT_PUBLIC_RECAPTCHA_SITE_KEY=a RECAPTCHA_SECRET_KEY=a DATABASE_URL=postgresql://u:p@localhost:5432/db DIRECT_URL=postgresql://u:p@localhost:5432/db SUPABASE_URL=http://localhost SUPABASE_SERVICE_ROLE_KEY=a SUPABASE_JWT_SECRET=a NEXT_PUBLIC_SUPABASE_ANON_KEY=a POSTGRES_PASSWORD=a POSTGRES_USER=a POSTGRES_HOST=localhost POSTGRES_DATABASE=a pnpm run build` (warnings)
- `DB_PROVIDER=supabase JWT_SECRET=1 NEXTAUTH_SECRET=1 NEXTAUTH_URL=http://localhost EMAIL_ADMIN=a EMAIL_DESTINO_ESTANDAR=a EMAIL_DESTINO_VALIDACION=a SMTP_USER=a SMTP_PASS=a NEXT_PUBLIC_RECAPTCHA_SITE_KEY=a RECAPTCHA_SECRET_KEY=a DATABASE_URL=postgresql://u:p@localhost:5432/db DIRECT_URL=postgresql://u:p@localhost:5432/db SUPABASE_URL=http://localhost SUPABASE_SERVICE_ROLE_KEY=a SUPABASE_JWT_SECRET=a NEXT_PUBLIC_SUPABASE_ANON_KEY=a POSTGRES_PASSWORD=a POSTGRES_USER=a POSTGRES_HOST=localhost POSTGRES_DATABASE=a pnpm test` (11 failed)


------
https://chatgpt.com/codex/tasks/task_e_688e7e5b20b48328a8de7ed5245c8708